### PR TITLE
Remove unnecessary dependency from codepush.gradle

### DIFF
--- a/android/codepush.gradle
+++ b/android/codepush.gradle
@@ -59,7 +59,6 @@ gradle.projectsEvaluated {
             runBefore("processX86${targetName}Resources", generateBundledResourcesHash)
             runBefore("processUniversal${targetName}Resources", generateBundledResourcesHash)
             runBefore("process${targetName}Resources", generateBundledResourcesHash)
-            runBefore("process${targetName}Manifest", generateBundledResourcesHash)
         }
     }
 }


### PR DESCRIPTION
This dependency is not needed. It is not used by the RN build. https://github.com/facebook/react-native/blob/master/local-cli/generator-android/templates/src/app/react.gradle#L91