### PR TITLE
isPending property on package objects

### DIFF
--- a/CodePush.m
+++ b/CodePush.m
@@ -15,7 +15,7 @@ RCT_EXPORT_MODULE()
 
 static BOOL usingTestFolder = NO;
 
-// These keys represent the names we use to store data in NSUserDdefaults
+// These keys represent the names we use to store data in NSUserDefaults
 static NSString *const FailedUpdatesKey = @"CODE_PUSH_FAILED_UPDATES";
 static NSString *const PendingUpdateKey = @"CODE_PUSH_PENDING_UPDATE";
 
@@ -24,7 +24,7 @@ static NSString *const PendingUpdateKey = @"CODE_PUSH_PENDING_UPDATE";
 static NSString *const PendingUpdateHashKey = @"hash";
 static NSString *const PendingUpdateIsLoadingKey = @"isLoading";
 
-// These keys are used to inspect/augment the metada
+// These keys are used to inspect/augment the metadata
 // that is associated with an update's package.
 static NSString *const PackageHashKey = @"packageHash";
 static NSString *const PackageIsPendingKey = @"isPending";

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -38,7 +38,6 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 public class CodePush {
-
     private boolean didUpdate = false;
     private boolean usingTestFolder = false;
 
@@ -89,13 +88,13 @@ public class CodePush {
         initializeUpdateAfterRestart();
     }
 
-    public ReactPackage getReactPackage() {
-        if (codePushReactPackage == null) {
-            codePushReactPackage = new CodePushReactPackage();
+    private void clearReactDevBundleCache() {
+        File cachedDevBundle = new File(this.applicationContext.getFilesDir(), REACT_DEV_BUNDLE_CACHE_FILE_NAME);
+        if (cachedDevBundle.exists()) {
+            cachedDevBundle.delete();
         }
-        return codePushReactPackage;
     }
-
+    
     public long getBinaryResourcesModifiedTime() {
         ApplicationInfo ai = null;
         ZipFile applicationFile = null;
@@ -148,6 +147,57 @@ public class CodePush {
         }
     }
 
+    private JSONObject getPendingUpdate() {
+        SharedPreferences settings = applicationContext.getSharedPreferences(CODE_PUSH_PREFERENCES, 0);
+        String pendingUpdateString = settings.getString(PENDING_UPDATE_KEY, null);
+        if (pendingUpdateString == null) {
+            return null;
+        }
+
+        try {
+            JSONObject pendingUpdate = new JSONObject(pendingUpdateString);
+            return pendingUpdate;
+        } catch (JSONException e) {
+            // Should not happen.
+            CodePushUtils.log("Unable to parse pending update metadata " + pendingUpdateString +
+                    " stored in SharedPreferences");
+            return null;
+        }
+    }
+
+    public ReactPackage getReactPackage() {
+        if (codePushReactPackage == null) {
+            codePushReactPackage = new CodePushReactPackage();
+        }
+        return codePushReactPackage;
+    }
+    
+    private void initializeUpdateAfterRestart() {
+        JSONObject pendingUpdate = getPendingUpdate();
+        if (pendingUpdate != null) {
+            didUpdate = true;
+            try {
+                boolean updateIsLoading = pendingUpdate.getBoolean(PENDING_UPDATE_IS_LOADING_KEY);
+                if (updateIsLoading) {
+                    // Pending update was initialized, but notifyApplicationReady was not called.
+                    // Therefore, deduce that it is a broken update and rollback.
+                    CodePushUtils.log("Update did not finish loading the last time, rolling back to a previous version.");
+                    rollbackPackage();
+                } else {
+                    // Clear the React dev bundle cache so that new updates can be loaded.
+                    clearReactDevBundleCache();
+                    // Mark that we tried to initialize the new update, so that if it crashes,
+                    // we will know that we need to rollback when the app next starts.
+                    savePendingUpdate(pendingUpdate.getString(PENDING_UPDATE_HASH_KEY),
+                            /* isLoading */true);
+                }
+            } catch (JSONException e) {
+                // Should not happen.
+                throw new CodePushUnknownException("Unable to read pending update metadata stored in SharedPreferences", e);
+            }
+        }
+    }
+    
     private boolean isFailedHash(String packageHash) {
         SharedPreferences settings = applicationContext.getSharedPreferences(CODE_PUSH_PREFERENCES, 0);
         String failedUpdatesString = settings.getString(FAILED_UPDATES_KEY, null);
@@ -165,6 +215,26 @@ public class CodePush {
         }
     }
 
+    private boolean isPendingUpdate(String packageHash) {
+        JSONObject pendingUpdate = getPendingUpdate();
+        
+        try {
+            boolean updateIsPending = pendingUpdate != null &&
+                                      pendingUpdate.getBoolean(PENDING_UPDATE_IS_LOADING_KEY) == false &&
+                                      pendingUpdate.getString(PENDING_UPDATE_HASH_KEY).equals(packageHash);
+                                 
+            return updateIsPending;
+        }
+        catch (JSONException e) {
+            throw new CodePushUnknownException("Unable to read pending update metadata in isPendingUpdate.", e);
+        }
+    }
+
+    private void removePendingUpdate() {
+        SharedPreferences settings = applicationContext.getSharedPreferences(CODE_PUSH_PREFERENCES, 0);
+        settings.edit().remove(PENDING_UPDATE_KEY).commit();
+    }
+    
     private void rollbackPackage() {
         try {
             String packageHash = codePushPackage.getCurrentPackageHash();
@@ -207,11 +277,6 @@ public class CodePush {
         }
     }
 
-    private void removePendingUpdate() {
-        SharedPreferences settings = applicationContext.getSharedPreferences(CODE_PUSH_PREFERENCES, 0);
-        settings.edit().remove(PENDING_UPDATE_KEY).commit();
-    }
-
     private void savePendingUpdate(String packageHash, boolean isLoading) {
         SharedPreferences settings = applicationContext.getSharedPreferences(CODE_PUSH_PREFERENCES, 0);
         JSONObject pendingUpdate = new JSONObject();
@@ -222,57 +287,6 @@ public class CodePush {
         } catch (JSONException e) {
             // Should not happen.
             throw new CodePushUnknownException("Unable to save pending update.", e);
-        }
-    }
-
-    private JSONObject getPendingUpdate() {
-        SharedPreferences settings = applicationContext.getSharedPreferences(CODE_PUSH_PREFERENCES, 0);
-        String pendingUpdateString = settings.getString(PENDING_UPDATE_KEY, null);
-        if (pendingUpdateString == null) {
-            return null;
-        }
-
-        try {
-            JSONObject pendingUpdate = new JSONObject(pendingUpdateString);
-            return pendingUpdate;
-        } catch (JSONException e) {
-            // Should not happen.
-            CodePushUtils.log("Unable to parse pending update metadata " + pendingUpdateString +
-                     " stored in SharedPreferences");
-            return null;
-        }
-    }
-
-    private void initializeUpdateAfterRestart() {
-        JSONObject pendingUpdate = getPendingUpdate();
-        if (pendingUpdate != null) {
-            didUpdate = true;
-            try {
-                boolean updateIsLoading = pendingUpdate.getBoolean(PENDING_UPDATE_IS_LOADING_KEY);
-                if (updateIsLoading) {
-                    // Pending update was initialized, but notifyApplicationReady was not called.
-                    // Therefore, deduce that it is a broken update and rollback.
-                    CodePushUtils.log("Update did not finish loading the last time, rolling back to a previous version.");
-                    rollbackPackage();
-                } else {
-                    // Clear the React dev bundle cache so that new updates can be loaded.
-                    clearReactDevBundleCache();
-                    // Mark that we tried to initialize the new update, so that if it crashes,
-                    // we will know that we need to rollback when the app next starts.
-                    savePendingUpdate(pendingUpdate.getString(PENDING_UPDATE_HASH_KEY),
-                            /* isLoading */true);
-                }
-            } catch (JSONException e) {
-                // Should not happen.
-                throw new CodePushUnknownException("Unable to read pending update metadata stored in SharedPreferences", e);
-            }
-        }
-    }
-
-    private void clearReactDevBundleCache() {
-        File cachedDevBundle = new File(this.applicationContext.getFilesDir(), REACT_DEV_BUNDLE_CACHE_FILE_NAME);
-        if (cachedDevBundle.exists()) {
-            cachedDevBundle.delete();
         }
     }
 
@@ -287,10 +301,80 @@ public class CodePush {
         }
 
         @ReactMethod
+        public void downloadUpdate(final ReadableMap updatePackage, final Promise promise) {
+            AsyncTask asyncTask = new AsyncTask() {
+                @Override
+                protected Void doInBackground(Object... params) {
+                    try {
+                        WritableMap mutableUpdatePackage = CodePushUtils.convertReadableMapToWritableMap(updatePackage);
+                        mutableUpdatePackage.putString(BINARY_MODIFIED_TIME_KEY, "" + getBinaryResourcesModifiedTime());
+                        codePushPackage.downloadPackage(applicationContext, mutableUpdatePackage, new DownloadProgressCallback() {
+                            @Override
+                            public void call(DownloadProgress downloadProgress) {
+                                getReactApplicationContext()
+                                        .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                                        .emit(DOWNLOAD_PROGRESS_EVENT_NAME, downloadProgress.createWritableMap());
+                            }
+                        });
+
+                        WritableMap newPackage = codePushPackage.getPackage(CodePushUtils.tryGetString(updatePackage, codePushPackage.PACKAGE_HASH_KEY));
+                        promise.resolve(newPackage);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                        promise.reject(e.getMessage());
+                    }
+
+                    return null;
+                }
+            };
+
+            asyncTask.execute();
+        }
+
+        @ReactMethod
+        public void getConfiguration(Promise promise) {
+            WritableNativeMap configMap = new WritableNativeMap();
+            configMap.putString("appVersion", appVersion);
+            configMap.putInt("buildVersion", buildVersion);
+            configMap.putString("deploymentKey", deploymentKey);
+            configMap.putString("serverUrl", serverUrl);
+            promise.resolve(configMap);
+        }
+
+        @ReactMethod
+        public void getCurrentPackage(final Promise promise) {
+            AsyncTask asyncTask = new AsyncTask() {
+                @Override
+                protected Void doInBackground(Object... params) {
+                    try {
+                        WritableMap currentPackage = codePushPackage.getCurrentPackage();
+
+                        Boolean isPendingUpdate = false;
+
+                        if (currentPackage.hasKey(codePushPackage.PACKAGE_HASH_KEY)) {
+                            String currentHash = currentPackage.getString(codePushPackage.PACKAGE_HASH_KEY);
+                            isPendingUpdate = CodePush.this.isPendingUpdate(currentHash);
+                        }
+
+                        currentPackage.putBoolean("isPending", isPendingUpdate);
+                        promise.resolve(currentPackage);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                        promise.reject(e.getMessage());
+                    }
+                    
+                    return null;
+                }
+            };
+
+            asyncTask.execute();
+        }
+        
+        @ReactMethod
         public void installUpdate(final ReadableMap updatePackage, final int installMode, final Promise promise) {
             AsyncTask asyncTask = new AsyncTask() {
                 @Override
-                protected Void doInBackground(Object[] params) {
+                protected Void doInBackground(Object... params) {
                     try {
                         codePushPackage.installPackage(updatePackage);
 
@@ -336,67 +420,7 @@ public class CodePush {
 
             asyncTask.execute();
         }
-
-        @ReactMethod
-        public void downloadUpdate(final ReadableMap updatePackage, final Promise promise) {
-            AsyncTask asyncTask = new AsyncTask() {
-                @Override
-                protected Void doInBackground(Object[] params) {
-                    try {
-                        WritableMap mutableUpdatePackage = CodePushUtils.convertReadableMapToWritableMap(updatePackage);
-                        mutableUpdatePackage.putString(BINARY_MODIFIED_TIME_KEY, "" + getBinaryResourcesModifiedTime());
-                        codePushPackage.downloadPackage(applicationContext, mutableUpdatePackage, new DownloadProgressCallback() {
-                            @Override
-                            public void call(DownloadProgress downloadProgress) {
-                                getReactApplicationContext()
-                                        .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                                        .emit(DOWNLOAD_PROGRESS_EVENT_NAME, downloadProgress.createWritableMap());
-                            }
-                        });
-
-                        WritableMap newPackage = codePushPackage.getPackage(CodePushUtils.tryGetString(updatePackage, codePushPackage.PACKAGE_HASH_KEY));
-                        promise.resolve(newPackage);
-                    } catch (IOException e) {
-                        e.printStackTrace();
-                        promise.reject(e.getMessage());
-                    }
-
-                    return null;
-                }
-            };
-
-            asyncTask.execute();
-        }
-
-        @ReactMethod
-        public void getConfiguration(Promise promise) {
-            WritableNativeMap configMap = new WritableNativeMap();
-            configMap.putString("appVersion", appVersion);
-            configMap.putInt("buildVersion", buildVersion);
-            configMap.putString("deploymentKey", deploymentKey);
-            configMap.putString("serverUrl", serverUrl);
-            promise.resolve(configMap);
-        }
-
-        @ReactMethod
-        public void getCurrentPackage(final Promise promise) {
-            AsyncTask asyncTask = new AsyncTask() {
-                @Override
-                protected Void doInBackground(Object[] params) {
-                    try {
-                        promise.resolve(codePushPackage.getCurrentPackage());
-                    } catch (IOException e) {
-                        e.printStackTrace();
-                        promise.reject(e.getMessage());
-                    }
-
-                    return null;
-                }
-            };
-
-            asyncTask.execute();
-        }
-
+        
         @ReactMethod
         public void isFailedUpdate(String packageHash, Promise promise) {
             promise.resolve(isFailedHash(packageHash));
@@ -421,15 +445,15 @@ public class CodePush {
             removePendingUpdate();
             promise.resolve("");
         }
+        
+        @ReactMethod
+        public void restartApp() {
+            loadBundle();
+        }
 
         @ReactMethod
         public void setUsingTestFolder(boolean shouldUseTestFolder) {
             usingTestFolder = shouldUseTestFolder;
-        }
-
-        @ReactMethod
-        public void restartApp() {
-            loadBundle();
         }
 
         @Override
@@ -474,5 +498,4 @@ public class CodePush {
             return new ArrayList();
         }
     }
-
 }

--- a/package-mixins.js
+++ b/package-mixins.js
@@ -3,7 +3,7 @@ import { DeviceEventEmitter } from "react-native";
 // This function is used to augment remote and local
 // package objects with additional functionality/properties
 // beyond what is included in the metadata sent by the server.
-module.exports = function PackageMixinFactory(NativeCodePush) {
+module.exports = (NativeCodePush) => {
   const remote = {
     abortDownload() {
       return NativeCodePush.abortDownload(this);


### PR DESCRIPTION
This PR primarily introduces a new `isPending` property onto the package objects, to allow apps to determine whether the current package (obtained by calling `getCurrentPackage`) represents an installed but not yet applied update. This is a feature we knew we needed to add, but bug #110 help re-prioritize it higher. Moving forward, I would like to improve the way we handle the `isFirstRun` and `failedInstall` properties, so that they don't require extra roundtrips to the native side. I implemented `isPending` this way, so as to not create another roundtrip, but I didn't want to modify more code right now than was necessary.

Additionally, while addressing this item, I made a few additional "cleanup" changes:

1. The `_timer` ivar in the iOS implementation wasn't necessary anymore now that we removed the `rollbackTimeout` parameter from `sync` and `LocalPackage.install`.

2. I re-ordered the methods declared in the `CodePush` class in the Android implementation for better readability. This is the cause of the majority of the changes in `CodePush.java`.

3. I updated the `package-mixins.js` file to use a few ES6 features (e.g. property name shorthands, arrow functions, ES6 module imports, const vs. var), for better readability/semantic value.

4. I addressed bug #107, since it was super simple.