### PR TITLE
Add logging and lift dev restriction on telemtry

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -58,7 +58,7 @@ async function checkForUpdate(deploymentKey = null) {
    *    client app is resilient to a potential issue with the update check.
    */
   if (!update || update.updateAppVersion || (update.packageHash === localPackage.packageHash)) {
-    if (update.updateAppVersion) {
+    if (update && update.updateAppVersion) {
       log("An update is available but it is targeting a newer binary version than you are currently running.");
     }
     

--- a/CodePush.js
+++ b/CodePush.js
@@ -59,7 +59,7 @@ async function checkForUpdate(deploymentKey = null) {
    */
   if (!update || update.updateAppVersion || (update.packageHash === localPackage.packageHash)) {
     if (update.updateAppVersion) {
-      log("An update is available but it is targetting a newer binary version than you are currently running.");
+      log("An update is available but it is targeting a newer binary version than you are currently running.");
     }
     
     return null;

--- a/CodePush.js
+++ b/CodePush.js
@@ -58,6 +58,10 @@ async function checkForUpdate(deploymentKey = null) {
    *    client app is resilient to a potential issue with the update check.
    */
   if (!update || update.updateAppVersion || (update.packageHash === localPackage.packageHash)) {
+    if (update.updateAppVersion) {
+      log("An update is available but it is targetting a newer binary version than you are currently running.");
+    }
+    
     return null;
   } else {     
     const remotePackage = { ...update, ...PackageMixins.remote(sdk.reportStatusDownload) };
@@ -136,12 +140,7 @@ function log(message) {
 }
 
 async function notifyApplicationReady() {
-  await NativeCodePush.notifyApplicationReady();
-  if (__DEV__) {
-    // Don't report metrics if in DEV mode.
-    return;
-  }
-  
+  await NativeCodePush.notifyApplicationReady();  
   const statusReport = await NativeCodePush.getNewStatusReport();
   if (statusReport) {
     const config = await getConfiguration();
@@ -254,7 +253,12 @@ async function sync(options = {}, syncStatusChangeCallback, downloadProgressCall
       return CodePush.SyncStatus.UPDATE_INSTALLED;
     };
     
-    if (!remotePackage || (remotePackage.failedInstall && syncOptions.ignoreFailedUpdates)) {
+    const updateShouldBeIgnored = remotePackage && (remotePackage.failedInstall && syncOptions.ignoreFailedUpdates);
+    if (!remotePackage || updateShouldBeIgnored) {
+      if (updateShouldBeIgnored) {
+          log("An update is available, but it is being ignored due to having been previously rolled back.");
+      }
+      
       syncStatusChangeCallback(CodePush.SyncStatus.UP_TO_DATE);
       return CodePush.SyncStatus.UP_TO_DATE;
     } else if (syncOptions.updateDialog) {

--- a/CodePush.m
+++ b/CodePush.m
@@ -511,13 +511,7 @@ RCT_EXPORT_METHOD(notifyApplicationReady:(RCTPromiseResolveBlock)resolve
  */
 RCT_EXPORT_METHOD(getNewStatusReport:(RCTPromiseResolveBlock)resolve
                             rejecter:(RCTPromiseRejectBlock)reject)
-{
-    if ([_bridge.bundleURL.scheme hasPrefix:@"http"]) {
-        // Do not report metrics if running bundle from packager.
-        resolve(nil);
-        return;
-    }
-    
+{    
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         if (needToReportRollback) {
             needToReportRollback = NO;

--- a/package-mixins.js
+++ b/package-mixins.js
@@ -26,7 +26,7 @@ module.exports = (NativeCodePush) => {
         try {  
           const downloadedPackage = await NativeCodePush.downloadUpdate(this);
           // Don't report metrics if in DEV mode.
-          !__DEV__ && reportStatusDownload && reportStatusDownload(this);
+          reportStatusDownload && reportStatusDownload(this);
           return { ...downloadedPackage, ...local };
         } finally {
           downloadProgressSubscription && downloadProgressSubscription.remove();

--- a/package-mixins.js
+++ b/package-mixins.js
@@ -25,7 +25,6 @@ module.exports = (NativeCodePush) => {
         // so that the client knows what the current package version is.
         try {  
           const downloadedPackage = await NativeCodePush.downloadUpdate(this);
-          // Don't report metrics if in DEV mode.
           reportStatusDownload && reportStatusDownload(this);
           return { ...downloadedPackage, ...local };
         } finally {


### PR DESCRIPTION
This PR does two things:

1. Adds more diagnostic logging to help identify when an update isn't available due to targeting a newer binary version or having previously failed.

2. Removes the dev restriction on telemetry