### PR TITLE
Adding logging to UNKNOWN_ERROR sync status

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -294,6 +294,7 @@ function sync(options = {}, syncStatusChangeCallback, downloadProgressCallback) 
       })
       .catch((error) => {
         syncStatusChangeCallback(CodePush.SyncStatus.UNKNOWN_ERROR);
+        log(error.message);
         reject(error);
       })
       .done();

--- a/CodePush.js
+++ b/CodePush.js
@@ -219,6 +219,12 @@ function sync(options = {}, syncStatusChangeCallback, downloadProgressCallback) 
       };
   
   return new Promise((resolve, reject) => {
+    var rejectPromise = (error) => {
+      syncStatusChangeCallback(CodePush.SyncStatus.UNKNOWN_ERROR);
+      log(error.message); 
+      reject(error);
+    };
+    
     CodePush.notifyApplicationReady()
       .then(() => {
         syncStatusChangeCallback(CodePush.SyncStatus.CHECKING_FOR_UPDATE);
@@ -235,7 +241,7 @@ function sync(options = {}, syncStatusChangeCallback, downloadProgressCallback) 
                 resolve(CodePush.SyncStatus.UPDATE_INSTALLED);
               });
             })
-            .catch(reject)
+            .catch(rejectPromise)
             .done();
         }
         
@@ -292,11 +298,7 @@ function sync(options = {}, syncStatusChangeCallback, downloadProgressCallback) 
           doDownloadAndInstall();
         }
       })
-      .catch((error) => {
-        syncStatusChangeCallback(CodePush.SyncStatus.UNKNOWN_ERROR);
-        log(error.message);
-        reject(error);
-      })
+      .catch(rejectPromise)
       .done();
   });     
 };


### PR DESCRIPTION
If a developer calls `done()` on the `Promise` that is returned from `sync`, any errors that occur as part of the process will result in a red-box during development. Additionally, if they add a `catch` block to the `Promise`, they can be notified and inspect the actual error that occurred.

However, if a developer simply calls `sync()`, then any exceptions (e.g. non-semver compliant app version in `Info.plist`, missing deployment key) are swallowed, and the only diagnostics information they have is the "Unknown error" message that is logged by `sync`. 

This change simply logs the error message to the console, along with rejecting the `Promise` and notifying the `syncStatusCallback` about the error. This way, the simple consumption scenario is a bit easier to diagnose when an error occurs.

Additionally, any errors that were occurring as part of the `download` or `install` portion of the `sync` method were also being swallowed, so this change does the same `Promise` rejection in those situations as was already being done for the `checkForUpdate` portion.