### PR TITLE
Rollback if the app crashed

### DIFF
--- a/CodePush.h
+++ b/CodePush.h
@@ -57,6 +57,7 @@ failCallback:(void (^)(NSError *err))failCallback;
 @interface CodePushPackage : NSObject
 
 + (void)installPackage:(NSDictionary *)updatePackage
+       rollbackTimeout:(int)rollbackTimeout
                error:(NSError **)error;
 
 + (NSDictionary *)getCurrentPackage:(NSError **)error;
@@ -76,6 +77,9 @@ failCallback:(void (^)(NSError *err))failCallback;
            failCallback:(void (^)(NSError *err))failCallback;
 
 + (void)rollbackPackage;
+
++ (void)confirmPackageSuccess;
++ (BOOL)shouldRollbackIfNotConfirmPackageSuccess;
 
 @end
 


### PR DESCRIPTION
Currently, we can use `rollbackTimeout` parameter in `sync` method to rollback update if it doesn't call `notifyApplicationReady` method.
```javascript
componentDidMount() {
  CodePush.notifyApplicationReady();
  CodePush.sync({
    installMode: CodePush.InstallMode.IMMEDIATE,
    rollbackTimeout: 5000,
  });
},
```
However, if the app crashes with restarting, the rollback timer won't execute. Then, the app will use the broken update in next launch.
The goal of this PR is solving this issue. If the app crashes with restarting, it will know this thing and rollback in next launch. Maybe the codes needs some refactoring, but the concept is there.