### PR TITLE
Fixing Podspec for Swift consumption

### DIFF
--- a/CodePush.podspec
+++ b/CodePush.podspec
@@ -1,16 +1,17 @@
 Pod::Spec.new do |s|
 
-  s.name             = 'CodePush'
-  s.version          = '1.7.3-beta'
-  s.summary          = 'React Native plugin for the CodePush service'
-  s.author           = 'Microsoft Corporation'
-  s.license          = 'MIT'
-  s.homepage         = 'http://microsoft.github.io/code-push/'
-  s.source           = { :git => 'https://github.com/Microsoft/react-native-code-push.git', :tag => "v#{s.version}" }
-  s.platform         = :ios, '7.0'
-  s.source_files     = '*.{h,m}', 'SSZipArchive/*.{h,m}', 'SSZipArchive/aes/*.{h,c}', 'SSZipArchive/minizip/*.{h,c}'
-  s.preserve_paths   = '*.js'
-  s.library          = 'z'
+  s.name                = 'CodePush'
+  s.version             = '1.7.4-beta'
+  s.summary             = 'React Native plugin for the CodePush service'
+  s.author              = 'Microsoft Corporation'
+  s.license             = 'MIT'
+  s.homepage            = 'http://microsoft.github.io/code-push/'
+  s.source              = { :git => 'https://github.com/Microsoft/react-native-code-push.git', :tag => "v#{s.version}" }
+  s.platform            = :ios, '7.0'
+  s.source_files        = 'ios/CodePush/*.{h,m}', 'ios/CodePush/SSZipArchive/*.{h,m}', 'ios/CodePush/SSZipArchive/aes/*.{h,c}', 'ios/CodePush/SSZipArchive/minizip/*.{h,c}'
+  s.public_header_files = 'ios/CodePush/CodePush.h'
+  s.preserve_paths      = '*.js'
+  s.library             = 'z'
   s.dependency 'React'
 
 end

--- a/ios/CodePush/CodePush.h
+++ b/ios/CodePush/CodePush.h
@@ -1,6 +1,6 @@
-#import "RCTBridgeModule.h"
+#import <Foundation/Foundation.h>
 
-@interface CodePush : NSObject <RCTBridgeModule>
+@interface CodePush : NSObject
 
 + (NSURL *)binaryBundleURL;
 /*

--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -6,6 +6,9 @@
 
 #import "CodePush.h"
 
+@interface CodePush () <RCTBridgeModule>
+@end
+
 @implementation CodePush {
     BOOL _hasResumeListener;
     BOOL _isFirstRunAfterUpdate;


### PR DESCRIPTION
This fixes #226 by making the following changes:

1. Moves the use of the `RCTBridgeModule` protocol from the public interface of our `CodePush` class, to the private implementation (via a class extension). This allows the class to have the same behavior, but the public header no longer needs to import `RCTBridgeModule.h`, which doesn't work when we are built as a framework via CocoaPods (since frameworks can't use quoted imports to headers that aren't embedded within them)

2. Explicitly sets the public header in our Podspec, so that CocoaPods doesn't include the SSArchive headers into it when it generates the module map when building as a framework

Additionally, unrelated to this bug, I updated the Podspec to accomodate the Xcode project refactoring we did, and I also bumped the version for our upcoming release.