### PR TITLE
Avoid dismissing alert dialog when the user touches the screen

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushDialog.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushDialog.java
@@ -33,6 +33,8 @@ public class CodePushDialog extends ReactContextBaseJavaModule{
 
         AlertDialog.Builder builder = new AlertDialog.Builder(fragmentActivity);
 
+        builder.setCancelable(false);
+
         DialogInterface.OnClickListener clickListener = new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {


### PR DESCRIPTION
When update is mandatory, it doesn't make sense that the users can touch the screen to dismiss alert.