### PR TITLE
Removing 'Name' suffix

### DIFF
--- a/CodePush.h
+++ b/CodePush.h
@@ -4,10 +4,10 @@
 
 + (NSURL *)bundleURL;
 
-+ (NSURL *)bundleURLForResourceName:(NSString *)resourceName;
++ (NSURL *)bundleURLForResource:(NSString *)resourceName;
 
-+ (NSURL *)bundleURLForResourceName:(NSString *)resourceName
-                      withExtension:(NSString *)resourceExtension;
++ (NSURL *)bundleURLForResource:(NSString *)resourceName
+                  withExtension:(NSString *)resourceExtension;
 
 + (NSString *)getDocumentsDirectory;
 

--- a/CodePush.m
+++ b/CodePush.m
@@ -30,14 +30,14 @@ static NSString * const PendingUpdateRollbackTimeoutKey = @"rollbackTimeout";
     return [self bundleURLForResourceName:@"main"];
 }
 
-+ (NSURL *)bundleURLForResourceName:(NSString *)resourceName
++ (NSURL *)bundleURLForResource:(NSString *)resourceName
 {
     return [self bundleURLForResourceName:resourceName
                             withExtension:@"jsbundle"];
 }
 
-+ (NSURL *)bundleURLForResourceName:(NSString *)resourceName
-                      withExtension:(NSString *)resourceExtension
++ (NSURL *)bundleURLForResource:(NSString *)resourceName
+                  withExtension:(NSString *)resourceExtension
 {
     NSError *error;
     NSString *packageFile = [CodePushPackage getCurrentPackageBundlePath:&error];

--- a/CodePush.m
+++ b/CodePush.m
@@ -27,13 +27,13 @@ static NSString * const PendingUpdateRollbackTimeoutKey = @"rollbackTimeout";
 
 + (NSURL *)bundleURL
 {
-    return [self bundleURLForResourceName:@"main"];
+    return [self bundleURLForResource:@"main"];
 }
 
 + (NSURL *)bundleURLForResource:(NSString *)resourceName
 {
-    return [self bundleURLForResourceName:resourceName
-                            withExtension:@"jsbundle"];
+    return [self bundleURLForResource:resourceName
+                        withExtension:@"jsbundle"];
 }
 
 + (NSURL *)bundleURLForResource:(NSString *)resourceName

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Once your Xcode project has been setup to build/link the CodePush plugin, you ne
 
 This change configures your app to always load the most recent version of your app's JS bundle. On the initial launch, this will correspond to the file that was compiled with the app. However, after an update has been pushed via CodePush, this will return the location of the most recently installed update.
 
-*NOTE: The `bundleURL` method assumes your app's JS bundle is named `main.jsbundle`. If you have configured your app to use a different file name, simply call the `bundleURLForResourceName:` method (which assumes you're using the `.jsbundle` extension) or `bundleURLForResourceName:withExtension:` method instead, in order to overwrite that default behavior*
+*NOTE: The `bundleURL` method assumes your app's JS bundle is named `main.jsbundle`. If you have configured your app to use a different file name, simply call the `bundleURLForResource:` method (which assumes you're using the `.jsbundle` extension) or `bundleURLForResource:withExtension:` method instead, in order to overwrite that default behavior*
 
 To let the CodePush runtime know which deployment it should query for updates against, perform the following steps:
 


### PR DESCRIPTION
This PR simply removes the `Name` suffix from the new `bundleURLForResource` methods, which aligns more closely with the `URLForResource` method of the `NSBundle` class, which these are effectively mirroring.