### PR TITLE
Upgrading SDK dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/Microsoft/react-native-code-push"
   },
   "dependencies": {
-    "code-push": "1.5.2-beta"
+    "code-push": "1.7.0-beta"
   },
   "devDependencies": {
     "react-native": "0.19.0"


### PR DESCRIPTION
Simply upgrading our SDK dependency, which among other things, removes the transitive dependency on the GitHub-based `superagent` version. Issue #237 could still exist depending on the developer's network conditions, but we mine as well consolidate the number of locations that dependencies are pulled from to just NPM.