### PR TITLE
Revert to module.exports

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -295,4 +295,4 @@ const CodePush = {
   }
 };
 
-export default CodePush;
+module.exports = CodePush;

--- a/package-mixins.js
+++ b/package-mixins.js
@@ -5,7 +5,7 @@ import { DeviceEventEmitter } from "react-native";
 // This function is used to augment remote and local
 // package objects with additional functionality/properties
 // beyond what is included in the metadata sent by the server.
-export default (NativeCodePush) => {
+module.exports = (NativeCodePush) => {
   const remote = {
     async download(downloadProgressCallback) {
       if (!this.downloadUrl) {

--- a/request-fetch-adapter.js
+++ b/request-fetch-adapter.js
@@ -1,6 +1,6 @@
 "use strict";
 
-export default {
+module.exports = {
   async request(verb, url, body, callback) {
     if (typeof body === "function") {
       callback = body;


### PR DESCRIPTION
This PR is needed because of https://phabricator.babeljs.io/T2212, so that babel@6 users can continue to use `require("react-native-code-push")` instead of having to do `require("react-native-code-push").default`.