### PR TITLE
Fixing minimumBackgroundDuration on iOS

### DIFF
--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -531,6 +531,7 @@ RCT_EXPORT_METHOD(getCurrentPackage:(RCTPromiseResolveBlock)resolve
  */
 RCT_EXPORT_METHOD(installUpdate:(NSDictionary*)updatePackage
                     installMode:(CodePushInstallMode)installMode
+      minimumBackgroundDuration:(int)minimumBackgroundDuration
                        resolver:(RCTPromiseResolveBlock)resolve
                        rejecter:(RCTPromiseRejectBlock)reject)
 {


### PR DESCRIPTION
I have no clue how this got removed in my previous PR, so this simply fixes the method signature.