### PR TITLE
Only clear update state in release mode

### DIFF
--- a/CodePush.m
+++ b/CodePush.m
@@ -76,7 +76,10 @@ static NSString *const PackageIsPendingKey = @"isPending";
         NSLog(logMessageFormat, packageUrl);
         return packageUrl;
     } else {
+#ifndef DEBUG
         [CodePush clearUpdates];
+#endif
+
         NSLog(logMessageFormat, binaryJsBundleUrl);
         return binaryJsBundleUrl;
     }


### PR DESCRIPTION
If a developer is debugging their app, and is using the `[CodePush bundleURL]` method to set their JS bundle location, then the update state will be continuously cleared whenever they deploy new binaries. This has the effect of prompting them for updates they've already seen, which can quickly become pretty annoying. While we recommend that devs use the packager while debugging, this change simply enables them to choose either the packager or the CodePush API, without being distracted with superfluous updates during development. 

The Android implementation already does this, and therefore, this PR is simply adding parity between the two platforms.