### PR TITLE
Another way to init CodePush runtime for RN Android >=0.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ After installing the plugin and syncing your Android Studio project with Gradle,
         // Activity lifecycle event using the right deployment key
         @Override
         protected void onCreate(Bundle savedInstanceState) {
-            codePush = new CodePush("0dsIDongIcoH0mqAmoR0CYb5FhBZNy1w4Bf-l", this, BuildConfig.DEBUG);
+            this._codePush = new CodePush("0dsIDongIcoH0mqAmoR0CYb5FhBZNy1w4Bf-l", this, BuildConfig.DEBUG);
             super.onCreate(savedInstanceState);
         }
         ...

--- a/README.md
+++ b/README.md
@@ -215,10 +215,17 @@ After installing the plugin and syncing your Android Studio project with Gradle,
     public class MainActivity extends ReactActivity {
         // 2. Define a private field to hold the CodePush runtime instance
         private CodePush _codePush;
-
+        
+        // 3. Instantiate the CodePush runtime inside the onCreate
+        // Activity lifecycle event using the right deployment key
+        @Override
+        protected void onCreate(Bundle savedInstanceState) {
+            codePush = new CodePush("0dsIDongIcoH0mqAmoR0CYb5FhBZNy1w4Bf-l", this, BuildConfig.DEBUG);
+            super.onCreate(savedInstanceState);
+        }
         ...
 
-        // 3. Override the getJSBundleFile method in order to let
+        // 4. Override the getJSBundleFile method in order to let
         // the CodePush runtime determine where to get the JS
         // bundle location from on each app start
         @Override
@@ -228,9 +235,6 @@ After installing the plugin and syncing your Android Studio project with Gradle,
 
         @Override
         protected List<ReactPackage> getPackages() {
-            // 4. Instantiate an instance of the CodePush runtime, using the right deployment key
-            this._codePush = new CodePush("0dsIDongIcoH0mqAmoR0CYb5FhBZNy1w4Bf-l", this, BuildConfig.DEBUG);
-
             // 5. Add the CodePush package to the list of existing packages
             return Arrays.<ReactPackage>asList(
                 new MainReactPackage(), this._codePush.getReactPackage());


### PR DESCRIPTION
This updates the docs to prescribe initializing the `_codePush` instance variable inside `onCreate`, which seems to be a common practice for initializing instance variables in Android, since it is guaranteed to be only called once early in the Activity lifecycle. Just a suggestion. @lostintangent 