### PR TITLE
Make loading our JS module more permissive

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -27,6 +27,7 @@ async function checkForUpdate(deploymentKey = null) {
    * deployments (e.g. an early access deployment for insiders).
    */
   const config = deploymentKey ? { ...nativeConfig, ...{ deploymentKey } } : nativeConfig;
+  
   const sdk = getPromisifiedSdk(requestFetchAdapter, config);
 
   // Use dynamically overridden getCurrentPackage() during tests.
@@ -368,42 +369,52 @@ async function syncInternal(options = {}, syncStatusChangeCallback, downloadProg
   } 
 };
 
-const CodePush = {
-  AcquisitionSdk: Sdk,
-  checkForUpdate,
-  getConfiguration,
-  getCurrentPackage,
-  log,
-  notifyApplicationReady,
-  restartApp,
-  setUpTestDependencies,
-  sync,
-  InstallMode: {
-    IMMEDIATE: NativeCodePush.codePushInstallModeImmediate, // Restart the app immediately
-    ON_NEXT_RESTART: NativeCodePush.codePushInstallModeOnNextRestart, // Don't artificially restart the app. Allow the update to be "picked up" on the next app restart
-    ON_NEXT_RESUME: NativeCodePush.codePushInstallModeOnNextResume // Restart the app the next time it is resumed from the background
-  },
-  SyncStatus: {
-    CHECKING_FOR_UPDATE: 0,
-    AWAITING_USER_ACTION: 1,
-    DOWNLOADING_PACKAGE: 2,
-    INSTALLING_UPDATE: 3,
-    UP_TO_DATE: 4, // The running app is up-to-date
-    UPDATE_IGNORED: 5, // The app had an optional update and the end-user chose to ignore it
-    UPDATE_INSTALLED: 6, // The app had an optional/mandatory update that was successfully downloaded and is about to be installed.
-    SYNC_IN_PROGRESS: 7, // There is an ongoing "sync" operation in progress.
-    UNKNOWN_ERROR: -1
-  },
-  DEFAULT_UPDATE_DIALOG: {
-    appendReleaseDescription: false,
-    descriptionPrefix: " Description: ",
-    mandatoryContinueButtonLabel: "Continue",
-    mandatoryUpdateMessage: "An update is available that must be installed.",
-    optionalIgnoreButtonLabel: "Ignore",
-    optionalInstallButtonLabel: "Install",
-    optionalUpdateMessage: "An update is available. Would you like to install it?",
-    title: "Update available"
-  }
-};
+let CodePush;
+
+// If the "NativeCodePush" variable isn't defined, then 
+// the app didn't properly install the native module,
+// and therefore, it doesn't make sense initializing 
+// the the JS interface when it wouldn't work anyways.
+if (NativeCodePush) {
+    CodePush = {
+        AcquisitionSdk: Sdk,
+        checkForUpdate,
+        getConfiguration,
+        getCurrentPackage,
+        log,
+        notifyApplicationReady,
+        restartApp,
+        setUpTestDependencies,
+        sync,
+        InstallMode: {
+            IMMEDIATE: NativeCodePush.codePushInstallModeImmediate, // Restart the app immediately
+            ON_NEXT_RESTART: NativeCodePush.codePushInstallModeOnNextRestart, // Don't artificially restart the app. Allow the update to be "picked up" on the next app restart
+            ON_NEXT_RESUME: NativeCodePush.codePushInstallModeOnNextResume // Restart the app the next time it is resumed from the background
+        },
+        SyncStatus: {
+            CHECKING_FOR_UPDATE: 0,
+            AWAITING_USER_ACTION: 1,
+            DOWNLOADING_PACKAGE: 2,
+            INSTALLING_UPDATE: 3,
+            UP_TO_DATE: 4, // The running app is up-to-date
+            UPDATE_IGNORED: 5, // The app had an optional update and the end-user chose to ignore it
+            UPDATE_INSTALLED: 6, // The app had an optional/mandatory update that was successfully downloaded and is about to be installed.
+            SYNC_IN_PROGRESS: 7, // There is an ongoing "sync" operation in progress.
+            UNKNOWN_ERROR: -1
+        },
+        DEFAULT_UPDATE_DIALOG: {
+            appendReleaseDescription: false,
+            descriptionPrefix: " Description: ",
+            mandatoryContinueButtonLabel: "Continue",
+            mandatoryUpdateMessage: "An update is available that must be installed.",
+            optionalIgnoreButtonLabel: "Ignore",
+            optionalInstallButtonLabel: "Install",
+            optionalUpdateMessage: "An update is available. Would you like to install it?",
+            title: "Update available"
+        }
+    }
+} else {
+    log("The CodePush module doesn't appear to be properly installed. Please double-check that everything is setup correctly.");
+}
 
 module.exports = CodePush;

--- a/CodePush.js
+++ b/CodePush.js
@@ -27,7 +27,6 @@ async function checkForUpdate(deploymentKey = null) {
    * deployments (e.g. an early access deployment for insiders).
    */
   const config = deploymentKey ? { ...nativeConfig, ...{ deploymentKey } } : nativeConfig;
-  
   const sdk = getPromisifiedSdk(requestFetchAdapter, config);
 
   // Use dynamically overridden getCurrentPackage() during tests.

--- a/CodePush.js
+++ b/CodePush.js
@@ -413,7 +413,7 @@ if (NativeCodePush) {
         }
     }
 } else {
-    log("The CodePush module doesn't appear to be properly installed Please double-check that everything is setup correctly.");
+    log("The CodePush module doesn't appear to be properly installed. Please double-check that everything is setup correctly.");
 }
 
 module.exports = CodePush;

--- a/CodePush.js
+++ b/CodePush.js
@@ -373,7 +373,7 @@ let CodePush;
 // If the "NativeCodePush" variable isn't defined, then 
 // the app didn't properly install the native module,
 // and therefore, it doesn't make sense initializing 
-// the the JS interface when it wouldn't work anyways.
+// the JS interface when it wouldn't work anyways.
 if (NativeCodePush) {
     CodePush = {
         AcquisitionSdk: Sdk,
@@ -413,7 +413,7 @@ if (NativeCodePush) {
         }
     }
 } else {
-    log("The CodePush module doesn't appear to be properly installed. Please double-check that everything is setup correctly.");
+    log("The CodePush module doesn't appear to be properly installed Please double-check that everything is setup correctly.");
 }
 
 module.exports = CodePush;


### PR DESCRIPTION
Currently, simply `import`ing or `require`ing the `react-native-code-push` JS module requires that the native-end of the module also be fully installed/initialized. This change simply removes this dependency by only constructing the JS API in the event that the native module was initialized, which allows an app to load our module without getting a cryptic error. This addresses issue #214.

If an app tried to access any members on the module export (e.g. `codePush.sync()`), without the native module being installed properly or initialized, that would still error out, but at least it would be a more intuitive/explicit action that led to the error, as opposed to simply importing the module, which is arguably weird to have result in an app crash.

Additionally, I added some new logging in the event that the native module isn't initialized, which should allow for easier diagnostics when users haven't properly installed the plugin.