### PR TITLE
Bumping the version and fixing license

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-code-push",
-  "version": "1.0.0-beta",
+  "version": "1.0.1-beta",
   "description": "React Native plugin for the CodePush service",
   "main": "CodePush.ios.js",
   "homepage": "https://microsoft.github.io/code-push",
@@ -10,7 +10,7 @@
     "push"
   ],
   "author": "Microsoft Corporation",
-  "license": "Licensed under the MIT license.",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/Microsoft/react-native-code-push"


### PR DESCRIPTION
Bumped the version so that we could publish [this fix](https://github.com/Microsoft/react-native-code-push/commit/6dda12881b7c24440690821710c8dbaeeea1ae8f) to NPM, and also fixed the license string.