### PR TITLE
Fixing isFirstRun on iOS after calling restartApp

### DIFF
--- a/CodePush.m
+++ b/CodePush.m
@@ -8,11 +8,11 @@
 
 @implementation CodePush {
     BOOL _hasResumeListener;
+    BOOL _isFirstRunAfterUpdate;
 }
 
 RCT_EXPORT_MODULE()
 
-static BOOL didUpdate = NO;
 static NSTimer *_timer;
 static BOOL usingTestFolder = NO;
 
@@ -129,7 +129,7 @@ static NSString *const PendingUpdateRollbackTimeoutKey = @"rollbackTimeout";
     NSDictionary *pendingUpdate = [preferences objectForKey:PendingUpdateKey];
     
     if (pendingUpdate) {
-        didUpdate = true;
+        _isFirstRunAfterUpdate = YES;
         int rollbackTimeout = [pendingUpdate[PendingUpdateRollbackTimeoutKey] intValue];
         if (0 != rollbackTimeout) {
             dispatch_async(dispatch_get_main_queue(), ^{
@@ -345,7 +345,7 @@ RCT_EXPORT_METHOD(installUpdate:(NSDictionary*)updatePackage
                                                              selector:@selector(loadBundle)
                                                                  name:UIApplicationWillEnterForegroundNotification
                                                                object:[UIApplication sharedApplication]];
-                    _hasResumeListener = true;
+                    _hasResumeListener = YES;
                 }
             }
             // Signal to JS that the update has been applied.
@@ -375,7 +375,7 @@ RCT_EXPORT_METHOD(isFirstRun:(NSString *)packageHash
                     rejecter:(RCTPromiseRejectBlock)reject)
 {
     NSError *error;
-    BOOL isFirstRun = didUpdate
+    BOOL isFirstRun = _isFirstRunAfterUpdate
                         && nil != packageHash
                         && [packageHash length] > 0
                         && [packageHash isEqualToString:[CodePushPackage getCurrentPackageHash:&error]];


### PR DESCRIPTION
The `didUpdate` global variable was never being reset to `NO` and therefore, if you called `restartApp` after an `IMMEDIATE` or `ON_NEXT_RESUME` update was applied, the `LocalPackage.isFirstRun` property would incorrectly be `true`. This change simply makes the `didUpdate` flag an ivar so that every time the app is restarted, it will be reset to `NO` and only set to `YES` when there was actually an update applied before the restart occurred. I also took it upon myself to rename the variable to better reflect its semantics.

This issue doesn't impact the Android implementation since when a reload happens, the `CodePush` class is collected along with the `MainActivity`, and therefore, doesn't rely on any global state like the iOS version was.