### PR TITLE
Fix failing tests

### DIFF
--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/CheckForUpdateTests/testcases/NewUpdateTest.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/CheckForUpdateTests/testcases/NewUpdateTest.js
@@ -1,3 +1,5 @@
+"use strict";
+
 import React from "react-native";
 import CodePush from "react-native-code-push";
 import createTestCaseComponent from "../../utils/createTestCaseComponent";

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/CheckForUpdateTests/testcases/NewUpdateTest.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/CheckForUpdateTests/testcases/NewUpdateTest.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import React from "react-native";
 import CodePush from "react-native-code-push";
 import createTestCaseComponent from "../../utils/createTestCaseComponent";
@@ -27,4 +25,4 @@ let NewUpdateTest = createTestCaseComponent(
   }
 );
 
-export default NewUpdateTest;
+module.exports = NewUpdateTest;

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/CheckForUpdateTests/testcases/NoRemotePackageTest.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/CheckForUpdateTests/testcases/NoRemotePackageTest.js
@@ -28,4 +28,4 @@ let NoRemotePackageTest = createTestCaseComponent(
   }
 );
 
-export default NoRemotePackageTest;
+module.exports = NoRemotePackageTest;

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/CheckForUpdateTests/testcases/RemotePackageAppVersionNewerTest.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/CheckForUpdateTests/testcases/RemotePackageAppVersionNewerTest.js
@@ -28,4 +28,4 @@ let RemotePackageAppVersionNewerTest = createTestCaseComponent(
   }
 );
 
-export default RemotePackageAppVersionNewerTest;
+module.exports = RemotePackageAppVersionNewerTest;

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/CheckForUpdateTests/testcases/SamePackageTest.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/CheckForUpdateTests/testcases/SamePackageTest.js
@@ -28,4 +28,4 @@ let SamePackageTest = createTestCaseComponent(
   }
 );
 
-export default SamePackageTest;
+module.exports = SamePackageTest;

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/CheckForUpdateTests/testcases/SwitchDeploymentKeyTest.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/CheckForUpdateTests/testcases/SwitchDeploymentKeyTest.js
@@ -29,4 +29,4 @@ let SwitchDeploymentKeyTest = createTestCaseComponent(
   }
 );
 
-export default SwitchDeploymentKeyTest;
+module.exports = SwitchDeploymentKeyTest;

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/DownloadProgressTests/resources/TestPackages.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/DownloadProgressTests/resources/TestPackages.js
@@ -44,4 +44,4 @@ packages.forEach((aPackage) => {
   }
 });
 
-export default packages;
+module.exports = packages;

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/DownloadProgressTests/testcases/DownloadProgressTest.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/DownloadProgressTests/testcases/DownloadProgressTest.js
@@ -50,4 +50,4 @@ let DownloadProgressTest = createTestCaseComponent(
   }
 );
 
-export default DownloadProgressTest;
+module.exports = DownloadProgressTest;

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/resources/remotePackage.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/InstallUpdateTests/resources/remotePackage.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   deploymentKey: "myKey123",
   description: "Angry flappy birds",
   appVersion: "1.5.0",

--- a/Examples/CodePushDemoApp/CodePushDemoAppTests/utils/mockAcquisitionSdk.js
+++ b/Examples/CodePushDemoApp/CodePushDemoAppTests/utils/mockAcquisitionSdk.js
@@ -13,12 +13,12 @@ function createMockAcquisitionSdk(serverPackage, localPackage, expectedDeploymen
     callback(/*err:*/ null, serverPackage);
   };
   
-  AcquisitionManager.prototype.reportStatusDeploy = (package, status, callback) => {
+  AcquisitionManager.prototype.reportStatusDeploy = (deployedPackage, status, callback) => {
     // No-op and return success.
     callback(null, null);
   };
   
-  AcquisitionManager.prototype.reportStatusDownload = (package, callback) => {
+  AcquisitionManager.prototype.reportStatusDownload = (downloadedPackage, callback) => {
     // No-op and return success.
     callback(null, null);
   };


### PR DESCRIPTION
Tiny PR, fixes some issues caused by the latest RN dependency version of Babel not being happy with the use of "export default" and the "package" keyword.