### PR TITLE
Fix getCurrentPackage

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -27,7 +27,7 @@ async function checkForUpdate(deploymentKey = null) {
    */
   const config = deploymentKey ? { ...nativeConfig, ...{ deploymentKey } } : nativeConfig;
   const sdk = getPromisifiedSdk(requestFetchAdapter, config);
-  
+
   // Use dynamically overridden getCurrentPackage() during tests.
   const localPackage = await module.exports.getCurrentPackage();
   
@@ -57,7 +57,7 @@ async function checkForUpdate(deploymentKey = null) {
    *    bug in the server, but we're adding this check just to double-check that the
    *    client app is resilient to a potential issue with the update check.
    */
-  if (!update || update.updateAppVersion || (update.packageHash === localPackage.packageHash)) {
+  if (!update || update.updateAppVersion || localPackage && (update.packageHash === localPackage.packageHash)) {
     if (update && update.updateAppVersion) {
       log("An update is available but it is targeting a newer binary version than you are currently running.");
     }
@@ -87,8 +87,10 @@ const getConfiguration = (() => {
 
 async function getCurrentPackage() {
   const localPackage = await NativeCodePush.getCurrentPackage();
-  localPackage.failedInstall = await NativeCodePush.isFailedUpdate(localPackage.packageHash);
-  localPackage.isFirstRun = await NativeCodePush.isFirstRun(localPackage.packageHash);
+  if (localPackage) {
+      localPackage.failedInstall = await NativeCodePush.isFailedUpdate(localPackage.packageHash);
+      localPackage.isFirstRun = await NativeCodePush.isFirstRun(localPackage.packageHash);
+  }
   return localPackage;
 }
 

--- a/CodePush.m
+++ b/CodePush.m
@@ -462,6 +462,7 @@ RCT_EXPORT_METHOD(getCurrentPackage:(RCTPromiseResolveBlock)resolve
     
     if (error) {
         reject([NSString stringWithFormat: @"%lu", (long)error.code], error.localizedDescription, error);
+        return;
     }
     
     // Add the "isPending" virtual property to the package at this point, so that

--- a/CodePushPackage.m
+++ b/CodePushPackage.m
@@ -211,9 +211,7 @@ NSString * const UnzippedFolderName = @"unzipped";
                                   withIntermediateDirectories:YES
                                                    attributes:nil
                                                         error:&error];
-    }
-    
-    if ([[NSFileManager defaultManager] fileExistsAtPath:newPackageFolderPath]) {
+    } else if ([[NSFileManager defaultManager] fileExistsAtPath:newPackageFolderPath]) {
         // This removes any stale data in newPackageFolderPath that could have been left
         // uncleared due to a crash or error during the download or install process.
         [[NSFileManager defaultManager] removeItemAtPath:newPackageFolderPath

--- a/CodePushPackage.m
+++ b/CodePushPackage.m
@@ -206,16 +206,16 @@ NSString * const UnzippedFolderName = @"unzipped";
     NSString *newPackageFolderPath = [self getPackageFolderPath:updatePackage[@"packageHash"]];
     NSError *error;
     
-    if (![[NSFileManager defaultManager] fileExistsAtPath:[self getCodePushPath]]) {
-        [[NSFileManager defaultManager] createDirectoryAtPath:[self getCodePushPath]
-                                  withIntermediateDirectories:YES
-                                                   attributes:nil
-                                                        error:&error];
-    } else if ([[NSFileManager defaultManager] fileExistsAtPath:newPackageFolderPath]) {
+    if ([[NSFileManager defaultManager] fileExistsAtPath:newPackageFolderPath]) {
         // This removes any stale data in newPackageFolderPath that could have been left
         // uncleared due to a crash or error during the download or install process.
         [[NSFileManager defaultManager] removeItemAtPath:newPackageFolderPath
                                                    error:&error];
+    } else if (![[NSFileManager defaultManager] fileExistsAtPath:[self getCodePushPath]]) {
+        [[NSFileManager defaultManager] createDirectoryAtPath:[self getCodePushPath]
+                                  withIntermediateDirectories:YES
+                                                   attributes:nil
+                                                        error:&error];
     }
     
     if (error) {

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -411,6 +411,10 @@ public class CodePush {
                 @Override
                 protected Void doInBackground(Object... params) {
                     WritableMap currentPackage = codePushPackage.getCurrentPackage();
+                    if (currentPackage == null) {
+                        promise.resolve("");
+                        return null;
+                    }
 
                     Boolean isPendingUpdate = false;
 

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushPackage.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushPackage.java
@@ -129,14 +129,14 @@ public class CodePushPackage {
     public WritableMap getCurrentPackage() {
         String folderPath = getCurrentPackageFolderPath();
         if (folderPath == null) {
-            return new WritableNativeMap();
+            return null;
         }
 
         String packagePath = CodePushUtils.appendPathComponent(folderPath, PACKAGE_FILE_NAME);
         try {
             return CodePushUtils.getWritableMapFromFile(packagePath);
         } catch (IOException e) {
-            // There is no current package.
+            // Should not happen unless the update metadata was somehow deleted.
             return null;
         }
     }
@@ -155,6 +155,12 @@ public class CodePushPackage {
                                 DownloadProgressCallback progressCallback) throws IOException {
 
         String newPackageFolderPath = getPackageFolderPath(CodePushUtils.tryGetString(updatePackage, PACKAGE_HASH_KEY));
+        if (FileUtils.fileAtPathExists(newPackageFolderPath)) {
+            // This removes any stale data in newPackageFolderPath that could have been left
+            // uncleared due to a crash or error during the download or install process.
+            FileUtils.deleteDirectoryAtPath(newPackageFolderPath);
+        }
+
         String downloadUrlString = CodePushUtils.tryGetString(updatePackage, DOWNLOAD_URL_KEY);
         URL downloadUrl = null;
         HttpURLConnection connection = null;


### PR DESCRIPTION
When the native `getCurrentPackage` API rejects the promise, it does not return from the function, resulting in the `Callback with id xx: CodePush.getCurrentPackage() not found` errors reported in https://github.com/Microsoft/react-native-code-push/issues/195 and https://github.com/Microsoft/react-native-code-push/issues/182.

More investigation needs to be done to ascertain why the promise gets rejected in the first place, e.g. why the `app.json` file could go missing with the rest of the files in the update folder still remains intact.

This PR also modifies the `downloadUpdate` native APIs to clear away any existing files in a new update folder in order to prevent any chance of an update being corrupted. Also, on iOS, this changes `downloadUpdate` to use the `NSFileManager`'s `copyItemAtPath` method instead of the custom copy method when copying from an old update to a new one in the case of a diff update, with the assumption that the stock Objective-C API is more reliable.