### PR TITLE
Implementing "failedApply" property on packages

### DIFF
--- a/CodePush.h
+++ b/CodePush.h
@@ -1,10 +1,9 @@
 #import "RCTBridgeModule.h"
 
-@interface CodePush : NSObject <RCTBridgeModule>
+@interface CodePush : NSObject<RCTBridgeModule>
 
-+ (NSString *) getDocumentsDirectory;
-
-+ (NSURL *) getBundleUrl;
++ (NSString *)getDocumentsDirectory;
++ (NSURL *)getBundleUrl;
 
 @end
 
@@ -48,4 +47,5 @@
                error:(NSError **)error;
 
 + (void)rollbackPackage;
+
 @end

--- a/CodePush.ios.js
+++ b/CodePush.ios.js
@@ -57,7 +57,7 @@ function getCurrentPackage() {
     NativeCodePush.getCurrentPackage()
       .then((currentPackage) => {
         localPackage = currentPackage;
-        return NativeCodePush.isFailedUpdate(currentPackage.packageHash)
+        return NativeCodePush.isFailedUpdate(currentPackage.packageHash);
       })
       .then((failedUpdate) => {
         localPackage.failedApply = failedUpdate;
@@ -104,7 +104,9 @@ function checkForUpdate() {
                 } else {
                   resolve(update);
                 }
-              });
+              })
+              .catch(reject)
+              .done();
             });
           });
 }

--- a/CodePush.ios.js
+++ b/CodePush.ios.js
@@ -1,8 +1,3 @@
-/**
- * @providesModule CodePush
- * @flow
- */
-
 'use strict';
 
 var extend = require("extend");

--- a/CodePush.ios.js
+++ b/CodePush.ios.js
@@ -100,13 +100,13 @@ function checkForUpdate() {
                     .then((isFailedHash) => {
                       update.failedApply = isFailedHash;
                       resolve(update);
-                    });
+                    })
+                    .catch(reject)
+                    .done();
                 } else {
                   resolve(update);
                 }
               })
-              .catch(reject)
-              .done();
             });
           });
 }

--- a/CodePush.m
+++ b/CodePush.m
@@ -52,10 +52,16 @@ NSString * const UpdateBundleFileName = @"app.jsbundle";
 
 - (void)loadBundle
 {
-    // Reset the runtime's bundle to be
-    // the latest URL, and then force a refresh
-    _bridge.bundleURL = [CodePush getBundleUrl];
-    [_bridge reload];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:[CodePush getBundleUrl]
+                                                            moduleName:[CodePushConfig getRootComponent]
+                                                     initialProperties:nil
+                                                         launchOptions:nil];
+        
+        UIViewController *rootViewController = [[UIViewController alloc] init];
+        rootViewController.view = rootView;
+        [UIApplication sharedApplication].delegate.window.rootViewController = rootViewController;
+    });
 }
 
 - (void)rollbackPackage

--- a/CodePushPackage.m
+++ b/CodePushPackage.m
@@ -6,7 +6,7 @@ NSString * const StatusFile = @"codepush.json";
 
 + (NSString *)getCodePushPath
 {
-    return [[CodePush getDocumentsDirectory] stringByAppendingPathComponent:@"CodePush"];
+    return [NSHomeDirectory() stringByAppendingPathComponent:@"CodePush"];
 }
 
 + (NSString *)getStatusFilePath

--- a/CodePushPackage.m
+++ b/CodePushPackage.m
@@ -6,7 +6,7 @@ NSString * const StatusFile = @"codepush.json";
 
 + (NSString *)getCodePushPath
 {
-    return [NSHomeDirectory() stringByAppendingPathComponent:@"CodePush"];
+    return [[CodePush getDocumentsDirectory] stringByAppendingPathComponent:@"CodePush"];
 }
 
 + (NSString *)getStatusFilePath

--- a/package-mixins.js
+++ b/package-mixins.js
@@ -2,6 +2,9 @@ var extend = require("extend");
 
 module.exports = (NativeCodePush) => {
   var remote = {
+    abortDownload: function abortDownload() {
+      return NativeCodePush.abortDownload(this);
+    },
     download: function download() {
       if (!this.downloadUrl) {
         return Promise.reject(new Error("Cannot download an update without a download url"));
@@ -13,9 +16,6 @@ module.exports = (NativeCodePush) => {
         .then((downloadedPackage) => {
           return extend({}, downloadedPackage, local);
         });
-    },
-    abortDownload: function abortDownload() {
-      return NativeCodePush.abortDownload(this);
     }
   };
 


### PR DESCRIPTION
This PR implements support for the "failedApply" property on the package objects. This way, an app can choose to ignore a discovered update that has previously failed, based on the rollback protection feature. The "sync" method already checks for this property, and silently ignores package's that are annotated as having failed.

I also did a little bit of re-ordering of functions, and removed some dead code.