### PR TITLE
[CodePush setDeploymentKey] method

### DIFF
--- a/CodePush.h
+++ b/CodePush.h
@@ -12,7 +12,7 @@
  * This method assumes that your JS bundle is named "main.jsbundle"
  * and therefore, if it isn't, you should use either the bundleURLForResource:
  * or bundleURLForResource:withExtension: methods to override that behavior.
-*/
+ */
 + (NSURL *)bundleURL;
 
 + (NSURL *)bundleURLForResource:(NSString *)resourceName;
@@ -21,6 +21,13 @@
                   withExtension:(NSString *)resourceExtension;
 
 + (NSString *)getApplicationSupportDirectory;
+
+/*
+ * This methods allows dynamically setting the app's
+ * deployment key, in addition to setting it via
+ * the Info.plist file's CodePushDeploymentKey setting.
+ */
++ (void)setDeploymentKey:(NSString *)deploymentKey;
 
 // The below methods are only used during tests.
 + (BOOL)isUsingTestConfiguration;
@@ -62,7 +69,7 @@ failCallback:(void (^)(NSError *err))failCallback;
 @interface CodePushPackage : NSObject
 
 + (void)installPackage:(NSDictionary *)updatePackage
-               error:(NSError **)error;
+                 error:(NSError **)error;
 
 + (NSDictionary *)getCurrentPackage:(NSError **)error;
 + (NSString *)getCurrentPackageFolderPath:(NSError **)error;

--- a/CodePush.m
+++ b/CodePush.m
@@ -403,9 +403,9 @@ RCT_EXPORT_METHOD(downloadUpdate:(NSDictionary*)updatePackage
             [self.bridge.eventDispatcher
                 sendDeviceEventWithName:@"CodePushDownloadProgress"
                 body:@{
-                    @"totalBytes":[NSNumber numberWithLongLong:expectedContentLength],
-                    @"receivedBytes":[NSNumber numberWithLongLong:receivedContentLength]
-                    }];
+                        @"totalBytes":[NSNumber numberWithLongLong:expectedContentLength],
+                        @"receivedBytes":[NSNumber numberWithLongLong:receivedContentLength]
+                      }];
         }
         // The download completed
         doneCallback:^{
@@ -516,9 +516,9 @@ RCT_EXPORT_METHOD(isFirstRun:(NSString *)packageHash
 {
     NSError *error;
     BOOL isFirstRun = _isFirstRunAfterUpdate
-    && nil != packageHash
-    && [packageHash length] > 0
-    && [packageHash isEqualToString:[CodePushPackage getCurrentPackageHash:&error]];
+                        && nil != packageHash
+                        && [packageHash length] > 0
+                        && [packageHash isEqualToString:[CodePushPackage getCurrentPackageHash:&error]];
     
     resolve(@(isFirstRun));
 }

--- a/CodePush.m
+++ b/CodePush.m
@@ -397,31 +397,31 @@ RCT_EXPORT_METHOD(downloadUpdate:(NSDictionary*)updatePackage
                         rejecter:(RCTPromiseRejectBlock)reject)
 {
     [CodePushPackage downloadPackage:updatePackage
-     // The download is progressing forward
-                    progressCallback:^(long long expectedContentLength, long long receivedContentLength) {
-                        // Notify the script-side about the progress
-                        [self.bridge.eventDispatcher
-                         sendDeviceEventWithName:@"CodePushDownloadProgress"
-                         body:@{
-                                @"totalBytes":[NSNumber numberWithLongLong:expectedContentLength],
-                                @"receivedBytes":[NSNumber numberWithLongLong:receivedContentLength]
-                                }];
-                    }
-     // The download completed
-                        doneCallback:^{
-                            NSError *err;
-                            NSDictionary *newPackage = [CodePushPackage getPackage:updatePackage[PackageHashKey] error:&err];
-                            
-                            if (err) {
-                                return reject(@"",@"",err);
-                            }
-                            
-                            resolve(newPackage);
-                        }
-     // The download failed
-                        failCallback:^(NSError *err) {
-                            reject(@"",@"",err);
-                        }];
+        // The download is progressing forward
+        progressCallback:^(long long expectedContentLength, long long receivedContentLength) {
+            // Notify the script-side about the progress
+            [self.bridge.eventDispatcher
+                sendDeviceEventWithName:@"CodePushDownloadProgress"
+                body:@{
+                    @"totalBytes":[NSNumber numberWithLongLong:expectedContentLength],
+                    @"receivedBytes":[NSNumber numberWithLongLong:receivedContentLength]
+                    }];
+        }
+        // The download completed
+        doneCallback:^{
+            NSError *err;
+            NSDictionary *newPackage = [CodePushPackage getPackage:updatePackage[PackageHashKey] error:&err];
+            
+            if (err) {
+                return reject(err);
+            }
+            
+            resolve(newPackage);
+        }
+        // The download failed
+        failCallback:^(NSError *err) {
+            reject(err);
+        }];
 }
 
 /*
@@ -447,7 +447,7 @@ RCT_EXPORT_METHOD(getCurrentPackage:(RCTPromiseResolveBlock)resolve
         NSMutableDictionary *package = [[CodePushPackage getCurrentPackage:&error] mutableCopy];
         
         if (error) {
-            reject(@"",@"",error);
+            reject(error);
         }
         
         // Add the "isPending" virtual property to the package at this point, so that
@@ -473,7 +473,7 @@ RCT_EXPORT_METHOD(installUpdate:(NSDictionary*)updatePackage
                                   error:&error];
         
         if (error) {
-            reject(@"",@"",error);
+            reject(error);
         } else {
             [self savePendingUpdate:updatePackage[PackageHashKey]
                           isLoading:NO];

--- a/CodePush.m
+++ b/CodePush.m
@@ -158,7 +158,7 @@ static NSString *const PackageIsPendingKey = @"isPending";
              @"codePushInstallModeOnNextRestart":@(CodePushInstallModeOnNextRestart),
              @"codePushInstallModeImmediate": @(CodePushInstallModeImmediate),
              @"codePushInstallModeOnNextResume": @(CodePushInstallModeOnNextResume)
-             };
+            };
 };
 
 - (void)dealloc
@@ -268,8 +268,8 @@ static NSString *const PackageIsPendingKey = @"isPending";
     // If there is a pending update whose "state" isn't loading, then we consider it "pending".
     // Additionally, if a specific hash was provided, we ensure it matches that of the pending update.
     BOOL updateIsPending = pendingUpdate &&
-    [pendingUpdate[PendingUpdateIsLoadingKey] boolValue] == NO &&
-    (!packageHash || [pendingUpdate[PendingUpdateHashKey] isEqualToString:packageHash]);
+                           [pendingUpdate[PendingUpdateIsLoadingKey] boolValue] == NO &&
+                           (!packageHash || [pendingUpdate[PendingUpdateHashKey] isEqualToString:packageHash]);
     
     return updateIsPending;
 }
@@ -393,8 +393,8 @@ static NSString *const PackageIsPendingKey = @"isPending";
  * This is native-side of the RemotePackage.download method
  */
 RCT_EXPORT_METHOD(downloadUpdate:(NSDictionary*)updatePackage
-                  resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
+                        resolver:(RCTPromiseResolveBlock)resolve
+                        rejecter:(RCTPromiseRejectBlock)reject)
 {
     [CodePushPackage downloadPackage:updatePackage
      // The download is progressing forward
@@ -431,7 +431,7 @@ RCT_EXPORT_METHOD(downloadUpdate:(NSDictionary*)updatePackage
  * app version, as well as the deployment key that was configured in the Info.plist file.
  */
 RCT_EXPORT_METHOD(getConfiguration:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
+                          rejecter:(RCTPromiseRejectBlock)reject)
 {
     resolve([[CodePushConfig current] configuration]);
 }
@@ -440,7 +440,7 @@ RCT_EXPORT_METHOD(getConfiguration:(RCTPromiseResolveBlock)resolve
  * This method is the native side of the CodePush.getCurrentPackage method.
  */
 RCT_EXPORT_METHOD(getCurrentPackage:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
+                           rejecter:(RCTPromiseRejectBlock)reject)
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         NSError *error;
@@ -463,9 +463,9 @@ RCT_EXPORT_METHOD(getCurrentPackage:(RCTPromiseResolveBlock)resolve
  * This method is the native side of the LocalPackage.install method.
  */
 RCT_EXPORT_METHOD(installUpdate:(NSDictionary*)updatePackage
-                  installMode:(CodePushInstallMode)installMode
-                  resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
+                    installMode:(CodePushInstallMode)installMode
+                       resolver:(RCTPromiseResolveBlock)resolve
+                       rejecter:(RCTPromiseRejectBlock)reject)
 {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         NSError *error;
@@ -499,8 +499,8 @@ RCT_EXPORT_METHOD(installUpdate:(NSDictionary*)updatePackage
  * module, and is only used internally to populate the RemotePackage.failedInstall property.
  */
 RCT_EXPORT_METHOD(isFailedUpdate:(NSString *)packageHash
-                  resolve:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
+                         resolve:(RCTPromiseResolveBlock)resolve
+                          reject:(RCTPromiseRejectBlock)reject)
 {
     BOOL isFailedHash = [self isFailedHash:packageHash];
     resolve(@(isFailedHash));
@@ -511,8 +511,8 @@ RCT_EXPORT_METHOD(isFailedUpdate:(NSString *)packageHash
  * module, and is only used internally to populate the LocalPackage.isFirstRun property.
  */
 RCT_EXPORT_METHOD(isFirstRun:(NSString *)packageHash
-                  resolve:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
+                     resolve:(RCTPromiseResolveBlock)resolve
+                    rejecter:(RCTPromiseRejectBlock)reject)
 {
     NSError *error;
     BOOL isFirstRun = _isFirstRunAfterUpdate
@@ -527,7 +527,7 @@ RCT_EXPORT_METHOD(isFirstRun:(NSString *)packageHash
  * This method is the native side of the CodePush.notifyApplicationReady() method.
  */
 RCT_EXPORT_METHOD(notifyApplicationReady:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
+                                rejecter:(RCTPromiseRejectBlock)reject)
 {
     [CodePush removePendingUpdate];
     resolve([NSNull null]);
@@ -538,7 +538,7 @@ RCT_EXPORT_METHOD(notifyApplicationReady:(RCTPromiseResolveBlock)resolve
  * or an update failed) and return its details (version label, status).
  */
 RCT_EXPORT_METHOD(getNewStatusReport:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
+                            rejecter:(RCTPromiseRejectBlock)reject)
 {
     if (needToReportRollback) {
         // Check if there was a rollback that was not yet reported


### PR DESCRIPTION
This PR exposes the existing `[CodePushConfig current].deploymentKey` property through the `CodePush` class, to allow dynamically setting the deployment key in Objective-C, without needing to use an internal class (`CodePushConfig`). This provides a "cleaner" solution to issue #163.

I also replaced our use of code comments for segmenting method declarations with `#pragma mark`, since Xcode provides special UI support for them.