### PR TITLE
Delete bundle file if it already exists

### DIFF
--- a/CodePushPackage.m
+++ b/CodePushPackage.m
@@ -302,6 +302,14 @@ NSString * const UnzippedFolderName = @"unzipped";
                     return;
                 }
             } else {
+                if ([[NSFileManager defaultManager] fileExistsAtPath:bundleFilePath]) {
+                    [[NSFileManager defaultManager] removeItemAtPath:bundleFilePath error:&error];
+                    if (error) {
+                        failCallback(error);
+                        return;
+                    }
+                }
+                
                 [[NSFileManager defaultManager] moveItemAtPath:downloadFilePath
                                                         toPath:bundleFilePath
                                                          error:&error];


### PR DESCRIPTION
This bug only occurs when switching between different deployment keys dynamically using the API. Because the packages are stored in folders named using the package hash, it is possible to switch to a different deployment that yields an update with the same package hash as one that is previously installed under a different deployment. In this case, `moveItemAtPath` will fail because the destination file already exists. This fix takes care of that.