### PR TITLE
Restart on resume

### DIFF
--- a/CodePush.h
+++ b/CodePush.h
@@ -71,3 +71,9 @@ failCallback:(void (^)(NSError *err))failCallback;
 + (void)rollbackPackage;
 
 @end
+
+typedef NS_ENUM(NSInteger, CodePushRestartMode) {
+    CodePushRestartModeNone,
+    CodePushRestartModeImmediate,
+    CodePushRestartModeOnNextResume
+};

--- a/CodePush.ios.js
+++ b/CodePush.ios.js
@@ -206,6 +206,11 @@ var CodePush = {
   notifyApplicationReady: NativeCodePush.notifyApplicationReady,
   setUpTestDependencies: setUpTestDependencies,
   sync: sync,
+  RestartMode: {
+    NONE: NativeCodePush.codePushRestartModeNone, // Don't artificially restart the app. Allow the update to be "picked up" on the next app restart
+    IMMEDIATE: NativeCodePush.codePushRestartModeImmediate, // Restart the app immediately
+    ON_NEXT_RESUME: NativeCodePush.codePushRestartModeOnNextResume // Restart the app the next time it is resumed from the background
+  },
   SyncStatus: {
     UP_TO_DATE: 0, // The running app is up-to-date
     UPDATE_IGNORED: 1, // The app had an optional update and the end-user chose to ignore it

--- a/CodePush.m
+++ b/CodePush.m
@@ -80,7 +80,7 @@ NSString * const PendingUpdateRollbackTimeoutKey = @"rollbackTimeout";
             if ([pendingHash isEqualToString:currentHash]) {
                 // We only want to initialize the rollback timer in two scenarios:
                 // 1) The app has been restarted, and therefore, the pending update is already applied
-                // 2) The app has been resumed, and the pending update indicates it supports being restarted on resume
+                // 2) The app has been resumed, and the pending update indicates it supports being restarted on resume, so we need to restart the app and the kickoff the rollback timer
                 if (isAppStart || (!isAppStart && [pendingUpdate[PendingUpdateAllowsRestartOnResumeKey] boolValue]))
                 {
                     int rollbackTimeout = [pendingUpdate[PendingUpdateRollbackTimeoutKey] intValue];
@@ -109,7 +109,7 @@ NSString * const PendingUpdateRollbackTimeoutKey = @"rollbackTimeout";
     return @{ @"codePushRestartModeNone": @(CodePushRestartModeNone),
               @"codePushRestartModeImmediate": @(CodePushRestartModeImmediate),
               @"codePushRestartModeOnNextResume": @(CodePushRestartModeOnNextResume)
-              };
+            };
 };
 
 - (void)dealloc {
@@ -179,7 +179,8 @@ NSString * const PendingUpdateRollbackTimeoutKey = @"rollbackTimeout";
     [self loadBundle];
 }
 
-- (void)saveFailedUpdate:(NSString *)packageHash {
+- (void)saveFailedUpdate:(NSString *)packageHash
+{
     NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
     NSMutableArray *failedUpdates = [preferences objectForKey:FailedUpdatesKey];
     if (failedUpdates == nil) {
@@ -224,10 +225,10 @@ NSString * const PendingUpdateRollbackTimeoutKey = @"rollbackTimeout";
 
 // JavaScript-exported module methods
 RCT_EXPORT_METHOD(applyUpdate:(NSDictionary*)updatePackage
-                  rollbackTimeout:(int)rollbackTimeout
+              rollbackTimeout:(int)rollbackTimeout
                   restartMode:(CodePushRestartMode)restartMode
-                  resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
+                     resolver:(RCTPromiseResolveBlock)resolve
+                     rejecter:(RCTPromiseRejectBlock)reject)
 {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         NSError *error;
@@ -250,8 +251,8 @@ RCT_EXPORT_METHOD(applyUpdate:(NSDictionary*)updatePackage
 }
 
 RCT_EXPORT_METHOD(downloadUpdate:(NSDictionary*)updatePackage
-                  resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
+                        resolver:(RCTPromiseResolveBlock)resolve
+                        rejecter:(RCTPromiseRejectBlock)reject)
 {
     [CodePushPackage downloadPackage:updatePackage
                     progressCallback:^(long expectedContentLength, long receivedContentLength) {
@@ -280,13 +281,13 @@ RCT_EXPORT_METHOD(downloadUpdate:(NSDictionary*)updatePackage
 }
 
 RCT_EXPORT_METHOD(getConfiguration:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
+                          rejecter:(RCTPromiseRejectBlock)reject)
 {
     resolve([CodePushConfig getConfiguration]);
 }
 
 RCT_EXPORT_METHOD(getCurrentPackage:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
+                           rejecter:(RCTPromiseRejectBlock)reject)
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         NSError *error;
@@ -300,16 +301,16 @@ RCT_EXPORT_METHOD(getCurrentPackage:(RCTPromiseResolveBlock)resolve
 }
 
 RCT_EXPORT_METHOD(isFailedUpdate:(NSString *)packageHash
-                  resolve:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
+                         resolve:(RCTPromiseResolveBlock)resolve
+                          reject:(RCTPromiseRejectBlock)reject)
 {
     BOOL isFailedHash = [self isFailedHash:packageHash];
     resolve(@(isFailedHash));
 }
 
 RCT_EXPORT_METHOD(isFirstRun:(NSString *)packageHash
-                  resolve:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
+                     resolve:(RCTPromiseResolveBlock)resolve
+                    rejecter:(RCTPromiseRejectBlock)reject)
 {
     NSError *error;
     BOOL isFirstRun = didUpdate
@@ -321,7 +322,7 @@ RCT_EXPORT_METHOD(isFirstRun:(NSString *)packageHash
 }
 
 RCT_EXPORT_METHOD(notifyApplicationReady:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
+                                rejecter:(RCTPromiseRejectBlock)reject)
 {
     [self cancelRollbackTimer];
     resolve([NSNull null]);

--- a/CodePush.m
+++ b/CodePush.m
@@ -9,9 +9,9 @@
 
 RCT_EXPORT_MODULE()
 
+BOOL didUpdate = NO;
 NSTimer *_timer;
 BOOL usingTestFolder = NO;
-BOOL didUpdate = NO;
 
 NSString * const FailedUpdatesKey = @"CODE_PUSH_FAILED_UPDATES";
 NSString * const PendingUpdateKey = @"CODE_PUSH_PENDING_UPDATE";
@@ -63,7 +63,8 @@ NSString * const PendingUpdateRollbackTimeoutKey = @"rollbackTimeout";
     });
 }
 
-- (void)checkForPendingUpdate:(BOOL)isAppStart {
+- (void)checkForPendingUpdate:(BOOL)isAppStart
+{
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
         NSDictionary *pendingUpdate = [preferences objectForKey:PendingUpdateKey];
@@ -98,7 +99,8 @@ NSString * const PendingUpdateRollbackTimeoutKey = @"rollbackTimeout";
     });
 }
 
-- (void)checkForPendingUpdateDuringResume {
+- (void)checkForPendingUpdateDuringResume
+{
     [self checkForPendingUpdate:NO];
 }
 
@@ -112,7 +114,8 @@ NSString * const PendingUpdateRollbackTimeoutKey = @"rollbackTimeout";
             };
 };
 
-- (void)dealloc {
+- (void)dealloc
+{
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 

--- a/CodePush.m
+++ b/CodePush.m
@@ -113,7 +113,7 @@ NSString * const PendingUpdateRollbackTimeoutKey = @"rollbackTimeout";
 - (void)dealloc
 {
     // Ensure the global resume handler is cleared, so that
-    // this object isn't kept alive unneccesarily
+    // this object isn't kept alive unnecessarily
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 

--- a/CodePush.xcodeproj/project.pbxproj
+++ b/CodePush.xcodeproj/project.pbxproj
@@ -8,7 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		13BE3DEE1AC21097009241FE /* CodePush.m in Sources */ = {isa = PBXBuildFile; fileRef = 13BE3DED1AC21097009241FE /* CodePush.m */; };
-		54FFEDE01BF550630061DD23 /* CodePushDownloadHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 54FFEDDF1BF550630061DD23 /* CodePushDownloadHandler.m */; settings = {ASSET_TAGS = (); }; };
+		1B23B9141BF9267B000BB2F0 /* RCTConvert+CodePushRestartMode.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B23B9131BF9267B000BB2F0 /* RCTConvert+CodePushRestartMode.m */; };
+		54FFEDE01BF550630061DD23 /* CodePushDownloadHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 54FFEDDF1BF550630061DD23 /* CodePushDownloadHandler.m */; };
 		810D4E6D1B96935000B397E9 /* CodePushPackage.m in Sources */ = {isa = PBXBuildFile; fileRef = 810D4E6C1B96935000B397E9 /* CodePushPackage.m */; };
 		81D51F3A1B6181C2000DA084 /* CodePushConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 81D51F391B6181C2000DA084 /* CodePushConfig.m */; };
 /* End PBXBuildFile section */
@@ -29,6 +30,7 @@
 		134814201AA4EA6300B7C361 /* libCodePush.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libCodePush.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		13BE3DEC1AC21097009241FE /* CodePush.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CodePush.h; sourceTree = "<group>"; };
 		13BE3DED1AC21097009241FE /* CodePush.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CodePush.m; sourceTree = "<group>"; };
+		1B23B9131BF9267B000BB2F0 /* RCTConvert+CodePushRestartMode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RCTConvert+CodePushRestartMode.m"; sourceTree = "<group>"; };
 		54FFEDDF1BF550630061DD23 /* CodePushDownloadHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CodePushDownloadHandler.m; sourceTree = "<group>"; };
 		810D4E6C1B96935000B397E9 /* CodePushPackage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CodePushPackage.m; sourceTree = "<group>"; };
 		81D51F391B6181C2000DA084 /* CodePushConfig.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CodePushConfig.m; sourceTree = "<group>"; };
@@ -56,6 +58,7 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
+				1B23B9131BF9267B000BB2F0 /* RCTConvert+CodePushRestartMode.m */,
 				54FFEDDF1BF550630061DD23 /* CodePushDownloadHandler.m */,
 				810D4E6C1B96935000B397E9 /* CodePushPackage.m */,
 				81D51F391B6181C2000DA084 /* CodePushConfig.m */,
@@ -121,6 +124,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1B23B9141BF9267B000BB2F0 /* RCTConvert+CodePushRestartMode.m in Sources */,
 				81D51F3A1B6181C2000DA084 /* CodePushConfig.m in Sources */,
 				54FFEDE01BF550630061DD23 /* CodePushDownloadHandler.m in Sources */,
 				13BE3DEE1AC21097009241FE /* CodePush.m in Sources */,

--- a/RCTConvert+CodePushRestartMode.m
+++ b/RCTConvert+CodePushRestartMode.m
@@ -1,0 +1,14 @@
+#import "CodePush.h"
+#import "RCTConvert.h"
+
+// Extending the RCTConvert class allows the React Native
+// bridge to handle args of type "CodePushRestartMode"
+@implementation RCTConvert (CodePushRestartMode)
+
+RCT_ENUM_CONVERTER(CodePushRestartMode, (@{ @"codePushRestartModeNone": @(CodePushRestartModeNone),
+                                            @"codePushRestartModeImmediate": @(CodePushRestartModeImmediate),
+                                            @"codePushRestartModeOnNextResume": @(CodePushRestartModeOnNextResume) }),
+                   CodePushRestartModeImmediate, // Default enum value
+                   integerValue)
+
+@end

--- a/package-mixins.js
+++ b/package-mixins.js
@@ -1,6 +1,5 @@
 var extend = require("extend");
 var { NativeAppEventEmitter } = require("react-native");
-var { RestartMode } = require("react-native-code-push");
 
 module.exports = (NativeCodePush) => {
   var remote = {
@@ -37,7 +36,7 @@ module.exports = (NativeCodePush) => {
   };
 
   var local = {
-    apply: function apply(rollbackTimeout = 0, restartMode = RestartMode.IMMEDIATE) {
+    apply: function apply(rollbackTimeout = 0, restartMode = NativeCodePush.codePushRestartModeImmediate) {
       return NativeCodePush.applyUpdate(this, rollbackTimeout, restartMode);
     }
   };

--- a/package-mixins.js
+++ b/package-mixins.js
@@ -1,5 +1,6 @@
 var extend = require("extend");
 var { NativeAppEventEmitter } = require("react-native");
+var { RestartMode } = require("react-native-code-push");
 
 module.exports = (NativeCodePush) => {
   var remote = {
@@ -36,8 +37,8 @@ module.exports = (NativeCodePush) => {
   };
 
   var local = {
-    apply: function apply(rollbackTimeout = 0, restartImmediately = true) {
-      return NativeCodePush.applyUpdate(this, rollbackTimeout, restartImmediately);
+    apply: function apply(rollbackTimeout = 0, restartMode = RestartMode.IMMEDIATE) {
+      return NativeCodePush.applyUpdate(this, rollbackTimeout, restartMode);
     }
   };
 


### PR DESCRIPTION
This extends/replaces the previous `restartImmediately` flag by allowing the caller to pass a `restartMode` to `LocalPackage.apply`, which adds the ability to restart the app on the next resume, as opposed to simply restarting immediately or not. The default value when a mode isn't specified is still "immediate", but this change gives devs more options, particularly if they want to employ a "silent update" mechanism, which doesn't immediately restart the app, but does on the next app resume.

Moving forward, we could also expose an API to script that allows restarting the app at a custom, app-specific time, that way you apply the update, specifying a restart mode of none, and then force the restart sooner at a point the app can determine is acceptable (e.g. the end-user navigated back to the home page).

This change only impacts the `LocalPackage.apply` method. We need to determine how to best expose the `restartMode` via `sync`, in a way that still respects the `isMandatory` option of an update and doesn't allow the app to have a weird update experience (e.g. not applying the update immediately is kind of strange when you asked the end-user for permission to install it). We'll address that in a future PR, along with exposing the new `progressCallback` feature that was added to the `RemotePackage.download` method.