### PR TITLE
Use same header search path for release builds as for debug

### DIFF
--- a/CodePush.xcodeproj/project.pbxproj
+++ b/CodePush.xcodeproj/project.pbxproj
@@ -225,6 +225,8 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/../../node_modules/react-native/React/**",
+					"$(SRCROOT)/node_modules/react-native/React/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
Reopening https://github.com/Microsoft/react-native-code-push/pull/33 for the CLA bot's approval.

Fixes issue with creating Release builds with applications depending on CodePush (#32).