### PR TITLE
Fixing overriding _bundleURL on RN 0.18

### DIFF
--- a/CodePush.m
+++ b/CodePush.m
@@ -1,4 +1,5 @@
 #import "RCTBridgeModule.h"
+#import "RCTBridge+Private.h"
 #import "RCTConvert.h"
 #import "RCTEventDispatcher.h"
 #import "RCTRootView.h"


### PR DESCRIPTION
In RN 0.18 - _bundleURL became a private property. Import the "Private" category here to allow writing to it.