### PR TITLE
Removing .done call

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -218,8 +218,7 @@ const sync = (() => {
     const syncPromise = syncInternal(options, syncStatusChangeCallback, downloadProgressCallback);
     syncPromise
       .then(setSyncCompleted)
-      .catch(setSyncCompleted)
-      .done();
+      .catch(setSyncCompleted);
 
     return syncPromise;
   };


### PR DESCRIPTION
`Promise.prototype.done` is not part of the ES6 spec, and therefore, we shouldn't rely on it's presence unless we really need it. In this case, we actually don't need to call `done` since our resolve/reject handler will already get called successfully, and we're not expecting any unhandled exceptions to occur within them that would get otherwise "swallowed". Now that React Native displays unhandled promise rejections via the yellow box during development, this is less of an issue anyways, and the value of `done` is becoming smaller.

This change is motivated by a user-report on Discord, where our use of `done` threw an exception because the user had replaced the standard React Native `Promise` polypill with their own. While this doesn't seem like a common scenario, we should ideally be a future-proof as possible, and since we don't need `done` anyways, and we know it isn't standard, we mine as well just removed our dependency on it.