### PR TITLE
Removing the NDK section from our build.gradle file

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -9,10 +9,8 @@ android {
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"
-        ndk {
-            abiFilters "armeabi-v7a", "x86"
-        }
     }
+    
     buildTypes {
         release {
             minifyEnabled false


### PR DESCRIPTION
Our plugin doesn't include any C++ code so we shouldn't need to specify any NDK config of our own. We had a user report issues with integrating CodePush into their NDK app, and it was because of the superflous `android.defaultConfig.ndk` section in our `build.grade` file. This fixes that issue by simply removing it entirely, since we don't actually need it.