### PR TITLE
Version bump

### DIFF
--- a/CodePush.podspec
+++ b/CodePush.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name             = 'CodePush'
-  s.version          = '1.6.0-beta'
+  s.version          = '1.7.1-beta'
   s.summary          = 'React Native plugin for the CodePush service'
   s.author           = 'Microsoft Corporation'
   s.license          = 'MIT'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-code-push",
-  "version": "1.7.0-beta",
+  "version": "1.7.1-beta",
   "description": "React Native plugin for the CodePush service",
   "main": "CodePush.js",
   "homepage": "https://microsoft.github.io/code-push",


### PR DESCRIPTION
We never bumped the Podspec version as part of the 1.7.0 release, and so I'm bumping our package version again so that we can release an update to NPM which includes the appropriate version in the Podspec as well.