### PR TITLE
Simplify JS bundle discovery strategy

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -365,7 +365,7 @@ public class CodePush {
                     try {
                         WritableMap mutableUpdatePackage = CodePushUtils.convertReadableMapToWritableMap(updatePackage);
                         mutableUpdatePackage.putString(BINARY_MODIFIED_TIME_KEY, "" + getBinaryResourcesModifiedTime());
-                        codePushPackage.downloadPackage(applicationContext, mutableUpdatePackage, new DownloadProgressCallback() {
+                        codePushPackage.downloadPackage(applicationContext, mutableUpdatePackage, CodePush.this.assetsBundleFileName, new DownloadProgressCallback() {
                             @Override
                             public void call(DownloadProgress downloadProgress) {
                                 getReactApplicationContext()

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushPackage.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushPackage.java
@@ -151,7 +151,7 @@ public class CodePushPackage {
         }
     }
 
-    public void downloadPackage(Context applicationContext, ReadableMap updatePackage,
+    public void downloadPackage(Context applicationContext, ReadableMap updatePackage, String expectedBundleFileName,
                                 DownloadProgressCallback progressCallback) throws IOException {
         String newUpdateHash = CodePushUtils.tryGetString(updatePackage, PACKAGE_HASH_KEY);
         String newUpdateFolderPath = getPackageFolderPath(newUpdateHash);
@@ -243,7 +243,7 @@ public class CodePushPackage {
 
             // For zip updates, we need to find the relative path to the jsBundle and save it in the
             // metadata so that we can find and run it easily the next time.
-            String relativeBundlePath = CodePushUpdateUtils.findJSBundleInUpdateContents(newUpdateFolderPath);
+            String relativeBundlePath = CodePushUpdateUtils.findJSBundleInUpdateContents(newUpdateFolderPath, expectedBundleFileName);
 
             if (relativeBundlePath == null) {
                 throw new CodePushInvalidUpdateException("Update is invalid - no files with extension .bundle, .js or .jsbundle were found in the update package.");

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateUtils.java
@@ -79,24 +79,20 @@ public class CodePushUpdateUtils {
         }
     }
 
-    public static String findJSBundleInUpdateContents(String folderPath) {
+    public static String findJSBundleInUpdateContents(String folderPath, String expectedFileName) {
         File folder = new File(folderPath);
         File[] folderFiles = folder.listFiles();
         for (File file : folderFiles) {
             String fullFilePath = CodePushUtils.appendPathComponent(folderPath, file.getName());
             if (file.isDirectory()) {
-                String mainBundlePathInSubFolder = findJSBundleInUpdateContents(fullFilePath);
+                String mainBundlePathInSubFolder = findJSBundleInUpdateContents(fullFilePath, expectedFileName);
                 if (mainBundlePathInSubFolder != null) {
                     return CodePushUtils.appendPathComponent(file.getName(), mainBundlePathInSubFolder);
                 }
             } else {
                 String fileName = file.getName();
-                int dotIndex = fileName.lastIndexOf(".");
-                if (dotIndex >= 0) {
-                    String fileExtension = fileName.substring(dotIndex + 1);
-                    if (fileExtension.equals("bundle") || fileExtension.equals("js") || fileExtension.equals("jsbundle")) {
-                        return fileName;
-                    }
+                if (fileName.equals(expectedFileName)) {
+                    return fileName;
                 }
             }
         }

--- a/ios/CodePush/CodePush.h
+++ b/ios/CodePush/CodePush.h
@@ -70,6 +70,7 @@ failCallback:(void (^)(NSError *err))failCallback;
 @interface CodePushPackage : NSObject
 
 + (void)downloadPackage:(NSDictionary *)updatePackage
+ expectedBundleFileName:(NSString *)expectedBundleFileName
        progressCallback:(void (^)(long long, long long))progressCallback
            doneCallback:(void (^)())doneCallback
            failCallback:(void (^)(NSError *err))failCallback;
@@ -113,6 +114,7 @@ failCallback:(void (^)(NSError *err))failCallback;
                       error:(NSError **)error;
 
 + (NSString *)findMainBundleInFolder:(NSString *)folderPath
+                    expectedFileName:(NSString *)expectedFileName
                                error:(NSError **)error;
 
 + (NSString *)assetsFolderName;

--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -419,7 +419,9 @@ RCT_EXPORT_METHOD(downloadUpdate:(NSDictionary*)updatePackage
                                 forKey:BinaryBundleDateKey];
     }
     
-    [CodePushPackage downloadPackage:mutableUpdatePackage
+    [CodePushPackage
+        downloadPackage:mutableUpdatePackage
+        expectedBundleFileName:[bundleResourceName stringByAppendingPathExtension:bundleResourceExtension]
         // The download is progressing forward
         progressCallback:^(long long expectedContentLength, long long receivedContentLength) {
             dispatch_async(_methodQueue, ^{

--- a/ios/CodePush/CodePushPackage.m
+++ b/ios/CodePush/CodePushPackage.m
@@ -205,6 +205,7 @@ NSString * const UnzippedFolderName = @"unzipped";
 }
 
 + (void)downloadPackage:(NSDictionary *)updatePackage
+ expectedBundleFileName:(NSString *)expectedBundleFileName
        progressCallback:(void (^)(long long, long long))progressCallback
            doneCallback:(void (^)())doneCallback
            failCallback:(void (^)(NSError *err))failCallback
@@ -360,7 +361,9 @@ NSString * const UnzippedFolderName = @"unzipped";
                 }
                 
                 NSString *relativeBundlePath = [CodePushUpdateUtils findMainBundleInFolder:newUpdateFolderPath
+                                                                          expectedFileName:expectedBundleFileName
                                                                                      error:&error];
+                
                 if (error) {
                     failCallback(error);
                     return;

--- a/ios/CodePush/CodePushUpdateUtils.m
+++ b/ios/CodePush/CodePushUpdateUtils.m
@@ -118,6 +118,7 @@ NSString * const ManifestFolderPrefix = @"CodePush";
 }
 
 + (NSString *)findMainBundleInFolder:(NSString *)folderPath
+                    expectedFileName:(NSString *)expectedFileName
                                error:(NSError **)error
 {
     NSArray* folderFiles = [[NSFileManager defaultManager]
@@ -132,7 +133,9 @@ NSString * const ManifestFolderPrefix = @"CodePush";
         BOOL isDir = NO;
         if ([[NSFileManager defaultManager] fileExistsAtPath:fullFilePath
                                                  isDirectory:&isDir] && isDir) {
-            NSString *mainBundlePathInFolder = [self findMainBundleInFolder:fullFilePath error:error];
+            NSString *mainBundlePathInFolder = [self findMainBundleInFolder:fullFilePath
+                                                           expectedFileName:expectedFileName
+                                                                      error:error];
             if (*error) {
                 return nil;
             }
@@ -140,9 +143,7 @@ NSString * const ManifestFolderPrefix = @"CodePush";
             if (mainBundlePathInFolder) {
                 return [fileName stringByAppendingPathComponent:mainBundlePathInFolder];
             }
-        } else if ([[fileName pathExtension] isEqualToString:@"bundle"] ||
-                   [[fileName pathExtension] isEqualToString:@"jsbundle"] ||
-                   [[fileName pathExtension] isEqualToString:@"js"]) {
+        } else if ([fileName isEqualToString:expectedFileName]) {
             return fileName;
         }
     }


### PR DESCRIPTION
This PR removes the "fuzzy logic" for locating the JS bundle in a downloaded update, and instead, looks for the exact same file name that the plugin already looks for in the binary. This simplifies things in the following ways:

1. Looking for `.js` files is potentially error prone, since we've seen cases where apps ship `WebView` hosted content, including `.js` files. We want to allow app devs to use `.js` instead of `.jsbundle`, but only if they explicitly tell us they are using that extension via `[CodePush bundleURLForResource:withExtension]`. If an app is configured to use `.jsbundle` files, it doesn't make sense for us to look for or consider `.js` files as valid app bundles.

2. Looking for the first file that uses any of these extensions makes it easier for our logic to have a false positive, if the update includes both `.js` and `.jsbundle` files.

3. If a dev wants to call their JS bundle file `foo.bar`, this change would allow it, since we're no longer restricted to a few extension types, as opposed to simply looking for the same file that was shipped with the binary

As long as everything uses the same bundle file name, then the E2E should be more reliable, while still being flexible enough to allow devs to configure a different name and/or extension when necessary.