### PR TITLE
Adding conditional check to restartApp method

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -109,6 +109,10 @@ function log(message) {
   console.log(`[CodePush] ${message}`)
 }
 
+function restartApp(onlyIfUpdateIsPending = false) {
+  NativeCodePush.restartApp(onlyIfUpdateIsPending);
+}
+
 var testConfig;
 
 // This function is only used for tests. Replaces the default SDK, configuration and native bridge
@@ -265,7 +269,7 @@ const CodePush = {
   getCurrentPackage,
   log,
   notifyApplicationReady: NativeCodePush.notifyApplicationReady,
-  restartApp: NativeCodePush.restartApp,
+  restartApp,
   setUpTestDependencies,
   sync,
   InstallMode: {

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ If you are using the `sync` function, and doing your update check on app start, 
 codePush.restartApp(onlyIfUpdateIsPending: Boolean = false): void;		
 ```		
 		
-Immediately restarts the app. If there is an update pending, it will be presented to the end user and the "rollback protection" feature will ensure it succeeds. Otherwise, calling this method simply has the same behavior as the end user killing and restarting the process. If a truthy value is passed to the `onlyIfUpdateIsPending` parameter, then the app will only be restarted if there is actually a pending update waiting to be applied. Otherwise, this method call will no-op.
+Immediately restarts the app. If a truthy value is provided to the `onlyIfUpdateIsPending` parameter, then the app will only restart if there is actually a pending update waiting to be applied.
 
 This method is for advanced scenarios, and is primarily useful when the following conditions are true:		
 		

--- a/README.md
+++ b/README.md
@@ -336,12 +336,15 @@ If you are using the `sync` function, and doing your update check on app start, 
 #### codePush.restartApp		
 		
 ```javascript		
-codePush.restartApp(): void;		
+codePush.restartApp(onlyIfUpdateIsPending: Boolean = false): void;		
 ```		
 		
-Immediately restarts the app. If there is an update pending, it will be presented to the end user and the rollback timer (if specified when installing the update) will begin. Otherwise, calling this method simply has the same behavior as the end user killing and restarting the process. This method is for advanced scenarios, and is primarily useful when the following conditions are true:		
+Immediately restarts the app. If there is an update pending, it will be presented to the end user and the rollback timer (if specified when installing the update) will begin. Otherwise, calling this method simply has the same behavior as the end user killing and restarting the process. If a truthy value is passed to the `onlyIfUpdateIsPending` parameter, then the app will only be restarted if there is actually a pending update waiting to be applied. Otherwise, this method call will no-op.
+
+This method is for advanced scenarios, and is primarily useful when the following conditions are true:		
 		
-1. Your app is specifying an install mode value of `ON_NEXT_RESTART` or `ON_NEXT_RESUME` when calling the `sync` or `LocalPackage.install` methods. This has the effect of not applying your update until the app has been restarted (by either the end user or OS)	or resumed, and therefore, the update won't be immediately displayed to the end user 	.
+1. Your app is specifying an install mode value of `ON_NEXT_RESTART` or `ON_NEXT_RESUME` when calling the `sync` or `LocalPackage.install` methods. This has the effect of not applying your update until the app has been restarted (by either the end user or OS)	or resumed, and therefore, the update won't be immediately displayed to the end user.
+
 2. You have an app-specific user event (e.g. the end user navigated back to the app's home route) that allows you to apply the update in an unobtrusive way, and potentially gets the update in front of the end user sooner then waiting until the next restart or resume.		
 
 #### codePush.sync

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ If you are using the `sync` function, and doing your update check on app start, 
 codePush.restartApp(onlyIfUpdateIsPending: Boolean = false): void;		
 ```		
 		
-Immediately restarts the app. If there is an update pending, it will be presented to the end user and the rollback timer (if specified when installing the update) will begin. Otherwise, calling this method simply has the same behavior as the end user killing and restarting the process. If a truthy value is passed to the `onlyIfUpdateIsPending` parameter, then the app will only be restarted if there is actually a pending update waiting to be applied. Otherwise, this method call will no-op.
+Immediately restarts the app. If there is an update pending, it will be presented to the end user and the "rollback protection" feature will ensure it succeeds. Otherwise, calling this method simply has the same behavior as the end user killing and restarting the process. If a truthy value is passed to the `onlyIfUpdateIsPending` parameter, then the app will only be restarted if there is actually a pending update waiting to be applied. Otherwise, this method call will no-op.
 
 This method is for advanced scenarios, and is primarily useful when the following conditions are true:		
 		

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -241,7 +241,7 @@ public class CodePush {
         try {
             boolean updateIsPending = pendingUpdate != null &&
                                       pendingUpdate.getBoolean(PENDING_UPDATE_IS_LOADING_KEY) == false &&
-                                      pendingUpdate.getString(PENDING_UPDATE_HASH_KEY).equals(packageHash);
+                                      (packageHash == null || pendingUpdate.getString(PENDING_UPDATE_HASH_KEY).equals(packageHash));
             return updateIsPending;
         }
         catch (JSONException e) {
@@ -483,8 +483,12 @@ public class CodePush {
         }
         
         @ReactMethod
-        public void restartApp() {
-            loadBundle();
+        public void restartApp(boolean onlyIfUpdateIsPending) {
+            // If this is an unconditional restart request, or there
+            // is current pending update, then reload the app.
+            if (!onlyIfUpdateIsPending || CodePush.this.isPendingUpdate(null)) {
+                loadBundle();
+            }
         }
 
         @ReactMethod


### PR DESCRIPTION
This PR allows the `CodePush.restartApp` method to be called and only result in an app restart if there is actually a pending update to apply. It defaults to `false` to maintain back-compat as well as prevent confusion, since it's potentially unintuitive for the function to no-op unless you expect it to. 

This change makes it easier for an app to call `sync` with a non-immediate `InstallMode`, and then call `restartApp` in a well-known spot (e.g. navigating to the root component). This allows the app to discover/download/install updates silently, but apply them sooner if possible, without forcing superfluous app restarts, and without needing to rely on `getCurrentPackage`/`LocalPackage.isPending` to achieve this experience.

Aside from introducing `LocalPackage.isPending` (which makes a lot of sense semantically), this PR allows the bug issued in #110 to be achieved more simply.