### PR TITLE
Delete old packages

### DIFF
--- a/AlertAdapter.js
+++ b/AlertAdapter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Platform = require("react-native").Platform;
+var { Platform } = require("react-native");
 var Alert;
 
 if (Platform.OS === "android") {

--- a/AlertAdapter.js
+++ b/AlertAdapter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Platform = require("Platform");
+var Platform = require("react-native").Platform;
 var Alert;
 
 if (Platform.OS === "android") {

--- a/CodePush.xcodeproj/project.pbxproj
+++ b/CodePush.xcodeproj/project.pbxproj
@@ -217,6 +217,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/node_modules/react-native/React/**",
 					"$(SRCROOT)/Examples/CodePushDemoApp/node_modules/react-native/React/**",
+					"$(SRCROOT)/../react-native/React/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
@@ -233,6 +234,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/node_modules/react-native/React/**",
 					"$(SRCROOT)/Examples/CodePushDemoApp/node_modules/react-native/React/**",
+					"$(SRCROOT)/../react-native/React/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";

--- a/CodePushPackage.m
+++ b/CodePushPackage.m
@@ -218,6 +218,15 @@ NSString * const UpdateBundleFileName = @"app.jsbundle";
         return;
     }
     
+    NSString *previousPackageHash = [self getPreviousPackageHash:error];
+    if (!*error && previousPackageHash && ![previousPackageHash isEqualToString:packageHash]) {
+        NSString *previousPackageFolderPath = [self getPackageFolderPath:previousPackageHash];
+        [[NSFileManager defaultManager] removeItemAtPath:previousPackageFolderPath error:error];
+        if (*error) {
+            return;
+        }
+    }
+    
     [info setValue:info[@"currentPackage"] forKey:@"previousPackage"];
     [info setValue:packageHash forKey:@"currentPackage"];
 

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/DownloadProgressTests/DownloadProgressTest.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/DownloadProgressTests/DownloadProgressTest.js
@@ -1,11 +1,10 @@
 "use strict";
 
 var React = require("react-native");
-var { DeviceEventEmitter } = require("react-native");
+var { Platform, DeviceEventEmitter } = require("react-native");
 var CodePushSdk = require("react-native-code-push");
 var NativeCodePush = require("react-native").NativeModules.CodePush;
 var RCTTestModule = require('NativeModules').TestModule || {};
-var Platform = require("react-native").Platform;
 
 var {
   Text,

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/DownloadProgressTests/DownloadProgressTest.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/DownloadProgressTests/DownloadProgressTest.js
@@ -5,7 +5,7 @@ var { DeviceEventEmitter } = require("react-native");
 var CodePushSdk = require("react-native-code-push");
 var NativeCodePush = require("react-native").NativeModules.CodePush;
 var RCTTestModule = require('NativeModules').TestModule || {};
-var Platform = require("Platform");
+var Platform = require("react-native").Platform;
 
 var {
   Text,

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/DownloadProgressTests/TestPackages.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/DownloadProgressTests/TestPackages.js
@@ -1,4 +1,4 @@
-var Platform = require("Platform");
+var Platform = require("react-native").Platform;
 
 var packages = {
   smallPackage: {

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/DownloadProgressTests/TestPackages.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/DownloadProgressTests/TestPackages.js
@@ -1,4 +1,4 @@
-var Platform = require("react-native").Platform;
+var { Platform } = require("react-native");
 
 var packages = {
   smallPackage: {

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/TestPackage.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/TestPackage.js
@@ -1,4 +1,4 @@
-var Platform = require("Platform");
+var Platform = require("react-native").Platform;
 
 var testPackage = {
   description: "Angry flappy birds",

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/TestPackage.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/TestPackage.js
@@ -1,4 +1,4 @@
-var Platform = require("react-native").Platform;
+var { Platform } = require("react-native");
 
 var testPackage = {
   description: "Angry flappy birds",

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -275,7 +275,7 @@ public class CodePush {
                     savePendingUpdate(pendingHash, rollbackTimeout);
                 }
 
-                if (installMode != CodePushInstallMode.IMMEDIATE.getValue()) {
+                if (installMode == CodePushInstallMode.IMMEDIATE.getValue()) {
                     loadBundle();
                 } else if (installMode == CodePushInstallMode.ON_NEXT_RESUME.getValue()) {
                     // Ensure we do not add the listener twice.

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushPackage.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushPackage.java
@@ -170,6 +170,11 @@ public class CodePushPackage {
     public void installPackage(ReadableMap updatePackage) throws IOException {
         String packageHash = CodePushUtils.tryGetString(updatePackage, PACKAGE_HASH_KEY);
         WritableMap info = getCurrentPackageInfo();
+        String previousPackageHash = getPreviousPackageHash();
+        if (previousPackageHash != null && !previousPackageHash.equals(packageHash)) {
+            CodePushUtils.deleteDirectoryAtPath(getPackageFolderPath(previousPackageHash));
+        }
+
         info.putString(PREVIOUS_PACKAGE_KEY, CodePushUtils.tryGetString(info, CURRENT_PACKAGE_KEY));
         info.putString(CURRENT_PACKAGE_KEY, packageHash);
         updateCurrentPackageInfo(info);

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUtils.java
@@ -61,6 +61,27 @@ public class CodePushUtils {
         }
     }
 
+    public static void deleteDirectoryAtPath(String directoryPath) {
+        deleteDirectory(new File(directoryPath));
+    }
+
+    public static void deleteDirectory(File directory) {
+        if (directory.exists()) {
+            File[] files = directory.listFiles();
+            if (files != null) {
+                for (int i=0; i<files.length; i++) {
+                    if(files[i].isDirectory()) {
+                        deleteDirectory(files[i]);
+                    }
+                    else {
+                        files[i].delete();
+                    }
+                }
+            }
+        }
+        directory.delete();
+    }
+
     public static boolean createFolderAtPath(String filePath) {
         File file = new File(filePath);
         return file.mkdir();

--- a/package-mixins.js
+++ b/package-mixins.js
@@ -1,5 +1,4 @@
-var Platform = require("react-native").Platform;
-var { DeviceEventEmitter } = require("react-native");
+var { Platform, DeviceEventEmitter } = require("react-native");
 
 module.exports = (NativeCodePush) => {
   var remote = {

--- a/package-mixins.js
+++ b/package-mixins.js
@@ -1,4 +1,4 @@
-var Platform = require("Platform");
+var Platform = require("react-native").Platform;
 var { DeviceEventEmitter } = require("react-native");
 
 module.exports = (NativeCodePush) => {


### PR DESCRIPTION
This PR

1. Clears older packages beyond the "previousPackage"
2. Fixes the header search path on iOS for NPM v3
3. Fixes a "require" issue with the "Platform" module which is a submodule of React
4. Fixes a bug with "install immediate" on android