### PR TITLE
Fix date comparison bug

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -1,6 +1,6 @@
 package com.microsoft.codepush.react;
 
-import com.facebook.react.*;
+import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.NativeModule;

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -50,7 +50,6 @@ public class CodePush {
     private final String PENDING_UPDATE_IS_LOADING_KEY = "isLoading";
     private final String ASSETS_BUNDLE_PREFIX = "assets://";
     private final String CODE_PUSH_PREFERENCES = "CodePush";
-    private final String CODE_PUSH_TAG = "CodePush";
     private final String DOWNLOAD_PROGRESS_EVENT_NAME = "CodePushDownloadProgress";
     private final String RESOURCES_BUNDLE = "resources.arsc";
     private final String REACT_DEV_BUNDLE_CACHE_FILE_NAME = "ReactNativeDevBundle.js";
@@ -136,9 +135,9 @@ public class CodePush {
                 return packageFilePath;
             } else {
                 // The binary version is newer.
-                Log.d(CODE_PUSH_TAG, "Found a package installed via CodePush that was " +
-                        "installed under a different binary version, so the JS bundle packaged " +
-                        "in the binary will be used as the most current package.");
+                CodePushUtils.log("Found a package installed via CodePush that was installed " +
+                        "under a different binary version, so the JS bundle packaged in the " +
+                        "binary will be used as the most current package.");
                 return binaryJsBundleUrl;
             }
         } catch (IOException e) {
@@ -237,8 +236,8 @@ public class CodePush {
             return pendingUpdate;
         } catch (JSONException e) {
             // Should not happen.
-            Log.e(CODE_PUSH_TAG, "Unable to parse pending update metadata " +
-                    pendingUpdateString + " stored in SharedPreferences", e);
+            CodePushUtils.log("Unable to parse pending update metadata " + pendingUpdateString +
+                     " stored in SharedPreferences");
             return null;
         }
     }
@@ -252,7 +251,7 @@ public class CodePush {
                 if (updateIsLoading) {
                     // Pending update was initialized, but notifyApplicationReady was not called.
                     // Therefore, deduce that it is a broken update and rollback.
-                    Log.d(CODE_PUSH_TAG, "Update did not finish loading the last time, rolling back to a previous version.");
+                    CodePushUtils.log("Update did not finish loading the last time, rolling back to a previous version.");
                     rollbackPackage();
                 } else {
                     // Clear the React dev bundle cache so that new updates can be loaded.

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -125,6 +125,7 @@ public class CodePush {
             String packageFilePath = codePushPackage.getCurrentPackageBundlePath();
             if (packageFilePath == null) {
                 // There has not been any downloaded updates.
+                CodePushUtils.logBundleUrl(binaryJsBundleUrl);
                 return binaryJsBundleUrl;
             }
 
@@ -132,12 +133,11 @@ public class CodePush {
             // May throw NumberFormatException.
             Long binaryModifiedDateDuringPackageInstall = Long.parseLong(CodePushUtils.tryGetString(packageMetadata, BINARY_MODIFIED_TIME_KEY));
             if (binaryModifiedDateDuringPackageInstall == binaryResourcesModifiedTime) {
+                CodePushUtils.logBundleUrl(packageFilePath);
                 return packageFilePath;
             } else {
                 // The binary version is newer.
-                CodePushUtils.log("Found a package installed via CodePush that was installed " +
-                        "under a different binary version, so the JS bundle packaged in the " +
-                        "binary will be used as the most current package.");
+                CodePushUtils.logBundleUrl(binaryJsBundleUrl);
                 return binaryJsBundleUrl;
             }
         } catch (IOException e) {
@@ -255,7 +255,6 @@ public class CodePush {
                     rollbackPackage();
                 } else {
                     // Clear the React dev bundle cache so that new updates can be loaded.
-                    if (com.facebook.react.BuildConfig.DEBUG)
                     clearReactDevBundleCache();
                     // Mark that we tried to initialize the new update, so that if it crashes,
                     // we will know that we need to rollback when the app next starts.

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUtils.java
@@ -248,6 +248,11 @@ public class CodePushUtils {
         return jsonArr;
     }
 
+    public static WritableMap convertReadableMapToWritableMap(ReadableMap map) {
+        JSONObject mapJSON = convertReadableToJsonObject(map);
+        return convertJsonObjectToWriteable(mapJSON);
+    }
+
     public static String tryGetString(ReadableMap map, String key) {
         try {
             return map.getString(key);

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUtils.java
@@ -268,4 +268,8 @@ public class CodePushUtils {
     public static void log(String message) {
         Log.d(REACT_NATIVE_LOG_TAG, "[CodePush] " + message);
     }
+
+    public static void logBundleUrl(String path) {
+        log("Loading JS bundle from \"" + path + "\"");
+    }
 }

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUtils.java
@@ -1,5 +1,7 @@
 package com.microsoft.codepush.react;
 
+import android.util.Log;
+
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.NoSuchKeyException;
 import com.facebook.react.bridge.ReadableArray;
@@ -22,6 +24,8 @@ import java.io.PrintWriter;
 import java.util.Iterator;
 
 public class CodePushUtils {
+
+    public static final String REACT_NATIVE_LOG_TAG = "ReactNative";
 
     public static String appendPathComponent(String basePath, String appendPathComponent) {
         return new File(basePath, appendPathComponent).getAbsolutePath();
@@ -259,5 +263,9 @@ public class CodePushUtils {
         } catch (NoSuchKeyException e) {
             return null;
         }
+    }
+
+    public static void log(String message) {
+        Log.d(REACT_NATIVE_LOG_TAG, "[CodePush] " + message);
     }
 }


### PR DESCRIPTION
This fixes an issue with the native bundle somehow taking precedence over a newly CodePush installed bundle, caused by http://stackoverflow.com/questions/27675454/zipentry-gettime-unpredictable-results. It turns out that on certain devices and time zones, the binary date returned could be newer than a CodePush installed bundle. The fix writes the the binary's resources modified time in each installed pacakge metadata, and use that for comparison instead.

iOS resources are not packaged as a zip, so this change does not impact iOS.

Also, added logging when the binary version is used over a CodePush installed package, and whenever a rollback is applied.