### PR TITLE
Use Application Support Directory

### DIFF
--- a/CodePush.h
+++ b/CodePush.h
@@ -20,7 +20,7 @@
 + (NSURL *)bundleURLForResource:(NSString *)resourceName
                   withExtension:(NSString *)resourceExtension;
 
-+ (NSString *)getDocumentsDirectory;
++ (NSString *)getApplicationSupportDirectory;
 
 @end
 

--- a/CodePush.m
+++ b/CodePush.m
@@ -62,10 +62,10 @@ static NSString *const PendingUpdateRollbackTimeoutKey = @"rollbackTimeout";
     }
 }
 
-+ (NSString *)getDocumentsDirectory
++ (NSString *)getApplicationSupportDirectory
 {
-    NSString *documentsDirectory = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];
-    return documentsDirectory;
+    NSString *applicationSupportDirectory = [NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES) objectAtIndex:0];
+    return applicationSupportDirectory;
 }
 
 // Private API methods

--- a/CodePushPackage.m
+++ b/CodePushPackage.m
@@ -14,7 +14,7 @@ NSString * const UnzippedFolderName = @"unzipped";
 
 + (NSString *)getCodePushPath
 {
-    return [[CodePush getDocumentsDirectory] stringByAppendingPathComponent:@"CodePush"];
+    return [[CodePush getApplicationSupportDirectory] stringByAppendingPathComponent:@"CodePush"];
 }
 
 + (NSString *)getDownloadFilePath
@@ -290,6 +290,22 @@ NSString * const UnzippedFolderName = @"unzipped";
                 }
                 
                 if (relativeBundlePath) {
+                    NSString *absoluteBundlePath = [newPackageFolderPath stringByAppendingPathComponent:relativeBundlePath];
+                    NSDictionary *bundleFileAttributes = [[[NSFileManager defaultManager] attributesOfItemAtPath:absoluteBundlePath error:&error] mutableCopy];
+                    if (error) {
+                        failCallback(error);
+                        return;
+                    }
+                    
+                    [bundleFileAttributes setValue:[NSDate date] forKey:NSFileModificationDate];
+                    [[NSFileManager defaultManager] setAttributes:bundleFileAttributes
+                                                     ofItemAtPath:absoluteBundlePath
+                                                            error:&error];
+                    if (error) {
+                        failCallback(error);
+                        return;
+                    }
+                    
                     [mutableUpdatePackage setValue:relativeBundlePath forKey:RelativeBundlePathKey];
                 } else {
                     error = [[NSError alloc] initWithDomain:CodePushErrorDomain


### PR DESCRIPTION
This PR:

1. Uses the Libraries/Application Support directory instead of the Documents directory to store files, so as to better conform to [Apple's guidelines](https://developer.apple.com/library/ios/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html#//apple_ref/doc/uid/TP40010672-CH2-SW1)

2. Bumps the modified date in the file metadata of downloaded bundles to the current date at which it was installed. After supporting asset updates, the files in the zip would keep their file metadata, which is not what we want - we want to use the installed date in comparison with the binary's date to determine which version is newer.