### PR TITLE
Disable metrics in debug

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -137,6 +137,11 @@ function log(message) {
 
 async function notifyApplicationReady() {
   await NativeCodePush.notifyApplicationReady();
+  if (__DEV__) {
+    // Don't report metrics if in DEV mode.
+    return;
+  }
+  
   const statusReport = await NativeCodePush.getNewStatusReport();
   if (statusReport) {
     const config = await getConfiguration();

--- a/CodePush.m
+++ b/CodePush.m
@@ -513,6 +513,7 @@ RCT_EXPORT_METHOD(getNewStatusReport:(RCTPromiseResolveBlock)resolve
                             rejecter:(RCTPromiseRejectBlock)reject)
 {
     if ([_bridge.bundleURL.scheme hasPrefix:@"http"]) {
+        // Do not report metrics if running bundle from packager.
         resolve(nil);
         return;
     }

--- a/CodePush.m
+++ b/CodePush.m
@@ -538,7 +538,6 @@ RCT_EXPORT_METHOD(getNewStatusReport:(RCTPromiseResolveBlock)resolve
                 return;
             }
         } else if (isRunningBinaryVersion) {
-            // Check if the current appVersion has been reported.
             NSString *appVersion = [[CodePushConfig current] appVersion];
             resolve([CodePushTelemetryManager getBinaryUpdateReport:appVersion]);
             return;

--- a/CodePush.m
+++ b/CodePush.m
@@ -512,6 +512,10 @@ RCT_EXPORT_METHOD(notifyApplicationReady:(RCTPromiseResolveBlock)resolve
 RCT_EXPORT_METHOD(getNewStatusReport:(RCTPromiseResolveBlock)resolve
                             rejecter:(RCTPromiseRejectBlock)reject)
 {
+    if ([_bridge.bundleURL.scheme hasPrefix:@"http"]) {
+        resolve(nil);
+        return;
+    }
     
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         if (needToReportRollback) {
@@ -532,7 +536,7 @@ RCT_EXPORT_METHOD(getNewStatusReport:(RCTPromiseResolveBlock)resolve
                 resolve([CodePushTelemetryManager getUpdateReport:currentPackage]);
                 return;
             }
-        } else if (isRunningBinaryVersion || [_bridge.bundleURL.scheme hasPrefix:@"http"]) {
+        } else if (isRunningBinaryVersion) {
             // Check if the current appVersion has been reported.
             NSString *appVersion = [[CodePushConfig current] appVersion];
             resolve([CodePushTelemetryManager getBinaryUpdateReport:appVersion]);

--- a/CodePush.m
+++ b/CodePush.m
@@ -512,15 +512,6 @@ RCT_EXPORT_METHOD(notifyApplicationReady:(RCTPromiseResolveBlock)resolve
 RCT_EXPORT_METHOD(getNewStatusReport:(RCTPromiseResolveBlock)resolve
                             rejecter:(RCTPromiseRejectBlock)reject)
 {
-#ifdef DEBUG
-    // Do not report metrics if running in debug mode.
-    resolve(nil);
-#else
-    if ([_bridge.bundleURL.scheme hasPrefix:@"http"]) {
-        // Do not report metrics if running bundle from packager.
-        resolve(nil);
-        return;
-    }
     
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         if (needToReportRollback) {
@@ -541,7 +532,8 @@ RCT_EXPORT_METHOD(getNewStatusReport:(RCTPromiseResolveBlock)resolve
                 resolve([CodePushTelemetryManager getUpdateReport:currentPackage]);
                 return;
             }
-        } else if (isRunningBinaryVersion) {
+        } else if (isRunningBinaryVersion || [_bridge.bundleURL.scheme hasPrefix:@"http"]) {
+            // Check if the current appVersion has been reported.
             NSString *appVersion = [[CodePushConfig current] appVersion];
             resolve([CodePushTelemetryManager getBinaryUpdateReport:appVersion]);
             return;
@@ -549,7 +541,6 @@ RCT_EXPORT_METHOD(getNewStatusReport:(RCTPromiseResolveBlock)resolve
         
         resolve(nil);
     });
-#endif
 }
 
 /*

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.0.0'
-    compile 'com.facebook.react:react-native:0.15.1'
+    compile fileTree(dir: "libs", include: ["*.jar"])
+    compile "com.android.support:appcompat-v7:23.0.1"
+    compile "com.facebook.react:react-native:0.19.+"
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:23.0.1"
-    compile "com.facebook.react:react-native:0.19.+"
+    compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile 'com.android.support:appcompat-v7:23.0.0'
+    compile 'com.facebook.react:react-native:0.15.1'
 }

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -426,11 +426,6 @@ public class CodePush {
 
         @ReactMethod
         public void getNewStatusReport(final Promise promise) {
-            if (isDebugMode) {
-                // Do not report metrics if running in debug mode.
-                promise.resolve("");
-                return;
-            }
 
             AsyncTask asyncTask = new AsyncTask() {
                 @Override

--- a/package-mixins.js
+++ b/package-mixins.js
@@ -25,7 +25,8 @@ module.exports = (NativeCodePush) => {
         // so that the client knows what the current package version is.
         try {  
           const downloadedPackage = await NativeCodePush.downloadUpdate(this);
-          reportStatusDownload && reportStatusDownload(this);
+          // Don't report metrics if in DEV mode.
+          !__DEV__ && reportStatusDownload && reportStatusDownload(this);
           return { ...downloadedPackage, ...local };
         } finally {
           downloadProgressSubscription && downloadProgressSubscription.remove();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-code-push",
-  "version": "1.6.0-beta",
+  "version": "1.7.0-beta",
   "description": "React Native plugin for the CodePush service",
   "main": "CodePush.js",
   "homepage": "https://microsoft.github.io/code-push",
@@ -20,6 +20,6 @@
     "semver": "^5.1.0"
   },
   "devDependencies": {
-    "react-native": "0.15.0"
+    "react-native": "0.19.0"
   }
 }


### PR DESCRIPTION
Reverts https://github.com/Microsoft/react-native-code-push/pull/175 and disables the call to getNewStatusReport from JS instead.