### PR TITLE
Removing JS bundle modified date mutation

### DIFF
--- a/ios/CodePush/CodePushPackage.m
+++ b/ios/CodePush/CodePushPackage.m
@@ -331,23 +331,7 @@ NSString * const UnzippedFolderName = @"unzipped";
                     return;
                 }
                 
-                if (relativeBundlePath) {
-                    NSString *absoluteBundlePath = [newUpdateFolderPath stringByAppendingPathComponent:relativeBundlePath];
-                    NSDictionary *bundleFileAttributes = [[[NSFileManager defaultManager] attributesOfItemAtPath:absoluteBundlePath error:&error] mutableCopy];
-                    if (error) {
-                        failCallback(error);
-                        return;
-                    }
-                    
-                    [bundleFileAttributes setValue:[NSDate date] forKey:NSFileModificationDate];
-                    [[NSFileManager defaultManager] setAttributes:bundleFileAttributes
-                                                     ofItemAtPath:absoluteBundlePath
-                                                            error:&error];
-                    if (error) {
-                        failCallback(error);
-                        return;
-                    }
-                    
+                if (relativeBundlePath) {                    
                     [mutableUpdatePackage setValue:relativeBundlePath forKey:RelativeBundlePathKey];
                 } else {
                     error = [[NSError alloc] initWithDomain:CodePushErrorDomain


### PR DESCRIPTION
This PR removes the logic which explicitly sets the modified date of the JS bundle file when installing a ZIP update. This behavior was originally needed to determine precedence between a CodePush update and the binary contents, but we actually stopped relying on this a while ago, and therefore, it isn't necessary.

Additionally, this behavior causes an issue when the user releases an update whose JS bundle is read-only, and therefore, we can't mutate. By removing this logic, we can accommodate that scenario.