### PR TITLE
RN 0.18.0-rc fix bundleURL Assignment to readonly property

### DIFF
--- a/CodePush.m
+++ b/CodePush.m
@@ -4,6 +4,10 @@
 #import "RCTRootView.h"
 #import "RCTUtils.h"
 
+@interface RCTBridge ()
+@property (nonatomic, strong, readwrite) NSURL *bundleURL;
+@end
+
 #import "CodePush.h"
 
 @implementation CodePush {


### PR DESCRIPTION
RN 0.18.0-rc made bundleURL readonly.  This adds a class extension to expose the bundleURL as readwrite to allow `loadBundle` to work.