### PR TITLE
Fixing comment to reflect API name change

### DIFF
--- a/CodePush.m
+++ b/CodePush.m
@@ -356,7 +356,7 @@ RCT_EXPORT_METHOD(installUpdate:(NSDictionary*)updatePackage
 
 /*
  * This method isn't publicly exposed via the "react-native-code-push"
- * module, and is only used internally to populate the RemotePackage.failedApply property.
+ * module, and is only used internally to populate the RemotePackage.failedInstall property.
  */
 RCT_EXPORT_METHOD(isFailedUpdate:(NSString *)packageHash
                          resolve:(RCTPromiseResolveBlock)resolve


### PR DESCRIPTION
We renamed `failedApply` to `failedInstall` but forgot to update this comment to reflect that change. This fix addresses bug #87.