### PR TITLE
Renaming restartPendingUpdate to restartApp

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -267,7 +267,7 @@ var CodePush = {
   getCurrentPackage: getCurrentPackage,
   log: log,
   notifyApplicationReady: NativeCodePush.notifyApplicationReady,
-  restartPendingUpdate: NativeCodePush.restartPendingUpdate,
+  restartApp: NativeCodePush.restartApp,
   setUpTestDependencies: setUpTestDependencies,
   sync: sync,
   InstallMode: {

--- a/CodePush.m
+++ b/CodePush.m
@@ -396,7 +396,7 @@ RCT_EXPORT_METHOD(notifyApplicationReady:(RCTPromiseResolveBlock)resolve
 /*
  * This method is the native side of the CodePush.restartApp() method.
  */
-RCT_EXPORT_METHOD(restartApp
+RCT_EXPORT_METHOD(restartApp)
 {
     [self loadBundle];
 }

--- a/CodePush.m
+++ b/CodePush.m
@@ -394,33 +394,11 @@ RCT_EXPORT_METHOD(notifyApplicationReady:(RCTPromiseResolveBlock)resolve
 }
 
 /*
- * This method isn't publicly exposed via the "react-native-code-push"
- * module, and is only used internally to support immediately installed updates.
+ * This method is the native side of the CodePush.restartApp() method.
  */
-RCT_EXPORT_METHOD(restartImmediateUpdate:(int)rollbackTimeout)
+RCT_EXPORT_METHOD(restartApp
 {
     [self loadBundle];
-}
-
-/*
- * This method is the native side of the CodePush.restartPendingUpdate() method.
- */
-RCT_EXPORT_METHOD(restartPendingUpdate)
-{
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
-        NSDictionary *pendingUpdate = [preferences objectForKey:PendingUpdateKey];
-        
-        if (pendingUpdate) {
-            NSError *error;
-            NSString *pendingHash = pendingUpdate[PendingUpdateHashKey];
-            NSString *currentHash = [CodePushPackage getCurrentPackageHash:&error];
-            
-            NSAssert([pendingHash isEqualToString:currentHash], @"There is a pending update but it's hash doesn't match that of the current package.");
-            
-            [self loadBundle];
-        }
-    });
 }
 
 RCT_EXPORT_METHOD(setUsingTestFolder:(BOOL)shouldUseTestFolder)

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ When you require `react-native-code-push`, the module object provides the follow
 
 * [notifyApplicationReady](#codepushnotifyapplicationready): Notifies the CodePush runtime that an installed update is considered successful. This is an optional API, but is useful when you want to expicitly enable "rollback protection" in the event that an exception occurs in code that you've deployed to production.
 
-* [restartPendingUpdate](#codepushrestartPendingUpdate): Conditionally restarts the app if a previously installed update is currently pending (e.g. it was installed using the `ON_NEXT_RESTART` or `ON_NEXT_RESUME` modes, and the app hasn't been restarted or resumed yet).
+* [restartApp](#codepushrestartapp): Immediately restarts the app. If there is an update pending, it will be immediately displayed to the end-user, and the rollback timer (if specified when installing the update) will begin. Otherwise, calling this method simply has the same behavior as the end-user killing and restarting the process.
 
 * [sync](#codepushsync): Allows checking for an update, downloading it and installing it, all with a single call. Unless you need custom UI and/or behavior, we recommend most developers to use this method when integrating CodePush into their apps
 
@@ -255,18 +255,16 @@ Notifies the CodePush runtime that an update should be considered successful, an
 
 If the `rollbackTimeout` parameter was not specified, the CodePush runtime will not enforce any automatic rollback behavior, and therefore, calling this function is not required and will result in a no-op.
 
-### codePush.restartPendingUpdate		
+### codePush.restartApp		
 		
 ```javascript		
-codePush.restartPendingUpdate(): void;		
+codePush.restartApp(): void;		
 ```		
 		
-Applies the pending update (if applicable) by immediately restarting the app, and optionally starting the rollback timer. This method is for advanced scenarios, and is only useful when the following conditions are true:		
+Immediately restarts the app. If there is an update pending, it will be presented to the end-user and the rollback timer (if specified when installing the update) will begin. Otherwise, calling this method simply has the same behavior as the end-user killing and restarting the process. This method is for advanced scenarios, and is primarily useful when the following conditions are true:		
 		
 1. Your app is specifying an install mode value of `ON_NEXT_RESTART` or `ON_NEXT_RESUME` when calling the `sync` or `LocalPackage.install` methods. This has the effect of not applying your update until the app has been restarted (by either the end-user or OS)	or resumed, and therefore, the update won't be immediately displayed to the end-user 	.
 2. You have an app-specific user event (e.g. the end-user navigated back to the app's home route) that allows you to apply the update in an unobtrusive way, and potentially gets the update in front of the end-user sooner then waiting until the next restart or resume.		
-		
-If you call this method, and there isn't a pending update, it will result in a no-op. Otherwise, the app will be restarted in order to display the update to the end-user.
 
 ### codePush.sync
 

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -376,35 +376,8 @@ public class CodePush {
         }
 
         @ReactMethod
-        public void restartImmediateUpdate(int rollbackTimeout) {
+        public void restartApp() {
             loadBundle();
-        }
-
-        @ReactMethod
-        public void restartPendingUpdate() {
-            SharedPreferences settings = applicationContext.getSharedPreferences(CODE_PUSH_PREFERENCES, 0);
-            String pendingUpdateString = settings.getString(PENDING_UPDATE_KEY, null);
-
-            if (pendingUpdateString != null) {
-                try {
-                    JSONObject pendingUpdateJSON = new JSONObject(pendingUpdateString);
-                    String pendingHash = pendingUpdateJSON.getString(PENDING_UPDATE_HASH_KEY);
-                    String currentHash = codePushPackage.getCurrentPackageHash();
-                    if (!pendingHash.equals(currentHash)) {
-                        throw new CodePushUnknownException("Pending hash " + pendingHash +
-                                " and current hash " + currentHash + " are different");
-                    }
-
-                    loadBundle();
-                } catch (JSONException e) {
-                    // Should not happen.
-                    throw new CodePushUnknownException("Unable to parse pending update metadata " +
-                            pendingUpdateString + " stored in SharedPreferences", e);
-                } catch (IOException e) {
-                    // There is no current package hash.
-                    throw new CodePushUnknownException("Should not register a pending update without a saving a current package", e);
-                }
-            }
         }
 
         @Override

--- a/package-mixins.js
+++ b/package-mixins.js
@@ -41,7 +41,7 @@ module.exports = (NativeCodePush) => {
         .then(function() {
           updateInstalledCallback && updateInstalledCallback();
           if (installMode == NativeCodePush.codePushInstallModeImmediate) {
-            NativeCodePush.restartImmediateUpdate(rollbackTimeout);
+            NativeCodePush.restartApp();
           };
         });
     }


### PR DESCRIPTION
This change renames `restartPendingUpdate` to `restartApp` and modifies its behavior to simply restart the app, as opposed to conditionally checking if there is a pending update.