### PR TITLE
Fix semver compare when first version

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -50,7 +50,7 @@ function checkForUpdate(deploymentKey = null) {
              * to send the app version to the server, since we are interested
              * in any updates for current app store version, regardless of hash.
              */
-            if (localPackage && semver.compare(localPackage.appVersion, config.appVersion) === 0) {
+            if (localPackage && localPackage.appVersion && semver.compare(localPackage.appVersion, config.appVersion) === 0) {
               queryPackage = localPackage;
             }
             


### PR DESCRIPTION
In first version(not install any update from CodePush), we will get `[CodePush] An unknown error occurred.` after calling `CodePush.sync();`.
In `CodePush.js` line 55
```javascript
console.log('localPackage', localPackage); // -> { failedInstall: false, isFirstRun: false }

if (localPackage && semver.compare(localPackage.appVersion, config.appVersion) === 0) {
 queryPackage = localPackage;
}
```
Because `localPackage.appVersion` is `undefined`, `semver.compare` will throw an exception.
```javascript
try {
  semver.compare(localPackage.appVersion, config.appVersion);
} catch (e) {
  console.log('This is an error', e);
}
```
Logs are
```
'This is an error', { [TypeError: Invalid Version: undefined]
  line: 57942,
  column: 20,
  sourceURL: 'http://localhost:8081/index.ios.bundle?platform=ios&dev=true' }
```

So, just check `localPackage.appVersion` first then compare them.