### PR TITLE
Fixing caching issue with specifying a deployment key

### DIFF
--- a/CodePush.ios.js
+++ b/CodePush.ios.js
@@ -15,7 +15,7 @@ function checkForUpdate(deploymentKey = null) {
             // then let's override the one we retrieved
             // from the native-side of the app.
             if (deploymentKey) {
-              config = Object.assign({}, configResult, { deploymentKey: deploymentKey });
+              config = Object.assign({}, configResult, { deploymentKey });
             } else {
               config = configResult;
             }


### PR DESCRIPTION
The `getSDK` function was caching its results, which would result in there being issues with trying to override the deployment key in one call to `sync`/`checkForUpdate`, and then wanting to rely on the "default" key on a subsequent call. This change removes the caching behavior completely from `getSDK` since it isn't really needed, and its updates the `checkForUpdate` method to make a copy on the `config` object when it modifies it in place, as opposed to updating the instance it gets back from the `getConfiguration` promise.