### PR TITLE
Removing @flow annotation from JS module

### DIFF
--- a/CodePush.ios.js
+++ b/CodePush.ios.js
@@ -1,8 +1,3 @@
-/**
- * @providesModule CodePush
- * @flow
- */
-
 'use strict';
 
 var extend = require("extend");


### PR DESCRIPTION
At some point, we should flow-ify the plugin, but for now, this file shouldn't be marked for type checking since it doesn't actually succeed. Additionally, we shouldn't be using the @providesModule annotation, since that's an internal feature of the RN packager that we shouldn't be trying to use.