### PR TITLE
Attach binary bundle date to package metadata on download

### DIFF
--- a/CodePush.m
+++ b/CodePush.m
@@ -57,9 +57,7 @@ static NSString *const PackageIsPendingKey = @"isPending";
     NSError *error;
     NSString *packageFile = [CodePushPackage getCurrentPackageBundlePath:&error];
     NSURL *binaryJsBundleUrl = [[NSBundle mainBundle] URLForResource:resourceName withExtension:resourceExtension];
-    NSDictionary *binaryFileAttributes = [[NSFileManager defaultManager] attributesOfItemAtPath:[binaryJsBundleUrl path] error:nil];
-    NSDate *binaryDate = [binaryFileAttributes objectForKey:NSFileModificationDate];
-    [self saveBinaryBundleDate:binaryDate];
+    [self saveBinaryBundleDate:binaryJsBundleUrl];
     
     NSString *logMessageFormat = @"Loading JS bundle from %@";
     
@@ -124,10 +122,12 @@ static NSString *const PackageIsPendingKey = @"isPending";
     return testConfigurationFlag;
 }
 
-+ (void)saveBinaryBundleDate:(NSDate *)binaryBundleDate
++ (void)saveBinaryBundleDate:(NSURL *)binaryJsBundleUrl
 {
+    NSDictionary *binaryFileAttributes = [[NSFileManager defaultManager] attributesOfItemAtPath:[binaryJsBundleUrl path] error:nil];
+    NSDate *binaryDate = [binaryFileAttributes objectForKey:NSFileModificationDate];
     NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
-    [preferences setObject:binaryBundleDate forKey:BinaryBundleDateKey];
+    [preferences setObject:binaryDate forKey:BinaryBundleDateKey];
     [preferences synchronize];
 }
 

--- a/CodePush.m
+++ b/CodePush.m
@@ -46,11 +46,6 @@ static NSString *bundleResourceExtension = @"jsbundle";
 
 #pragma mark - Public Obj-C API
 
-+ (NSURL *)binaryBundleURL
-{
-    return [[NSBundle mainBundle] URLForResource:bundleResourceName withExtension:bundleResourceExtension];
-}
-
 + (NSURL *)bundleURL
 {
     return [self bundleURLForResource:bundleResourceName];
@@ -166,6 +161,11 @@ static NSString *bundleResourceExtension = @"jsbundle";
 #pragma mark - Private API methods
 
 @synthesize bridge = _bridge;
+
++ (NSURL *)binaryBundleURL
+{
+    return [[NSBundle mainBundle] URLForResource:bundleResourceName withExtension:bundleResourceExtension];
+}
 
 /*
  * This method is used by the React Native bridge to allow

--- a/CodePush.m
+++ b/CodePush.m
@@ -24,6 +24,7 @@ static NSString *const DeploymentFailed = @"DeploymentFailed";
 static NSString *const DeploymentSucceeded = @"DeploymentSucceeded";
 
 // These keys represent the names we use to store data in NSUserDefaults
+static NSString *const BinaryBundleDateKey = @"CODE_PUSH_BINARY_DATE";
 static NSString *const FailedUpdatesKey = @"CODE_PUSH_FAILED_UPDATES";
 static NSString *const PendingUpdateKey = @"CODE_PUSH_PENDING_UPDATE";
 
@@ -56,6 +57,11 @@ static NSString *const PackageIsPendingKey = @"isPending";
     NSError *error;
     NSString *packageFile = [CodePushPackage getCurrentPackageBundlePath:&error];
     NSURL *binaryJsBundleUrl = [[NSBundle mainBundle] URLForResource:resourceName withExtension:resourceExtension];
+    NSDictionary *binaryFileAttributes = [[NSFileManager defaultManager] attributesOfItemAtPath:[binaryJsBundleUrl path] error:nil];
+    NSDate *binaryDate = [binaryFileAttributes objectForKey:NSFileModificationDate];
+    NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
+    [preferences setObject:binaryDate forKey:FailedUpdatesKey];
+    [preferences synchronize];
     
     NSString *logMessageFormat = @"Loading JS bundle from %@";
     
@@ -65,10 +71,6 @@ static NSString *const PackageIsPendingKey = @"isPending";
         return binaryJsBundleUrl;
     }
     
-    NSDictionary *binaryFileAttributes = [[NSFileManager defaultManager] attributesOfItemAtPath:[binaryJsBundleUrl path] error:nil];
-    NSDictionary *appFileAttribs = [[NSFileManager defaultManager] attributesOfItemAtPath:packageFile error:nil];
-    NSDate *binaryDate = [binaryFileAttributes objectForKey:NSFileModificationDate];
-    NSDate *packageDate = [appFileAttribs objectForKey:NSFileModificationDate];
     NSString *binaryAppVersion = [[CodePushConfig current] appVersion];
     NSDictionary *currentPackageMetadata = [CodePushPackage getCurrentPackage:&error];
     if (error || !currentPackageMetadata) {
@@ -77,9 +79,11 @@ static NSString *const PackageIsPendingKey = @"isPending";
         return binaryJsBundleUrl;
     }
     
+    NSString *packageDate = [currentPackageMetadata objectForKey:BinaryBundleDateKey];
+    NSString *binaryDateString = [NSString stringWithFormat:@"%f", [binaryDate timeIntervalSince1970]];
     NSString *packageAppVersion = [currentPackageMetadata objectForKey:@"appVersion"];
     
-    if ([binaryDate compare:packageDate] == NSOrderedAscending && ([CodePush isUsingTestConfiguration] ||[binaryAppVersion isEqualToString:packageAppVersion])) {
+    if ([binaryDateString isEqualToString:packageDate] && ([CodePush isUsingTestConfiguration] ||[binaryAppVersion isEqualToString:packageAppVersion])) {
         // Return package file because it is newer than the app store binary's JS bundle
         NSURL *packageUrl = [[NSURL alloc] initFileURLWithPath:packageFile];
         NSLog(logMessageFormat, packageUrl);
@@ -362,11 +366,19 @@ static NSString *const PackageIsPendingKey = @"isPending";
 /*
  * This is native-side of the RemotePackage.download method
  */
-RCT_EXPORT_METHOD(downloadUpdate:(NSDictionary*)updatePackage
+RCT_EXPORT_METHOD(downloadUpdate:(NSDictionary*)immutableUpdatePackage
                         resolver:(RCTPromiseResolveBlock)resolve
                         rejecter:(RCTPromiseRejectBlock)reject)
 {
     dispatch_async(dispatch_get_main_queue(), ^{
+        NSDictionary* updatePackage = [immutableUpdatePackage mutableCopy];
+        NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
+        NSDate *binaryBundleDate = [preferences objectForKey:BinaryBundleDateKey];
+        if (binaryBundleDate != nil) {
+            [updatePackage setValue:[NSString stringWithFormat:@"%f", [binaryBundleDate timeIntervalSince1970]]
+                             forKey:BinaryBundleDateKey];
+        }
+        
         [CodePushPackage downloadPackage:updatePackage
             // The download is progressing forward
             progressCallback:^(long long expectedContentLength, long long receivedContentLength) {

--- a/CodePush.m
+++ b/CodePush.m
@@ -87,7 +87,7 @@ static NSString *bundleResourceName = @"main";
     NSString *packageDate = [currentPackageMetadata objectForKey:BinaryBundleDateKey];
     NSString *packageAppVersion = [currentPackageMetadata objectForKey:@"appVersion"];
     
-    if ([[self modifiedDateStringFromFileUrl:binaryBundleURL] isEqualToString:packageDate] && ([CodePush isUsingTestConfiguration] ||[binaryAppVersion isEqualToString:packageAppVersion])) {
+    if ([[self modifiedDateStringOfFileAtUrl:binaryBundleURL] isEqualToString:packageDate] && ([CodePush isUsingTestConfiguration] ||[binaryAppVersion isEqualToString:packageAppVersion])) {
         // Return package file because it is newer than the app store binary's JS bundle
         NSURL *packageUrl = [[NSURL alloc] initFileURLWithPath:packageFile];
         NSLog(logMessageFormat, packageUrl);
@@ -122,7 +122,7 @@ static NSString *bundleResourceName = @"main";
 /*
  * This returns the modified date as a string for a given file URL.
  */
-+ (NSString *)modifiedDateStringFromFileUrl:(NSURL *)fileUrl
++ (NSString *)modifiedDateStringOfFileAtUrl:(NSURL *)fileUrl
 {
     if (fileUrl != nil) {
         NSDictionary *fileAttributes = [[NSFileManager defaultManager] attributesOfItemAtPath:[fileUrl path] error:nil];
@@ -397,7 +397,7 @@ RCT_EXPORT_METHOD(downloadUpdate:(NSDictionary*)updatePackage
         NSDictionary *mutableUpdatePackage = [updatePackage mutableCopy];
         NSURL *binaryBundleURL = [CodePush binaryBundleURL];
         if (binaryBundleURL != nil) {
-            [mutableUpdatePackage setValue:[CodePush modifiedDateStringFromFileUrl:binaryBundleURL]
+            [mutableUpdatePackage setValue:[CodePush modifiedDateStringOfFileAtUrl:binaryBundleURL]
                                     forKey:BinaryBundleDateKey];
         }
         

--- a/CodePush.m
+++ b/CodePush.m
@@ -87,7 +87,7 @@ static NSString *bundleResourceName = @"main";
     NSString *packageDate = [currentPackageMetadata objectForKey:BinaryBundleDateKey];
     NSString *packageAppVersion = [currentPackageMetadata objectForKey:@"appVersion"];
     
-    if ([[self modifiedDateStringOfFileAtUrl:binaryBundleURL] isEqualToString:packageDate] && ([CodePush isUsingTestConfiguration] ||[binaryAppVersion isEqualToString:packageAppVersion])) {
+    if ([[self modifiedDateStringOfFileAtURL:binaryBundleURL] isEqualToString:packageDate] && ([CodePush isUsingTestConfiguration] ||[binaryAppVersion isEqualToString:packageAppVersion])) {
         // Return package file because it is newer than the app store binary's JS bundle
         NSURL *packageUrl = [[NSURL alloc] initFileURLWithPath:packageFile];
         NSLog(logMessageFormat, packageUrl);
@@ -397,7 +397,7 @@ RCT_EXPORT_METHOD(downloadUpdate:(NSDictionary*)updatePackage
         NSDictionary *mutableUpdatePackage = [updatePackage mutableCopy];
         NSURL *binaryBundleURL = [CodePush binaryBundleURL];
         if (binaryBundleURL != nil) {
-            [mutableUpdatePackage setValue:[CodePush modifiedDateStringOfFileAtUrl:binaryBundleURL]
+            [mutableUpdatePackage setValue:[CodePush modifiedDateStringOfFileAtURL:binaryBundleURL]
                                     forKey:BinaryBundleDateKey];
         }
         

--- a/CodePush.m
+++ b/CodePush.m
@@ -24,7 +24,6 @@ static NSString *const DeploymentFailed = @"DeploymentFailed";
 static NSString *const DeploymentSucceeded = @"DeploymentSucceeded";
 
 // These keys represent the names we use to store data in NSUserDefaults
-static NSString *const BinaryBundleDateKey = @"CODE_PUSH_BINARY_DATE";
 static NSString *const FailedUpdatesKey = @"CODE_PUSH_FAILED_UPDATES";
 static NSString *const PendingUpdateKey = @"CODE_PUSH_PENDING_UPDATE";
 
@@ -37,6 +36,7 @@ static NSString *const PendingUpdateIsLoadingKey = @"isLoading";
 // that is associated with an update's package.
 static NSString *const PackageHashKey = @"packageHash";
 static NSString *const PackageIsPendingKey = @"isPending";
+static NSString *const BinaryBundleDateKey = @"binaryDate";
 
 // These values are used to save the bundleURL and extension for the JS bundle
 // in the binary.

--- a/CodePush.m
+++ b/CodePush.m
@@ -119,20 +119,6 @@ static NSString *bundleResourceName = @"main";
     return testConfigurationFlag;
 }
 
-/*
- * This returns the modified date as a string for a given file URL.
- */
-+ (NSString *)modifiedDateStringOfFileAtUrl:(NSURL *)fileUrl
-{
-    if (fileUrl != nil) {
-        NSDictionary *fileAttributes = [[NSFileManager defaultManager] attributesOfItemAtPath:[fileUrl path] error:nil];
-        NSDate *modifiedDate = [fileAttributes objectForKey:NSFileModificationDate];
-        return [NSString stringWithFormat:@"%f", [modifiedDate timeIntervalSince1970]];
-    } else {
-        return nil;
-    }
-}
-
 + (void)setDeploymentKey:(NSString *)deploymentKey
 {
     [CodePushConfig current].deploymentKey = deploymentKey;
@@ -298,6 +284,20 @@ static NSString *bundleResourceName = @"main";
         
         [_bridge reload];
     });
+}
+
+/*
+ * This returns the modified date as a string for a given file URL.
+ */
++ (NSString *)modifiedDateStringOfFileAtURL:(NSURL *)fileURL
+{
+    if (fileURL != nil) {
+        NSDictionary *fileAttributes = [[NSFileManager defaultManager] attributesOfItemAtPath:[fileURL path] error:nil];
+        NSDate *modifiedDate = [fileAttributes objectForKey:NSFileModificationDate];
+        return [NSString stringWithFormat:@"%f", [modifiedDate timeIntervalSince1970]];
+    } else {
+        return nil;
+    }
 }
 
 /*

--- a/CodePush.m
+++ b/CodePush.m
@@ -36,8 +36,8 @@ static NSString *const PackageIsPendingKey = @"isPending";
 
 #pragma mark - Static variables
 
-static BOOL needToReportRollback = NO;
 static BOOL isRunningBinaryVersion = NO;
+static BOOL needToReportRollback = NO;
 static BOOL testConfigurationFlag = NO;
 
 // These values are used to save the bundleURL and extension for the JS bundle

--- a/CodePush.m
+++ b/CodePush.m
@@ -15,10 +15,6 @@ RCT_EXPORT_MODULE()
 
 #pragma mark - Private constants
 
-static BOOL needToReportRollback = NO;
-static BOOL isRunningBinaryVersion = NO;
-static BOOL testConfigurationFlag = NO;
-
 // These constants represent valid deployment statuses
 static NSString *const DeploymentFailed = @"DeploymentFailed";
 static NSString *const DeploymentSucceeded = @"DeploymentSucceeded";
@@ -37,6 +33,12 @@ static NSString *const PendingUpdateIsLoadingKey = @"isLoading";
 static NSString *const BinaryBundleDateKey = @"binaryDate";
 static NSString *const PackageHashKey = @"packageHash";
 static NSString *const PackageIsPendingKey = @"isPending";
+
+#pragma mark - Static variables
+
+static BOOL needToReportRollback = NO;
+static BOOL isRunningBinaryVersion = NO;
+static BOOL testConfigurationFlag = NO;
 
 // These values are used to save the bundleURL and extension for the JS bundle
 // in the binary.

--- a/CodePush.m
+++ b/CodePush.m
@@ -40,9 +40,8 @@ static NSString *const PackageIsPendingKey = @"isPending";
 
 // These values are used to save the bundleURL and extension for the JS bundle
 // in the binary.
-static NSString *bundleResourceName = @"main";
 static NSString *bundleResourceExtension = @"jsbundle";
-
+static NSString *bundleResourceName = @"main";
 
 #pragma mark - Public Obj-C API
 

--- a/CodePush.m
+++ b/CodePush.m
@@ -34,64 +34,64 @@ static NSString *const PendingUpdateIsLoadingKey = @"isLoading";
 
 // These keys are used to inspect/augment the metadata
 // that is associated with an update's package.
+static NSString *const BinaryBundleDateKey = @"binaryDate";
 static NSString *const PackageHashKey = @"packageHash";
 static NSString *const PackageIsPendingKey = @"isPending";
-static NSString *const BinaryBundleDateKey = @"binaryDate";
 
 // These values are used to save the bundleURL and extension for the JS bundle
 // in the binary.
-static NSString *binaryJsName = @"main";
-static NSString *binaryJsExtension = @"jsbundle";
+static NSString *bundleResourceName = @"main";
+static NSString *bundleResourceExtension = @"jsbundle";
 
 
 #pragma mark - Public Obj-C API
 
-+ (NSURL *)binaryJsBundleUrl
++ (NSURL *)binaryBundleURL
 {
-    return [[NSBundle mainBundle] URLForResource:binaryJsName withExtension:binaryJsExtension];
+    return [[NSBundle mainBundle] URLForResource:bundleResourceName withExtension:bundleResourceExtension];
 }
 
 + (NSURL *)bundleURL
 {
-    return [self bundleURLForResource:binaryJsName];
+    return [self bundleURLForResource:bundleResourceName];
 }
 
 + (NSURL *)bundleURLForResource:(NSString *)resourceName
 {
-    binaryJsName = resourceName;
+    bundleResourceName = resourceName;
     return [self bundleURLForResource:resourceName
-                        withExtension:binaryJsExtension];
+                        withExtension:bundleResourceExtension];
 }
 
 + (NSURL *)bundleURLForResource:(NSString *)resourceName
                   withExtension:(NSString *)resourceExtension
 {
-    binaryJsName = resourceName;
-    binaryJsExtension = resourceExtension;
+    bundleResourceName = resourceName;
+    bundleResourceExtension = resourceExtension;
     NSError *error;
     NSString *packageFile = [CodePushPackage getCurrentPackageBundlePath:&error];
-    NSURL *binaryJsBundleUrl = [self binaryJsBundleUrl];
+    NSURL *binaryBundleURL = [self binaryBundleURL];
     
     NSString *logMessageFormat = @"Loading JS bundle from %@";
     
     if (error || !packageFile) {
-        NSLog(logMessageFormat, binaryJsBundleUrl);
+        NSLog(logMessageFormat, binaryBundleURL);
         isRunningBinaryVersion = YES;
-        return binaryJsBundleUrl;
+        return binaryBundleURL;
     }
     
     NSString *binaryAppVersion = [[CodePushConfig current] appVersion];
     NSDictionary *currentPackageMetadata = [CodePushPackage getCurrentPackage:&error];
     if (error || !currentPackageMetadata) {
-        NSLog(logMessageFormat, binaryJsBundleUrl);
+        NSLog(logMessageFormat, binaryBundleURL);
         isRunningBinaryVersion = YES;
-        return binaryJsBundleUrl;
+        return binaryBundleURL;
     }
     
     NSString *packageDate = [currentPackageMetadata objectForKey:BinaryBundleDateKey];
     NSString *packageAppVersion = [currentPackageMetadata objectForKey:@"appVersion"];
     
-    if ([[self modifiedDateStringFromFileUrl:binaryJsBundleUrl] isEqualToString:packageDate] && ([CodePush isUsingTestConfiguration] ||[binaryAppVersion isEqualToString:packageAppVersion])) {
+    if ([[self modifiedDateStringFromFileUrl:binaryBundleURL] isEqualToString:packageDate] && ([CodePush isUsingTestConfiguration] ||[binaryAppVersion isEqualToString:packageAppVersion])) {
         // Return package file because it is newer than the app store binary's JS bundle
         NSURL *packageUrl = [[NSURL alloc] initFileURLWithPath:packageFile];
         NSLog(logMessageFormat, packageUrl);
@@ -102,9 +102,9 @@ static NSString *binaryJsExtension = @"jsbundle";
         [CodePush clearUpdates];
 #endif
         
-        NSLog(logMessageFormat, binaryJsBundleUrl);
+        NSLog(logMessageFormat, binaryBundleURL);
         isRunningBinaryVersion = YES;
-        return binaryJsBundleUrl;
+        return binaryBundleURL;
     }
 }
 
@@ -394,9 +394,9 @@ RCT_EXPORT_METHOD(downloadUpdate:(NSDictionary*)updatePackage
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         NSDictionary *mutableUpdatePackage = [updatePackage mutableCopy];
-        NSURL *binaryJsBundleUrl = [CodePush binaryJsBundleUrl];
-        if (binaryJsBundleUrl != nil) {
-            [mutableUpdatePackage setValue:[CodePush modifiedDateStringFromFileUrl:binaryJsBundleUrl]
+        NSURL *binaryBundleURL = [CodePush binaryBundleURL];
+        if (binaryBundleURL != nil) {
+            [mutableUpdatePackage setValue:[CodePush modifiedDateStringFromFileUrl:binaryBundleURL]
                                     forKey:BinaryBundleDateKey];
         }
         

--- a/CodePushPackage.m
+++ b/CodePushPackage.m
@@ -228,8 +228,16 @@ NSString * const UnzippedFolderName = @"unzipped";
             NSString * unzippedFolderPath = [CodePushPackage getUnzippedFolderPath];
             NSMutableDictionary * mutableUpdatePackage = [updatePackage mutableCopy];
             if (isZip) {
-                NSError *nonFailingError = nil;
+                if ([[NSFileManager defaultManager] fileExistsAtPath:unzippedFolderPath]) {
+                    [[NSFileManager defaultManager] removeItemAtPath:unzippedFolderPath
+                                                               error:&error];
+                    if (error) {
+                        failCallback(error);
+                        return;
+                    }
+                }
                 
+                NSError *nonFailingError = nil;
                 [SSZipArchive unzipFileAtPath:downloadFilePath
                                 toDestination:unzippedFolderPath];
                 [[NSFileManager defaultManager] removeItemAtPath:downloadFilePath

--- a/CodePushPackage.m
+++ b/CodePushPackage.m
@@ -229,6 +229,8 @@ NSString * const UnzippedFolderName = @"unzipped";
             NSMutableDictionary * mutableUpdatePackage = [updatePackage mutableCopy];
             if (isZip) {
                 if ([[NSFileManager defaultManager] fileExistsAtPath:unzippedFolderPath]) {
+                    // This removes any unzipped download data that could have been left
+                    // uncleared due to a crash or error during the download process.
                     [[NSFileManager defaultManager] removeItemAtPath:unzippedFolderPath
                                                                error:&error];
                     if (error) {

--- a/CodePushPackage.m
+++ b/CodePushPackage.m
@@ -285,6 +285,11 @@ NSString * const UnzippedFolderName = @"unzipped";
                 [CodePushPackage copyEntriesInFolder:unzippedFolderPath
                                           destFolder:newPackageFolderPath
                                                error:&error];
+                if (error) {
+                    failCallback(error);
+                    return;
+                }
+                
                 [[NSFileManager defaultManager] removeItemAtPath:unzippedFolderPath
                                                            error:&nonFailingError];
                 if (nonFailingError) {

--- a/Examples/CodePushDemoApp/iOS/CodePushDemoApp/Info.plist
+++ b/Examples/CodePushDemoApp/iOS/CodePushDemoApp/Info.plist
@@ -44,6 +44,6 @@
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
 	<key>CodePushDeploymentKey</key>
-	<string>deployment-key-here</string>
+	<string>5c73310a-cc93-4aa5-bf9f-81c6b648232c</string>
 </dict>
 </plist>

--- a/Examples/CodePushDemoApp/iOS/CodePushDemoApp/Info.plist
+++ b/Examples/CodePushDemoApp/iOS/CodePushDemoApp/Info.plist
@@ -44,6 +44,6 @@
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
 	<key>CodePushDeploymentKey</key>
-	<string>5c73310a-cc93-4aa5-bf9f-81c6b648232c</string>
+	<string>deployment-key-here</string>
 </dict>
 </plist>

--- a/android/app/src/main/java/com/microsoft/codepush/react/FileUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/FileUtils.java
@@ -152,9 +152,11 @@ public class FileUtils {
             ZipEntry entry;
 
             File destinationFolder = new File(destination);
-            if (!destinationFolder.exists()) {
-                destinationFolder.mkdirs();
+            if (destinationFolder.exists()) {
+                deleteDirectory(destinationFolder);
             }
+            
+            destinationFolder.mkdirs();
 
             byte[] buffer = new byte[WRITE_BUFFER_SIZE];
             while ((entry = zipStream.getNextEntry()) != null) {


### PR DESCRIPTION
Use the binary bundle date string attached to the package metadata for comparison in [CodePush bundleUrl] so as to avoid date synchronization issues (eg bundle date generated by the PC may be out of sync with device date). @lostintangent 