### PR TITLE
Doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ After installing the plugin and syncing your Android Studio project with Gradle,
     import com.microsoft.codepush.react.CodePush;
     
     // 2. Optional: extend FragmentActivity if you intend to show a dialog prompting users about updates.
-    //    If you do this, make sure to also add `import android.support.v4.app.FragmentActivity` to the file.
+    //    If you do this, make sure to also add "import android.support.v4.app.FragmentActivity" below #1.
     public class MainActivity extends FragmentActivity implements DefaultHardwareBackBtnHandler {
         ...
         

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ After installing the plugin and syncing your Android Studio project with Gradle,
     import com.microsoft.codepush.react.CodePush;
     
     // 2. Optional: extend FragmentActivity if you intend to show a dialog prompting users about updates.
+    //    If you do this, make sure to also add `import android.support.v4.app.FragmentActivity` to the file.
     public class MainActivity extends FragmentActivity implements DefaultHardwareBackBtnHandler {
         ...
         


### PR DESCRIPTION
This PR makes the following changes to the docs:

1. Documents the Java and Obj-C side of our API, including some detail around how bundle resolution occurs

2. Adds a little more detail to the disclaimer about pre 1.4.0 CodePush not being usable on iOS with apps using RN assets

3. Noting the Android doesn't support assets yet

4. Noting the need to import the `FragmentActivity` class as part of the Android setup steps