### PR TITLE
Add an error check to the update download function

### DIFF
--- a/package-mixins.js
+++ b/package-mixins.js
@@ -3,6 +3,10 @@ var extend = require("extend");
 module.exports = (NativeCodePush) => {
   var remote = {
     download: function download() {
+      if (!this.downloadUrl) {
+        return Promise.reject(new Error("Cannot download an update without a download url"));
+      }
+
       // Use the downloaded package info. Native code will save the package info
       // so that the client knows what the current package version is.
       return NativeCodePush.downloadUpdate(this)


### PR DESCRIPTION
This provides a more helpful error if an app author tries to apply an update that doesn't have a download URL (a.k.a. 'app version update')
