### PR TITLE
Report Acquisition Status

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -103,9 +103,9 @@ function getPromisifiedSdk(requestFetchAdapter, config) {
     });
   };
 
-  sdk.reportStatusDeploy = (package, status) => {
+  sdk.reportStatusDeploy = (deployedPackage, status) => {
     return new Promise((resolve, reject) => {
-      module.exports.AcquisitionSdk.prototype.reportStatusDeploy.call(sdk, package, status, (err) => {
+      module.exports.AcquisitionSdk.prototype.reportStatusDeploy.call(sdk, deployedPackage, status, (err) => {
         if (err) {
           reject(err);
         } else {
@@ -115,9 +115,9 @@ function getPromisifiedSdk(requestFetchAdapter, config) {
     });
   };
 
-  sdk.reportStatusDownload = (package, status) => {
+  sdk.reportStatusDownload = (downloadedPackage, status) => {
     return new Promise((resolve, reject) => {
-      module.exports.AcquisitionSdk.prototype.reportStatusDownload.call(sdk, package, (err) => {
+      module.exports.AcquisitionSdk.prototype.reportStatusDownload.call(sdk, downloadedPackage, (err) => {
         if (err) {
           reject(err);
         } else {

--- a/CodePush.js
+++ b/CodePush.js
@@ -115,7 +115,7 @@ function getPromisifiedSdk(requestFetchAdapter, config) {
     });
   };
 
-  sdk.reportStatusDownload = (downloadedPackage, status) => {
+  sdk.reportStatusDownload = (downloadedPackage) => {
     return new Promise((resolve, reject) => {
       module.exports.AcquisitionSdk.prototype.reportStatusDownload.call(sdk, downloadedPackage, (err) => {
         if (err) {

--- a/CodePushConfig.m
+++ b/CodePushConfig.m
@@ -1,4 +1,5 @@
 #import "CodePush.h"
+#import <UIKit/UIKit.h>
 
 @implementation CodePushConfig {
     NSMutableDictionary *_configDictionary;
@@ -10,6 +11,7 @@ static NSString * const AppVersionConfigKey = @"appVersion";
 static NSString * const BuildVdersionConfigKey = @"buildVersion";
 static NSString * const DeploymentKeyConfigKey = @"deploymentKey";
 static NSString * const ServerURLConfigKey = @"serverUrl";
+static NSString * const ClientUniqueIDConfigKey = @"clientUniqueId";
 
 + (instancetype)current
 {
@@ -31,6 +33,14 @@ static NSString * const ServerURLConfigKey = @"serverUrl";
     NSString *deploymentKey = [infoDictionary objectForKey:@"CodePushDeploymentKey"];
     NSString *serverURL = [infoDictionary objectForKey:@"CodePushServerURL"];
     
+    NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
+    NSString* clientUniqueId = [userDefaults stringForKey:ClientUniqueIDConfigKey];
+    if (clientUniqueId == nil) {
+        clientUniqueId = [[[UIDevice currentDevice] identifierForVendor] UUIDString];
+        [userDefaults setObject:clientUniqueId forKey:ClientUniqueIDConfigKey];
+        [userDefaults synchronize];
+    }
+    
     if (!serverURL) {
         serverURL = @"https://codepush.azurewebsites.net/";
     }
@@ -40,6 +50,7 @@ static NSString * const ServerURLConfigKey = @"serverUrl";
                             buildVersion,BuildVdersionConfigKey,
                             serverURL,ServerURLConfigKey,
                             deploymentKey,DeploymentKeyConfigKey,
+                            clientUniqueId,ClientUniqueIDConfigKey,
                             nil];
     
     return self;
@@ -68,6 +79,11 @@ static NSString * const ServerURLConfigKey = @"serverUrl";
 - (NSString *)serverURL
 {
     return [_configDictionary objectForKey:ServerURLConfigKey];
+}
+
+- (NSString *)clientUniqueId
+{
+    return [_configDictionary objectForKey:ClientUniqueIDConfigKey];
 }
 
 - (void)setDeploymentKey:(NSString *)deploymentKey

--- a/CodePushConfig.m
+++ b/CodePushConfig.m
@@ -33,8 +33,8 @@ static NSString * const ServerURLConfigKey = @"serverUrl";
     NSString *deploymentKey = [infoDictionary objectForKey:@"CodePushDeploymentKey"];
     NSString *serverURL = [infoDictionary objectForKey:@"CodePushServerURL"];
     
-    NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
-    NSString* clientUniqueId = [userDefaults stringForKey:ClientUniqueIDConfigKey];
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    NSString *clientUniqueId = [userDefaults stringForKey:ClientUniqueIDConfigKey];
     if (clientUniqueId == nil) {
         clientUniqueId = [[[UIDevice currentDevice] identifierForVendor] UUIDString];
         [userDefaults setObject:clientUniqueId forKey:ClientUniqueIDConfigKey];

--- a/CodePushConfig.m
+++ b/CodePushConfig.m
@@ -34,7 +34,12 @@ static NSString * const ServerURLConfigKey = @"serverUrl";
     NSString *serverURL = [infoDictionary objectForKey:@"CodePushServerURL"];
     
     NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
-    NSString* clientUniqueId = [[[UIDevice currentDevice] identifierForVendor] UUIDString];
+    NSString* clientUniqueId = [userDefaults stringForKey:ClientUniqueIDConfigKey];
+    if (clientUniqueId == nil) {
+        clientUniqueId = [[[UIDevice currentDevice] identifierForVendor] UUIDString];
+        [userDefaults setObject:clientUniqueId forKey:ClientUniqueIDConfigKey];
+        [userDefaults synchronize];
+    }
     
     if (!serverURL) {
         serverURL = @"https://codepush.azurewebsites.net/";

--- a/CodePushConfig.m
+++ b/CodePushConfig.m
@@ -9,9 +9,9 @@ static CodePushConfig *_currentConfig;
 
 static NSString * const AppVersionConfigKey = @"appVersion";
 static NSString * const BuildVdersionConfigKey = @"buildVersion";
+static NSString * const ClientUniqueIDConfigKey = @"clientUniqueId";
 static NSString * const DeploymentKeyConfigKey = @"deploymentKey";
 static NSString * const ServerURLConfigKey = @"serverUrl";
-static NSString * const ClientUniqueIDConfigKey = @"clientUniqueId";
 
 + (instancetype)current
 {
@@ -34,12 +34,7 @@ static NSString * const ClientUniqueIDConfigKey = @"clientUniqueId";
     NSString *serverURL = [infoDictionary objectForKey:@"CodePushServerURL"];
     
     NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
-    NSString* clientUniqueId = [userDefaults stringForKey:ClientUniqueIDConfigKey];
-    if (clientUniqueId == nil) {
-        clientUniqueId = [[[UIDevice currentDevice] identifierForVendor] UUIDString];
-        [userDefaults setObject:clientUniqueId forKey:ClientUniqueIDConfigKey];
-        [userDefaults synchronize];
-    }
+    NSString* clientUniqueId = [[[UIDevice currentDevice] identifierForVendor] UUIDString];
     
     if (!serverURL) {
         serverURL = @"https://codepush.azurewebsites.net/";
@@ -49,8 +44,8 @@ static NSString * const ClientUniqueIDConfigKey = @"clientUniqueId";
                             appVersion,AppVersionConfigKey,
                             buildVersion,BuildVdersionConfigKey,
                             serverURL,ServerURLConfigKey,
-                            deploymentKey,DeploymentKeyConfigKey,
                             clientUniqueId,ClientUniqueIDConfigKey,
+                            deploymentKey,DeploymentKeyConfigKey,
                             nil];
     
     return self;

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/CheckForUpdateTests/testcases/FirstUpdateTest.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/CheckForUpdateTests/testcases/FirstUpdateTest.js
@@ -24,7 +24,7 @@ let FirstUpdateTest = createTestCaseComponent(
   },
   async () => {
     let update = await CodePush.checkForUpdate();
-    assert.equal(JSON.stringify(update), JSON.stringify({ ...serverPackage, ...PackageMixins.remote, failedInstall: false }), "checkForUpdate did not return the update from the server");
+    assert.equal(JSON.stringify(update), JSON.stringify({ ...serverPackage, ...PackageMixins.remote(), failedInstall: false }), "checkForUpdate did not return the update from the server");
   }
 );
 

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/CheckForUpdateTests/testcases/NewUpdateTest.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/CheckForUpdateTests/testcases/NewUpdateTest.js
@@ -23,7 +23,7 @@ let NewUpdateTest = createTestCaseComponent(
   },
   async () => {
     let update = await CodePush.checkForUpdate();
-    assert.equal(JSON.stringify(update), JSON.stringify({ ...serverPackage, ...PackageMixins.remote, failedInstall: false }), "checkForUpdate did not return the update from the server");
+    assert.equal(JSON.stringify(update), JSON.stringify({ ...serverPackage, ...PackageMixins.remote(), failedInstall: false }), "checkForUpdate did not return the update from the server");
   }
 );
 

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/CheckForUpdateTests/testcases/SwitchDeploymentKeyTest.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/CheckForUpdateTests/testcases/SwitchDeploymentKeyTest.js
@@ -25,7 +25,7 @@ let SwitchDeploymentKeyTest = createTestCaseComponent(
   },
   async () => {
     let update = await CodePush.checkForUpdate(deploymentKey);
-    assert.equal(JSON.stringify(update), JSON.stringify({ ...serverPackage, ...PackageMixins.remote, failedInstall: false }), "checkForUpdate did not return the update from the server");
+    assert.equal(JSON.stringify(update), JSON.stringify({ ...serverPackage, ...PackageMixins.remote, failedInstall: false, deploymentKey }), "checkForUpdate did not return the update from the server");
   }
 );
 

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/CheckForUpdateTests/testcases/SwitchDeploymentKeyTest.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/CheckForUpdateTests/testcases/SwitchDeploymentKeyTest.js
@@ -25,7 +25,7 @@ let SwitchDeploymentKeyTest = createTestCaseComponent(
   },
   async () => {
     let update = await CodePush.checkForUpdate(deploymentKey);
-    assert.equal(JSON.stringify(update), JSON.stringify({ ...serverPackage, ...PackageMixins.remote, failedInstall: false, deploymentKey }), "checkForUpdate did not return the update from the server");
+    assert.equal(JSON.stringify(update), JSON.stringify({ ...serverPackage, ...PackageMixins.remote(), failedInstall: false, deploymentKey }), "checkForUpdate did not return the update from the server");
   }
 );
 

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/DownloadProgressTests/testcases/DownloadProgressTest.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/DownloadProgressTests/testcases/DownloadProgressTest.js
@@ -28,7 +28,7 @@ let DownloadProgressTest = createTestCaseComponent(
   "should successfully download all the bytes contained in the test packages",
   () => {
     testPackages.forEach((aPackage, index) => {
-      testPackages[index] = Object.assign(aPackage, PackageMixins.remote);
+      testPackages[index] = Object.assign(aPackage, PackageMixins.remote());
     });
     return Promise.resolve();
   },

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/resources/RollbackTestBundleV1.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/resources/RollbackTestBundleV1.js
@@ -27,7 +27,7 @@ let RollbackTest = React.createClass({
       await NativeCodePush.downloadAndReplaceCurrentBundle("http://localhost:8081/CodePushDemoAppTests/InstallUpdateTests/resources/RollbackTestBundleV1Pass.includeRequire.runModule.bundle?platform=ios&dev=true");
     }
     
-    remotePackage = Object.assign(remotePackage, PackageMixins.remote);
+    remotePackage = Object.assign(remotePackage, PackageMixins.remote());
 
     let localPackage = await remotePackage.download();
     return await localPackage.install(NativeCodePush.codePushInstallModeImmediate);

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/resources/remotePackage.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/resources/remotePackage.js
@@ -1,4 +1,5 @@
 export default {
+  deploymentKey: "myKey123",
   description: "Angry flappy birds",
   appVersion: "1.5.0",
   label: "2.4.0",

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/testcases/InstallModeImmediateTest.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/testcases/InstallModeImmediateTest.js
@@ -21,7 +21,7 @@ let InstallModeImmediateTest = createTestCaseComponent(
       remotePackage.downloadUrl = "http://localhost:8081/CodePushDemoAppTests/InstallUpdateTests/resources/PassInstallModeImmediateTest.includeRequire.runModule.bundle?platform=ios&dev=true"
     }
     
-    remotePackage = Object.assign(remotePackage, PackageMixins.remote);
+    remotePackage = Object.assign(remotePackage, PackageMixins.remote());
   },
   async () => {
     let localPackage = await remotePackage.download();

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/testcases/InstallModeOnNextRestartTest.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/testcases/InstallModeOnNextRestartTest.js
@@ -22,7 +22,7 @@ let InstallModeOnNextRestartTest = createTestCaseComponent(
       remotePackage.downloadUrl = "http://localhost:8081/CodePushDemoAppTests/InstallUpdateTests/resources/PassInstallModeOnNextRestartTest.includeRequire.runModule.bundle?platform=ios&dev=true"
     }
     
-    remotePackage = Object.assign(remotePackage, PackageMixins.remote);
+    remotePackage = Object.assign(remotePackage, PackageMixins.remote());
   },
   async () => {
     let localPackage = await remotePackage.download();

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/testcases/InstallModeOnNextResumeTest.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/testcases/InstallModeOnNextResumeTest.js
@@ -21,7 +21,7 @@ let InstallModeOnNextResumeTest = createTestCaseComponent(
       remotePackage.downloadUrl = "http://localhost:8081/CodePushDemoAppTests/InstallUpdateTests/resources/PassInstallModeOnNextResumeTest.includeRequire.runModule.bundle?platform=ios&dev=true"
     }
     
-    remotePackage = Object.assign(remotePackage, PackageMixins.remote);
+    remotePackage = Object.assign(remotePackage, PackageMixins.remote());
   },
   async () => {
     let localPackage = await remotePackage.download()

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/testcases/IsFailedUpdateTest.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/testcases/IsFailedUpdateTest.js
@@ -21,7 +21,7 @@ let IsFailedUpdateTest = createTestCaseComponent(
       remotePackage.downloadUrl = "http://localhost:8081/CodePushDemoAppTests/InstallUpdateTests/resources/IsFailedUpdateTestBundleV1.includeRequire.runModule.bundle?platform=ios&dev=true"
     }
     
-    remotePackage = Object.assign(remotePackage, PackageMixins.remote);
+    remotePackage = Object.assign(remotePackage, PackageMixins.remote());
   },
   async () => {
     let localPackage = await remotePackage.download();

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/testcases/IsFirstRunTest.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/testcases/IsFirstRunTest.js
@@ -20,7 +20,7 @@ let IsFirstRunTest = createTestCaseComponent(
       remotePackage.downloadUrl = "http://localhost:8081/CodePushDemoAppTests/InstallUpdateTests/resources/CheckIsFirstRunAndPassTest.includeRequire.runModule.bundle?platform=ios&dev=true"
     }
     
-    remotePackage = Object.assign(remotePackage, PackageMixins.remote);
+    remotePackage = Object.assign(remotePackage, PackageMixins.remote());
   },
   async () => {
     let localPackage = await remotePackage.download();

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/testcases/IsPendingTest.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/testcases/IsPendingTest.js
@@ -21,7 +21,7 @@ let IsPendingTest = createTestCaseComponent(
       remotePackage.downloadUrl = "http://localhost:8081/CodePushDemoAppTests/InstallUpdateTests/resources/CheckIsFirstRunAndPassTest.includeRequire.runModule.bundle?platform=ios&dev=true"
     }
     
-    remotePackage = Object.assign(remotePackage, PackageMixins.remote);
+    remotePackage = Object.assign(remotePackage, PackageMixins.remote());
   },
   async () => {
     let localPackage = await remotePackage.download();

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/testcases/NotifyApplicationReadyTest.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/testcases/NotifyApplicationReadyTest.js
@@ -21,7 +21,7 @@ let NotifyApplicationReadyTest = createTestCaseComponent(
       remotePackage.downloadUrl = "http://localhost:8081/CodePushDemoAppTests/InstallUpdateTests/resources/NotifyApplicationReadyAndRestart.includeRequire.runModule.bundle?platform=ios&dev=true"
     }
     
-    remotePackage = Object.assign(remotePackage, PackageMixins.remote);
+    remotePackage = Object.assign(remotePackage, PackageMixins.remote());
   },
   async () => {
     let localPackage = await remotePackage.download()

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/testcases/RollbackTest.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/testcases/RollbackTest.js
@@ -21,7 +21,7 @@ let RollbackTest = createTestCaseComponent(
       remotePackage.downloadUrl = "http://localhost:8081/CodePushDemoAppTests/InstallUpdateTests/resources/RollbackTestBundleV1.includeRequire.runModule.bundle?platform=ios&dev=true"
     }
     
-    remotePackage = Object.assign(remotePackage, PackageMixins.remote);
+    remotePackage = Object.assign(remotePackage, PackageMixins.remote());
   },
   async () => {
     let localPackage = await remotePackage.download()

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/utils/mockAcquisitionSdk.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/utils/mockAcquisitionSdk.js
@@ -13,6 +13,11 @@ function createMockAcquisitionSdk(serverPackage, localPackage, expectedDeploymen
     callback(/*err:*/ null, serverPackage);
   };
   
+  AcquisitionManager.prototype.reportStatus = (status, message, callback) => {
+    // No-op and return success.
+    callback(null, null);
+  };
+  
   return AcquisitionManager;
 }
 

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/utils/mockAcquisitionSdk.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/utils/mockAcquisitionSdk.js
@@ -13,7 +13,12 @@ function createMockAcquisitionSdk(serverPackage, localPackage, expectedDeploymen
     callback(/*err:*/ null, serverPackage);
   };
   
-  AcquisitionManager.prototype.reportStatus = (status, message, callback) => {
+  AcquisitionManager.prototype.reportStatusDeploy = (package, status, callback) => {
+    // No-op and return success.
+    callback(null, null);
+  };
+  
+  AcquisitionManager.prototype.reportStatusDownload = (package, callback) => {
     // No-op and return success.
     callback(null, null);
   };

--- a/Examples/CodePushDemoApp/crossplatformdemo.js
+++ b/Examples/CodePushDemoApp/crossplatformdemo.js
@@ -81,6 +81,10 @@ let CodePushDemoApp = React.createClass({
     }
   },
   
+  componentDidMount() {
+      CodePush.notifyApplicationReady();
+  },
+  
   getInitialState() {
     return { };
   },

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -23,7 +23,9 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.AsyncTask;
+import android.provider.Settings;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -43,17 +45,24 @@ public class CodePush {
 
     private String assetsBundleFileName;
 
+    private final String ASSETS_BUNDLE_PREFIX = "assets://";
+    private final String BINARY_MODIFIED_TIME_KEY = "binaryModifiedTime";
+    private final String CODE_PUSH_PREFERENCES = "CodePush";
+    private final String DEPLOYMENT_FAILED_STATUS = "DeploymentFailed";
+    private final String DEPLOYMENT_KEY_KEY = "deploymentKey";
+    private final String DEPLOYMENT_SUCCEEDED_STATUS = "DeploymentSucceeded";
+    private final String DOWNLOAD_PROGRESS_EVENT_NAME = "CodePushDownloadProgress";
     private final String FAILED_UPDATES_KEY = "CODE_PUSH_FAILED_UPDATES";
-    private final String PENDING_UPDATE_KEY = "CODE_PUSH_PENDING_UPDATE";
+    private final String LABEL_KEY = "label";
+    private final String PACKAGE_HASH_KEY = "packageHash";
     private final String PENDING_UPDATE_HASH_KEY = "hash";
     private final String PENDING_UPDATE_IS_LOADING_KEY = "isLoading";
-    private final String ASSETS_BUNDLE_PREFIX = "assets://";
-    private final String CODE_PUSH_PREFERENCES = "CodePush";
-    private final String DOWNLOAD_PROGRESS_EVENT_NAME = "CodePushDownloadProgress";
+    private final String PENDING_UPDATE_KEY = "CODE_PUSH_PENDING_UPDATE";
     private final String RESOURCES_BUNDLE = "resources.arsc";
+    private final String STATUS_REPORTS_KEY = "CODE_PUSH_STATUS_REPORTS";
+
     // This needs to be kept in sync with https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManager.java#L78
     private final String REACT_DEV_BUNDLE_CACHE_FILE_NAME = "ReactNativeDevBundle.js";
-    private final String BINARY_MODIFIED_TIME_KEY = "binaryModifiedTime";
 
     private CodePushPackage codePushPackage;
     private CodePushReactPackage codePushReactPackage;
@@ -145,7 +154,7 @@ public class CodePush {
             String pacakgeAppVersion = CodePushUtils.tryGetString(packageMetadata, "appVersion");
             if (binaryModifiedDateDuringPackageInstall != null &&
                     binaryModifiedDateDuringPackageInstall == binaryResourcesModifiedTime &&
-                    this.appVersion.equals(pacakgeAppVersion)) {
+                    (this.isUsingTestConfiguration() || this.appVersion.equals(pacakgeAppVersion))) {
                 CodePushUtils.logBundleUrl(packageFilePath);
                 return packageFilePath;
             } else {
@@ -162,6 +171,36 @@ public class CodePush {
             throw new CodePushUnknownException("Error in getting current package bundle path", e);
         } catch (NumberFormatException e) {
             throw new CodePushUnknownException("Error in reading binary modified date from package metadata", e);
+        }
+    }
+
+    private String getPackageStatusReportIdentifier(WritableMap updatePackage) {
+        // Because deploymentKeys can be dynamically switched, we use a
+        // combination of the deploymentKey and label as the packageIdentifier.
+        String deploymentKey = CodePushUtils.tryGetString(updatePackage, DEPLOYMENT_KEY_KEY);
+        String label = CodePushUtils.tryGetString(updatePackage, LABEL_KEY);
+        if (deploymentKey != null && label != null) {
+            return deploymentKey + ":" + label;
+        } else {
+            return null;
+        }
+    }
+
+    private JSONArray getFailedUpdates() {
+        SharedPreferences settings = applicationContext.getSharedPreferences(CODE_PUSH_PREFERENCES, 0);
+        String failedUpdatesString = settings.getString(FAILED_UPDATES_KEY, null);
+        if (failedUpdatesString == null) {
+            return new JSONArray();
+        }
+
+        try {
+            JSONArray failedUpdates = new JSONArray(failedUpdatesString);
+            return failedUpdates;
+        } catch (JSONException e) {
+            // Unrecognized data format, clear and replace with expected format.
+            JSONArray emptyArray = new JSONArray();
+            settings.edit().putString(FAILED_UPDATES_KEY, emptyArray.toString()).commit();
+            return emptyArray;
         }
     }
 
@@ -217,22 +256,39 @@ public class CodePush {
             }
         }
     }
-    
-    private boolean isFailedHash(String packageHash) {
+
+    private boolean isDeploymentStatusNotYetReported(String appVersionOrPackageIdentifier) {
         SharedPreferences settings = applicationContext.getSharedPreferences(CODE_PUSH_PREFERENCES, 0);
-        String failedUpdatesString = settings.getString(FAILED_UPDATES_KEY, null);
-        if (failedUpdatesString == null) {
-            return false;
+        String sentStatusReportsString = settings.getString(STATUS_REPORTS_KEY, null);
+        if (sentStatusReportsString == null) {
+            return true;
+        } else {
+            try {
+                JSONObject sentStatusReports = new JSONObject(sentStatusReportsString);
+                return !sentStatusReports.has(appVersionOrPackageIdentifier);
+            } catch (JSONException e) {
+                throw new CodePushUnknownException("Unable to parse sent status reports information " +
+                        sentStatusReportsString + " stored in SharedPreferences.", e);
+            }
+        }
+    }
+
+    private boolean isFailedHash(String packageHash) {
+        JSONArray failedUpdates = getFailedUpdates();
+        for (int i = 0; i < failedUpdates.length(); i++) {
+            JSONObject failedPackage = null;
+            try {
+                failedPackage = failedUpdates.getJSONObject(i);
+                String failedPackageHash = failedPackage.getString(PACKAGE_HASH_KEY);
+                if (packageHash.equals(failedPackageHash)) {
+                    return true;
+                }
+            } catch (JSONException e) {
+                throw new CodePushUnknownException("Unable to read failedUpdates data stored in SharedPreferences.", e);
+            }
         }
 
-        try {
-            JSONObject failedUpdates = new JSONObject(failedUpdatesString);
-            return failedUpdates.has(packageHash);
-        } catch (JSONException e) {
-            // Should not happen.
-            throw new CodePushUnknownException("Unable to parse failed updates information " +
-                    failedUpdatesString + " stored in SharedPreferences", e);
-        }
+        return false;
     }
 
     private boolean isPendingUpdate(String packageHash) {
@@ -249,6 +305,24 @@ public class CodePush {
         }
     }
 
+    private void recordDeploymentStatusReported(String appVersionOrPackageIdentifier, String status) {
+        SharedPreferences settings = applicationContext.getSharedPreferences(CODE_PUSH_PREFERENCES, 0);
+        String sentStatusReportsString = settings.getString(STATUS_REPORTS_KEY, null);
+        JSONObject sentStatusReports;
+        try {
+            if (sentStatusReportsString == null) {
+                sentStatusReports = new JSONObject();
+            } else {
+                sentStatusReports = new JSONObject(sentStatusReportsString);
+            }
+
+            sentStatusReports.put(appVersionOrPackageIdentifier, status);
+            settings.edit().putString(STATUS_REPORTS_KEY, sentStatusReports.toString()).commit();
+        } catch (JSONException e) {
+            throw new CodePushUnknownException("Unable to save new entry in SharedPreferences under " + STATUS_REPORTS_KEY + ".", e);
+        }
+    }
+
     private void removeFailedUpdates() {
         SharedPreferences settings = applicationContext.getSharedPreferences(CODE_PUSH_PREFERENCES, 0);
         settings.edit().remove(FAILED_UPDATES_KEY).commit();
@@ -261,8 +335,8 @@ public class CodePush {
     
     private void rollbackPackage() {
         try {
-            String packageHash = codePushPackage.getCurrentPackageHash();
-            saveFailedUpdate(packageHash);
+            WritableMap failedPackage = codePushPackage.getCurrentPackage();
+            saveFailedUpdate(failedPackage);
         } catch (IOException e) {
             throw new CodePushUnknownException("Attempted a rollback without having a current downloaded package", e);
         }
@@ -276,29 +350,25 @@ public class CodePush {
         removePendingUpdate();
     }
 
-    private void saveFailedUpdate(String packageHash) {
+    private void saveFailedUpdate(WritableMap failedPackage) {
         SharedPreferences settings = applicationContext.getSharedPreferences(CODE_PUSH_PREFERENCES, 0);
         String failedUpdatesString = settings.getString(FAILED_UPDATES_KEY, null);
-        JSONObject failedUpdates;
+        JSONArray failedUpdates;
         if (failedUpdatesString == null) {
-            failedUpdates = new JSONObject();
+            failedUpdates = new JSONArray();
         } else {
             try {
-                failedUpdates = new JSONObject(failedUpdatesString);
+                failedUpdates = new JSONArray(failedUpdatesString);
             } catch (JSONException e) {
                 // Should not happen.
                 throw new CodePushMalformedDataException("Unable to parse failed updates information " +
                         failedUpdatesString + " stored in SharedPreferences", e);
             }
         }
-        try {
-            failedUpdates.put(packageHash, true);
-            settings.edit().putString(FAILED_UPDATES_KEY, failedUpdates.toString()).commit();
-        } catch (JSONException e) {
-            // Should not happen unless the packageHash is null.
-            throw new CodePushUnknownException("Unable to save package hash " +
-                    packageHash + " as a failed update", e);
-        }
+
+        JSONObject failedPackageJSON = CodePushUtils.convertReadableToJsonObject(failedPackage);
+        failedUpdates.put(failedPackageJSON);
+        settings.edit().putString(FAILED_UPDATES_KEY, failedUpdates.toString()).commit();
     }
 
     private void savePendingUpdate(String packageHash, boolean isLoading) {
@@ -377,6 +447,9 @@ public class CodePush {
             configMap.putInt("buildVersion", buildVersion);
             configMap.putString("deploymentKey", deploymentKey);
             configMap.putString("serverUrl", serverUrl);
+            configMap.putString("clientUniqueId",
+                    Settings.Secure.getString(mainActivity.getContentResolver(),
+                            android.provider.Settings.Secure.ANDROID_ID));
             promise.resolve(configMap);
         }
 
@@ -408,7 +481,60 @@ public class CodePush {
 
             asyncTask.execute();
         }
-        
+
+        @ReactMethod
+        public void getNewStatusReport(Promise promise) {
+            // Check if the current appVersion has been reported.
+            if (isDeploymentStatusNotYetReported(appVersion)) {
+                recordDeploymentStatusReported(appVersion, DEPLOYMENT_SUCCEEDED_STATUS);
+                WritableNativeMap reportMap = new WritableNativeMap();
+                reportMap.putString("appVersion", appVersion);
+                promise.resolve(reportMap);
+                return;
+            }
+
+            // Check if there was a rollback that was not yet reported
+            JSONArray failedUpdates = getFailedUpdates();
+            if (failedUpdates != null && failedUpdates.length() > 0) {
+                try {
+                    JSONObject lastFailedPackageJSON = failedUpdates.getJSONObject(failedUpdates.length() - 1);
+                    WritableMap lastFailedPackage = CodePushUtils.convertJsonObjectToWriteable(lastFailedPackageJSON);
+                    String lastFailedPackageIdentifier = getPackageStatusReportIdentifier(lastFailedPackage);
+                    if (lastFailedPackage != null && isDeploymentStatusNotYetReported(lastFailedPackageIdentifier)) {
+                        recordDeploymentStatusReported(lastFailedPackageIdentifier, DEPLOYMENT_FAILED_STATUS);
+                        WritableNativeMap reportMap = new WritableNativeMap();
+                        reportMap.putMap("package", lastFailedPackage);
+                        reportMap.putString("status", DEPLOYMENT_FAILED_STATUS);
+                        promise.resolve(reportMap);
+                        return;
+                    }
+                } catch (JSONException e) {
+                    throw new CodePushUnknownException("Unable to read failed updates information stored in SharedPreferences.", e);
+                }
+            }
+
+            // Check if the current CodePush package has been reported
+            try {
+                WritableMap currentPackage = codePushPackage.getCurrentPackage();
+                if (currentPackage != null) {
+                    String currentPackageIdentifier = getPackageStatusReportIdentifier(currentPackage);
+                    if (currentPackageIdentifier != null && isDeploymentStatusNotYetReported(currentPackageIdentifier)) {
+                        recordDeploymentStatusReported(currentPackageIdentifier, DEPLOYMENT_SUCCEEDED_STATUS);
+                        WritableNativeMap reportMap = new WritableNativeMap();
+                        reportMap.putMap("package", currentPackage);
+                        reportMap.putString("status", DEPLOYMENT_SUCCEEDED_STATUS);
+                        promise.resolve(reportMap);
+                        return;
+                    }
+                }
+            } catch (IOException e) {
+                // No current package, resolve no report.
+                promise.resolve("");
+            }
+
+            promise.resolve("");
+        }
+
         @ReactMethod
         public void installUpdate(final ReadableMap updatePackage, final int installMode, final Promise promise) {
             AsyncTask asyncTask = new AsyncTask() {

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -491,17 +491,15 @@ public class CodePush {
                         return;
                     }
                 }
-            } else {
-                if (isRunningBinaryVersion) {
-                    // Check if the current appVersion has been reported.
-                    String binaryIdentifier = "" + getBinaryResourcesModifiedTime();
-                    if (isDeploymentStatusNotYetReported(binaryIdentifier)) {
-                        recordDeploymentStatusReported(binaryIdentifier);
-                        WritableNativeMap reportMap = new WritableNativeMap();
-                        reportMap.putString("appVersion", appVersion);
-                        promise.resolve(reportMap);
-                        return;
-                    }
+            } else if (isRunningBinaryVersion) {
+                // Check if the current appVersion has been reported.
+                String binaryIdentifier = "" + getBinaryResourcesModifiedTime();
+                if (isDeploymentStatusNotYetReported(binaryIdentifier)) {
+                    recordDeploymentStatusReported(binaryIdentifier);
+                    WritableNativeMap reportMap = new WritableNativeMap();
+                    reportMap.putString("appVersion", appVersion);
+                    promise.resolve(reportMap);
+                    return;
                 }
             }
 

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -40,8 +40,9 @@ import java.util.zip.ZipFile;
 
 public class CodePush {
 
-    private static boolean testConfigurationFlag = false;
     private static boolean didRollback = false;
+    private static boolean isRunningBinaryVersion = false;
+    private static boolean testConfigurationFlag = false;
 
     private boolean didUpdate = false;
 
@@ -143,6 +144,7 @@ public class CodePush {
             if (packageFilePath == null) {
                 // There has not been any downloaded updates.
                 CodePushUtils.logBundleUrl(binaryJsBundleUrl);
+                isRunningBinaryVersion = true;
                 return binaryJsBundleUrl;
             }
 
@@ -158,6 +160,7 @@ public class CodePush {
                     binaryModifiedDateDuringPackageInstall == binaryResourcesModifiedTime &&
                     (this.isUsingTestConfiguration() || this.appVersion.equals(packageAppVersion))) {
                 CodePushUtils.logBundleUrl(packageFilePath);
+                isRunningBinaryVersion = false;
                 return packageFilePath;
             } else {
                 // The binary version is newer.
@@ -167,6 +170,7 @@ public class CodePush {
                 }
 
                 CodePushUtils.logBundleUrl(binaryJsBundleUrl);
+                isRunningBinaryVersion = true;
                 return binaryJsBundleUrl;
             }
         } catch (NumberFormatException e) {
@@ -488,9 +492,7 @@ public class CodePush {
                     }
                 }
             } else {
-                String currentPackageHash = null;
-                currentPackageHash = codePushPackage.getCurrentPackageHash();
-                if (currentPackageHash == null) {
+                if (isRunningBinaryVersion) {
                     // Check if the current appVersion has been reported.
                     String binaryIdentifier = "" + getBinaryResourcesModifiedTime();
                     if (isDeploymentStatusNotYetReported(binaryIdentifier)) {

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushPackage.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushPackage.java
@@ -50,20 +50,28 @@ public class CodePushPackage {
         return CodePushUtils.appendPathComponent(getCodePushPath(), STATUS_FILE);
     }
 
-    public WritableMap getCurrentPackageInfo() throws IOException {
+    public WritableMap getCurrentPackageInfo() {
         String statusFilePath = getStatusFilePath();
         if (!CodePushUtils.fileAtPathExists(statusFilePath)) {
             return new WritableNativeMap();
         }
 
-        return CodePushUtils.getWritableMapFromFile(statusFilePath);
+        try {
+            return CodePushUtils.getWritableMapFromFile(statusFilePath);
+        } catch (IOException e) {
+            throw new CodePushUnknownException("Error getting current package info" , e);
+        }
     }
 
-    public void updateCurrentPackageInfo(ReadableMap packageInfo) throws IOException {
-        CodePushUtils.writeReadableMapToFile(packageInfo, getStatusFilePath());
+    public void updateCurrentPackageInfo(ReadableMap packageInfo) {
+        try {
+            CodePushUtils.writeReadableMapToFile(packageInfo, getStatusFilePath());
+        } catch (IOException e) {
+            throw new CodePushUnknownException("Error updating current package info" , e);
+        }
     }
 
-    public String getCurrentPackageFolderPath() throws IOException {
+    public String getCurrentPackageFolderPath() {
         WritableMap info = getCurrentPackageInfo();
         String packageHash = CodePushUtils.tryGetString(info, CURRENT_PACKAGE_KEY);
         if (packageHash == null) {
@@ -73,7 +81,7 @@ public class CodePushPackage {
         return getPackageFolderPath(packageHash);
     }
 
-    public String getCurrentPackageBundlePath() throws IOException {
+    public String getCurrentPackageBundlePath() {
         String packageFolder = getCurrentPackageFolderPath();
         if (packageFolder == null) {
             return null;
@@ -86,17 +94,17 @@ public class CodePushPackage {
         return CodePushUtils.appendPathComponent(getCodePushPath(), packageHash);
     }
 
-    public String getCurrentPackageHash() throws IOException {
+    public String getCurrentPackageHash() {
         WritableMap info = getCurrentPackageInfo();
         return CodePushUtils.tryGetString(info, CURRENT_PACKAGE_KEY);
     }
 
-    public String getPreviousPackageHash() throws IOException {
+    public String getPreviousPackageHash() {
         WritableMap info = getCurrentPackageInfo();
         return CodePushUtils.tryGetString(info, PREVIOUS_PACKAGE_KEY);
     }
 
-    public WritableMap getCurrentPackage() throws IOException {
+    public WritableMap getCurrentPackage() {
         String folderPath = getCurrentPackageFolderPath();
         if (folderPath == null) {
             return new WritableNativeMap();
@@ -111,7 +119,7 @@ public class CodePushPackage {
         }
     }
 
-    public WritableMap getPackage(String packageHash) throws IOException {
+    public WritableMap getPackage(String packageHash) {
         String folderPath = getPackageFolderPath(packageHash);
         String packageFilePath = CodePushUtils.appendPathComponent(folderPath, PACKAGE_FILE_NAME);
         try {
@@ -185,7 +193,7 @@ public class CodePushPackage {
         updateCurrentPackageInfo(info);
     }
 
-    public void rollbackPackage() throws IOException {
+    public void rollbackPackage() {
         WritableMap info = getCurrentPackageInfo();
         String currentPackageFolderPath = getCurrentPackageFolderPath();
         CodePushUtils.deleteDirectoryAtPath(currentPackageFolderPath);

--- a/package-mixins.js
+++ b/package-mixins.js
@@ -1,35 +1,39 @@
+import { AcquisitionManager as Sdk } from "code-push/script/acquisition-sdk";
 import { DeviceEventEmitter } from "react-native";
 
 // This function is used to augment remote and local
 // package objects with additional functionality/properties
 // beyond what is included in the metadata sent by the server.
 module.exports = (NativeCodePush) => {
-  const remote = {
-    async download(downloadProgressCallback) {
-      if (!this.downloadUrl) {
-        throw new Error("Cannot download an update without a download url");
-      }
+  const remote = (reportStatusDownload) => {
+    return {
+      async download(downloadProgressCallback) {
+        if (!this.downloadUrl) {
+          throw new Error("Cannot download an update without a download url");
+        }
 
-      let downloadProgressSubscription;
-      if (downloadProgressCallback) {
-        // Use event subscription to obtain download progress.   
-        downloadProgressSubscription = DeviceEventEmitter.addListener(
-          "CodePushDownloadProgress",
-          downloadProgressCallback
-        );
-      }
+        let downloadProgressSubscription;
+        if (downloadProgressCallback) {
+          // Use event subscription to obtain download progress.   
+          downloadProgressSubscription = DeviceEventEmitter.addListener(
+            "CodePushDownloadProgress",
+            downloadProgressCallback
+          );
+        }
       
-      // Use the downloaded package info. Native code will save the package info
-      // so that the client knows what the current package version is.
-      try {  
-        const downloadedPackage = await NativeCodePush.downloadUpdate(this);
-        return { ...downloadedPackage, ...local };
-      } finally {
-        downloadProgressSubscription && downloadProgressSubscription.remove();
-      }
-    },
+        // Use the downloaded package info. Native code will save the package info
+        // so that the client knows what the current package version is.
+        try {  
+          const downloadedPackage = await NativeCodePush.downloadUpdate(this);
+          reportStatusDownload && reportStatusDownload(this);
+          return { ...downloadedPackage, ...local };
+        } finally {
+          downloadProgressSubscription && downloadProgressSubscription.remove();
+        }
+      },
     
-    isPending: false // A remote package could never be in a pending state
+      isPending: false // A remote package could never be in a pending state
+    };
   };
 
   const local = {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/Microsoft/react-native-code-push"
   },
   "dependencies": {
-    "code-push": "^1.1.1-beta",
+    "code-push": "1.5.0-beta",
     "semver": "^5.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/Microsoft/react-native-code-push"
   },
   "dependencies": {
-    "code-push": "1.5.0-beta",
+    "code-push": "1.5.1-beta",
     "semver": "^5.1.0"
   },
   "devDependencies": {

--- a/request-fetch-adapter.js
+++ b/request-fetch-adapter.js
@@ -16,7 +16,7 @@ module.exports = {
 
     try {
       const response = await fetch(url, {
-        method: verb,
+        method: getHttpMethodName(verb),
         headers: headers,
         body: body
       });
@@ -29,3 +29,17 @@ module.exports = {
     }
   }
 };
+
+function getHttpMethodName(verb) {
+  return [
+    "GET",
+    "HEAD",
+    "POST",
+    "PUT",
+    "DELETE",
+    "TRACE",
+    "OPTIONS",
+    "CONNECT",
+    "PATCH"
+  ][verb];
+}

--- a/request-fetch-adapter.js
+++ b/request-fetch-adapter.js
@@ -1,8 +1,8 @@
 module.exports = {
-  async request(verb, url, body, callback) {
-    if (typeof body === "function") {
-      callback = body;
-      body = null;
+  async request(verb, url, requestBody, callback) {
+    if (typeof requestBody === "function") {
+      callback = requestBody;
+      requestBody = null;
     }
 
     var headers = {
@@ -10,15 +10,15 @@ module.exports = {
       "Content-Type": "application/json"
     };
 
-    if (body && typeof body === "object") {
-      body = JSON.stringify(body);
+    if (requestBody && typeof requestBody === "object") {
+      requestBody = JSON.stringify(requestBody);
     }
 
     try {
       const response = await fetch(url, {
         method: getHttpMethodName(verb),
         headers: headers,
-        body: body
+        body: requestBody
       });
         
       const statusCode = response.status;

--- a/request-fetch-adapter.js
+++ b/request-fetch-adapter.js
@@ -31,6 +31,8 @@ module.exports = {
 };
 
 function getHttpMethodName(verb) {
+  // Note: This should stay in sync with the enum definition in
+  // https://github.com/Microsoft/code-push/blob/master/sdk/script/acquisition-sdk.ts#L6
   return [
     "GET",
     "HEAD",


### PR DESCRIPTION
Goal: To allow client devices to report the status of their update acquisition (whether an update is successfully installed or rolled back, which update is the client running). The eventual goal is to allow developers to see this data from the CLI so that they can better manage their updates.

This PR: Configures the plugin to send a status report update everytime CodePush.notifiyApplicationReady is called. Keep track of the history of all status reports sent so that the same report will not be sent twice (even though the server knows how to handle repeat reports).

Note that this takes a dependency on code-push 1.5.0-beta, which has not been published to NPM yet. Therefore a release will be submitted for this change after the code-push SDK changes have also been release.