### PR TITLE
Simplify loadBundle

### DIFF
--- a/CodePush.m
+++ b/CodePush.m
@@ -52,16 +52,10 @@ NSString * const UpdateBundleFileName = @"app.jsbundle";
 
 - (void)loadBundle
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:[CodePush getBundleUrl]
-                                                            moduleName:[CodePushConfig getRootComponent]
-                                                     initialProperties:nil
-                                                         launchOptions:nil];
-        
-        UIViewController *rootViewController = [[UIViewController alloc] init];
-        rootViewController.view = rootView;
-        [UIApplication sharedApplication].delegate.window.rootViewController = rootViewController;
-    });
+    // Reset the runtime's bundle to be
+    // the latest URL, and then force a refresh
+    _bridge.bundleURL = [CodePush getBundleUrl];
+    [_bridge reload];
 }
 
 - (void)rollbackPackage


### PR DESCRIPTION
The way that we're currently reloading the app after an update has a couple of issues:

1. It requires us to know the name of the root component. To do this, we'd either have to ask the user for it (e.g. adding a param to the getBundleUrl method) and/or assume the name is predictable. This is what we currently do

2. It wouldn't support a React Native app that was embedded within another iOS app, because the restart assumes that the root view controller can be completely replaced

This change solves both issues by simply telling the React Native runtime about the new bundle URL and then asking it to reload. This way, we don't need to know where in the view hierarchy the React view lives and/or what the user's root component is named.