### PR TITLE
Bug fixes with the new sync refactor

### DIFF
--- a/CodePush.ios.js
+++ b/CodePush.ios.js
@@ -210,8 +210,7 @@ function sync(options = {}, syncStatusChangeCallback, downloadProgressCallback) 
         }
         else if (syncOptions.updateDialog) {
           // updateDialog supports any truthy value (e.g. true, "goo", 12),
-          // but when we merge it's properties with the default dialog's
-          // properties, it needs to be an object
+          // but we should treat a non-object value as just the default dialog
           if (typeof syncOptions.updateDialog !== "object") {
             syncOptions.updateDialog = CodePush.DEFAULT_UPDATE_DIALOG;
           } else {

--- a/CodePush.ios.js
+++ b/CodePush.ios.js
@@ -214,7 +214,7 @@ function sync(options = {}, syncStatusChangeCallback, downloadProgressCallback) 
           if (typeof syncOptions.updateDialog !== "object") {
             syncOptions.updateDialog = CodePush.DEFAULT_UPDATE_DIALOG;
           } else {
-            syncOptions.updateDialog = Object.assign(CodePush.DEFAULT_UPDATE_DIALOG, syncOptions.updateDialog);
+            syncOptions.updateDialog = Object.assign({}, CodePush.DEFAULT_UPDATE_DIALOG, syncOptions.updateDialog);
           }
           
           var message = null;

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ The method accepts an options object that allows you to customize numerous aspec
     * __optionalIgnoreButtonLabel__ (String) - The text to use for the button the end-user can press in order to ignore an optional update that is available. Defaults to `"Ignore"`.
     * __optionalInstallButtonLabel__ (String) - The text to use for the button the end-user can press in order to install an optional update. Defaults to `"Install"`.
     * __optionalUpdateMessage__ (String) - The text used as the body of an update notification, when the update is optional. Defaults to `"An update is available. Would you like to install it?"`.
-    * __updateTitle__ (String) - The text used as the header of an update notification that is displayed to the end-user. Defaults to `"Update available"`.
+    * __title__ (String) - The text used as the header of an update notification that is displayed to the end-user. Defaults to `"Update available"`.
 
 In addition, the method also recieves two function arguments which serve as event handlers which are called at various points in the sync process:
 

--- a/package-mixins.js
+++ b/package-mixins.js
@@ -1,4 +1,3 @@
-var extend = require("extend");
 var { NativeAppEventEmitter } = require("react-native");
 
 module.exports = (NativeCodePush) => {
@@ -25,7 +24,7 @@ module.exports = (NativeCodePush) => {
       return NativeCodePush.downloadUpdate(this)
         .then((downloadedPackage) => {
           downloadProgressSubscription && downloadProgressSubscription.remove();
-          return extend({}, downloadedPackage, local);
+          return Object.assign({}, downloadedPackage, local);
         })
         .catch((error) => {
           downloadProgressSubscription && downloadProgressSubscription.remove();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-code-push",
-  "version": "1.2.0-beta",
+  "version": "1.2.1-beta",
   "description": "React Native plugin for the CodePush service",
   "main": "CodePush.ios.js",
   "homepage": "https://microsoft.github.io/code-push",
@@ -16,8 +16,7 @@
     "url": "https://github.com/Microsoft/react-native-code-push"
   },
   "dependencies": {
-    "code-push": "^1.1.1-beta",
-    "extend": "3.0.0"
+    "code-push": "^1.1.1-beta"
   },
   "devDependencies": {
     "react-native": "0.11.4"


### PR DESCRIPTION
This PR fixes three bugs related to the `sync` refactoring:

1. The `UPDATE_IGNORED` sync status event was never fired to the `syncStatusChangeCallback`
2. The use of `Object.assign` would fail when the `updateDialog` sync options wasn't an object (e.g. you pass it true)
3. The update confirmation title wasn't being displayed due to it not using the new nested `updateDialog` object. While fixing this, I took it upon myself to rename this property to just `title` since `updateDialog.title` seems intutuive enough to not need the second "update" :)
4. Not a bug, but I replaced the use of the `extend` module with `Object.assign`