### PR TITLE
CocoaPods support

### DIFF
--- a/CodePush.podspec
+++ b/CodePush.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+
+  s.name             = 'CodePush'
+  s.version          = '1.6.0-beta'
+  s.summary          = 'React Native plugin for the CodePush service'
+  s.author           = 'Microsoft Corporation'
+  s.license          = 'MIT'
+  s.homepage         = 'http://microsoft.github.io/code-push/'
+  s.source           = { :git => 'https://github.com/Microsoft/react-native-code-push.git', :tag => "v#{s.version}" }
+  s.platform         = :ios, '7.0'
+  s.source_files     = '*.{h,m}', 'SSZipArchive/*.{h,m}', 'SSZipArchive/aes/*.{h,c}', 'SSZipArchive/minizip/*.{h,c}'
+  s.preserve_paths   = '*.js'
+  s.library          = 'z'
+  s.dependency 'React'
+
+end


### PR DESCRIPTION
This PR adds a `.podspec` file so that CodePush may be integrated via CocoaPods. I noted it handled here https://github.com/Microsoft/react-native-code-push/issues/44 where you guys preferred `rnpm`, but can't see any downsides to having it as an option. 

I opted to add the `SSZipArchive` as source files instead of as a proper CocoaPods dependency to streamline how that dependency is handled and avoid future upgrade bugs. 