### PR TITLE
CodePush.sync() API method

### DIFF
--- a/CodePush.ios.js
+++ b/CodePush.ios.js
@@ -96,6 +96,15 @@ function notifyApplicationReady() {
   return NativeCodePush.notifyApplicationReady();
 }
 
+/**
+ * The sync method provides a simple, one-line experience for
+ * incorporating the check, download and application of an update.
+ * 
+ * It simply composes the existing API methods together and adds additional
+ * support for respecting mandatory updates, ignoring previously failed
+ * releases, and displaying a standard confirmation UI to the end-user
+ * when an update is available.
+ */
 function sync(options = {}) {  
   var syncOptions = {
     ignoreFailedUpdates: true,
@@ -139,8 +148,10 @@ function sync(options = {}) {
             dialogButtons[0].text = syncOptions.mandatoryContinueButtonLabel;
           } else {
             message = syncOptions.optionalUpdateMessage;
-
-            dialogButtons[0].text = syncOptions.optionalInstallButtonLabel;            
+            dialogButtons[0].text = syncOptions.optionalInstallButtonLabel;     
+            
+            // Since this is an optional update, add another button
+            // to allow the end-user to ignore it       
             dialogButtons.push({
               text: syncOptions.optionalIgnoreButtonLabel,
               onPress: () => resolve(CodePush.SyncStatus.UPDATE_IGNORED)
@@ -161,9 +172,9 @@ var CodePush = {
   setUpTestDependencies: setUpTestDependencies,
   sync: sync,
   SyncStatus: {
-    NO_UPDATE_AVAILABLE: 0,
-    UPDATE_IGNORED: 1,
-    APPLY_SUCCESS: 2    
+    NO_UPDATE_AVAILABLE: 0, // The running app is up-to-date
+    UPDATE_IGNORED: 1, // The app had an optional update and the end-user chose to ignore it
+    APPLY_SUCCESS: 2 // The app had an optional/mandatory update that was successfully downloaded and is about to be applied
   }
 };
 

--- a/CodePush.ios.js
+++ b/CodePush.ios.js
@@ -10,6 +10,7 @@ var NativeCodePush = require('react-native').NativeModules.CodePush;
 var requestFetchAdapter = require("./request-fetch-adapter.js");
 var Sdk = require("code-push/script/acquisition-sdk").AcquisitionManager;
 var packageMixins = require("./package-mixins")(NativeCodePush);
+var { AlertIOS } = require("react-native");
 
 // This function is only used for tests. Replaces the default SDK, configuration and native bridge
 function setUpTestDependencies(providedTestSdk, providedTestConfig, testNativeBridge){
@@ -105,7 +106,7 @@ function sync(options = {}) {
       else {
         var dialogButtons = [
           {
-            text: options.downloadButtonText || "Download",
+            text: options.updateButtonText || "Update",
             onPress: () => { 
               remotePackage.download()
               .then((localPackage) => {
@@ -118,12 +119,12 @@ function sync(options = {}) {
         
         if (!remotePackage.isMandatory) {
           dialogButtons.push({
-            text: options.cancelButtonText || "Cancel",
+            text: options.cancelButtonText || "Ignore",
             onPress: () => resolve(CodePush.SyncStatus.USER_CANCELLED)
           });
         }
         
-        React.AlertIOS.alert(options.title || "Update available", remotePackage.description, dialogButtons);
+        AlertIOS.alert(options.title || "Update available", remotePackage.description, dialogButtons);
       }
     }, reject);
   });     
@@ -138,8 +139,8 @@ var CodePush = {
   sync: sync,
   SyncStatus: {
     NO_UPDATE_AVAILABLE: 0,
-    APPLY_SUCCESS: 1,
-    USER_CANCELLED: 2
+    USER_CANCELLED: 1,
+    APPLY_SUCCESS: 2    
   }
 };
 

--- a/CodePush.ios.js
+++ b/CodePush.ios.js
@@ -110,14 +110,16 @@ function sync(options = {}) {
     ignoreFailedUpdates: true,
     
     mandatoryContinueButtonLabel: "Continue",
-    mandatoryUpdateMessage: "An update is available that must be installed",
+    mandatoryUpdateMessage: "An update is available that must be installed.",
     
     optionalIgnoreButtonLabel: "Ignore",
     optionalInstallButtonLabel: "Install",
     optionalUpdateMessage: "An update is available. Would you like to install it?",
     
-    updateTitle: "Update available",
     rollbackTimeout: 0,
+    
+    updateTitle: "Update available",
+    useReleaseDescription: false,
     
     ...options 
   };
@@ -136,7 +138,7 @@ function sync(options = {}) {
               onPress: () => { 
                 remotePackage.download()
                   .then((localPackage) => {
-                    resolve(CodePush.SyncStatus.APPLY_SUCCESS);
+                    resolve(CodePush.SyncStatus.UPDATE_DOWNLOADED);
                     localPackage.apply(syncOptions.rollbackTimeout);
                   }, reject);
               }
@@ -158,7 +160,13 @@ function sync(options = {}) {
             });
           }
           
-          AlertIOS.alert(syncOptions.updateTitle, message || remotePackage.description, dialogButtons);
+          // If the update has a description, and the developer
+          // explicitly chose to display it, then set that as the message
+          if (syncOptions.useReleaseDescription && remotePackage.description) {
+            message = remotePackage.description;  
+          }
+          
+          AlertIOS.alert(syncOptions.updateTitle, message, dialogButtons);
         }
       }, reject);
   });     
@@ -174,7 +182,7 @@ var CodePush = {
   SyncStatus: {
     NO_UPDATE_AVAILABLE: 0, // The running app is up-to-date
     UPDATE_IGNORED: 1, // The app had an optional update and the end-user chose to ignore it
-    APPLY_SUCCESS: 2 // The app had an optional/mandatory update that was successfully downloaded and is about to be applied
+    UPDATE_DOWNLOADED: 2 // The app had an optional/mandatory update that was successfully downloaded and is about to be applied
   }
 };
 

--- a/CodePush.ios.js
+++ b/CodePush.ios.js
@@ -99,34 +99,34 @@ function notifyApplicationReady() {
 function sync(options = {}) {  
   return new Promise((resolve, reject) => {
     checkForUpdate()
-    .then((remotePackage) => {
-      if (!remotePackage) {
-        resolve(CodePush.SyncStatus.NO_UPDATE_AVAILABLE);
-      }
-      else {
-        var dialogButtons = [
-          {
-            text: options.updateButtonText || "Update",
-            onPress: () => { 
-              remotePackage.download()
-              .then((localPackage) => {
-                resolve(CodePush.SyncStatus.APPLY_SUCCESS);
-                localPackage.apply(options.rollbackTImeout);
-              }, reject);
-            }
-          }
-        ];
-        
-        if (!remotePackage.isMandatory) {
-          dialogButtons.push({
-            text: options.ignoreButtonText || "Ignore",
-            onPress: () => resolve(CodePush.SyncStatus.UPDATE_IGNORED)
-          });
+      .then((remotePackage) => {
+        if (!remotePackage) {
+          resolve(CodePush.SyncStatus.NO_UPDATE_AVAILABLE);
         }
-        
-        AlertIOS.alert(options.updateTitle || "Update available", remotePackage.description, dialogButtons);
-      }
-    }, reject);
+        else {
+          var dialogButtons = [
+            {
+              text: options.updateButtonText || "Update",
+              onPress: () => { 
+                remotePackage.download()
+                  .then((localPackage) => {
+                    resolve(CodePush.SyncStatus.APPLY_SUCCESS);
+                    localPackage.apply(options.rollbackTimeout);
+                  }, reject);
+              }
+            }
+          ];
+          
+          if (!remotePackage.isMandatory) {
+            dialogButtons.push({
+              text: options.ignoreButtonText || "Ignore",
+              onPress: () => resolve(CodePush.SyncStatus.UPDATE_IGNORED)
+            });
+          }
+          
+          AlertIOS.alert(options.updateTitle || "Update available", remotePackage.description, dialogButtons);
+        }
+      }, reject);
   });     
 };
 

--- a/CodePush.ios.js
+++ b/CodePush.ios.js
@@ -119,12 +119,12 @@ function sync(options = {}) {
         
         if (!remotePackage.isMandatory) {
           dialogButtons.push({
-            text: options.cancelButtonText || "Ignore",
-            onPress: () => resolve(CodePush.SyncStatus.USER_CANCELLED)
+            text: options.ignoreButtonText || "Ignore",
+            onPress: () => resolve(CodePush.SyncStatus.UPDATE_IGNORED)
           });
         }
         
-        AlertIOS.alert(options.title || "Update available", remotePackage.description, dialogButtons);
+        AlertIOS.alert(options.updateTitle || "Update available", remotePackage.description, dialogButtons);
       }
     }, reject);
   });     
@@ -139,7 +139,7 @@ var CodePush = {
   sync: sync,
   SyncStatus: {
     NO_UPDATE_AVAILABLE: 0,
-    USER_CANCELLED: 1,
+    UPDATE_IGNORED: 1,
     APPLY_SUCCESS: 2    
   }
 };

--- a/CodePush.ios.js
+++ b/CodePush.ios.js
@@ -127,7 +127,7 @@ function sync(options = {}) {
   return new Promise((resolve, reject) => {
     checkForUpdate()
       .then((remotePackage) => {
-        if (!remotePackage || (remotePackage.failedAppy && syncOptions.ignoreFailedUpdates)) {
+        if (!remotePackage || (remotePackage.failedApply && syncOptions.ignoreFailedUpdates)) {
           resolve(CodePush.SyncStatus.NO_UPDATE_AVAILABLE);
         }
         else {


### PR DESCRIPTION
This provides a simplified and opinionated one-line experience to CodePush-ifying an app. The CodePush.sync() method allows automating the act of checking for an update, downloading it and then subsequently applying it, all while also supporting ignoring previously failed updates, respecting mandatory updates and displaying a standard user confirmation dialog when updates are available.

The method takes an optional options object that can be used to customize the strings used when displaying the user dialog, as well as the rollback timeout.

It returns a Promise that will be resolved with a SyncStatus code, that indicates why the sync succeeded:

0 - No update was available, so the running app is up to do
1 - The app had an optional update, but the end-user chose to ignore it
2 - The app had an optional or mandatory update and the user accepted it

If a failure occurs at any point during the sync, the returned Promise will be rejected with the error reason.

I'll update the docs in a subsequent PR, but I just wanted to get this change out since the respective Cordova change is in review.