### PR TITLE
Android code cleanup

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushDialog.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushDialog.java
@@ -11,7 +11,7 @@ import com.facebook.react.bridge.ReactMethod;
 
 public class CodePushDialog extends ReactContextBaseJavaModule{
 
-    Activity mainActivity;
+    private Activity mainActivity;
 
     public CodePushDialog(ReactApplicationContext reactContext, Activity mainActivity) {
         super(reactContext);

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushInstallMode.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushInstallMode.java
@@ -6,7 +6,7 @@ public enum CodePushInstallMode {
     ON_NEXT_RESUME(2);
 
     private final int value;
-    private CodePushInstallMode(int value) {
+    CodePushInstallMode(int value) {
         this.value = value;
     }
     public int getValue() {

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUnknownException.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUnknownException.java
@@ -1,6 +1,6 @@
 package com.microsoft.codepush.react;
 
-public class CodePushUnknownException extends RuntimeException {
+class CodePushUnknownException extends RuntimeException {
 
     public CodePushUnknownException(String message, Throwable cause) {
         super(message, cause);

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateUtils.java
@@ -115,7 +115,7 @@ public class CodePushUpdateUtils {
     }
 
     public static void verifyHashForDiffUpdate(String folderPath, String expectedHash) {
-        ArrayList<String> updateContentsManifest = new ArrayList<String>();
+        ArrayList<String> updateContentsManifest = new ArrayList<>();
         addContentsOfFolderToManifest(folderPath, "", updateContentsManifest);
         Collections.sort(updateContentsManifest);
         JSONArray updateContentsJSONArray = new JSONArray();

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUtils.java
@@ -15,29 +15,22 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.PrintWriter;
 import java.util.Iterator;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
 
 public class CodePushUtils {
 
-    public static final String CODE_PUSH_TAG = "CodePush";
     public static final String REACT_NATIVE_LOG_TAG = "ReactNative";
 
     public static String appendPathComponent(String basePath, String appendPathComponent) {
         return new File(basePath, appendPathComponent).getAbsolutePath();
     }
 
-    public static WritableArray convertJsonArrayToWriteable(JSONArray jsonArr) {
+    public static WritableArray convertJsonArrayToWritable(JSONArray jsonArr) {
         WritableArray arr = Arguments.createArray();
         for (int i=0; i<jsonArr.length(); i++) {
             Object obj = null;
@@ -49,9 +42,9 @@ public class CodePushUtils {
             }
 
             if (obj instanceof JSONObject)
-                arr.pushMap(convertJsonObjectToWriteable((JSONObject) obj));
+                arr.pushMap(convertJsonObjectToWritable((JSONObject) obj));
             else if (obj instanceof JSONArray)
-                arr.pushArray(convertJsonArrayToWriteable((JSONArray) obj));
+                arr.pushArray(convertJsonArrayToWritable((JSONArray) obj));
             else if (obj instanceof String)
                 arr.pushString((String) obj);
             else if (obj instanceof Double)
@@ -69,7 +62,7 @@ public class CodePushUtils {
         return arr;
     }
 
-    public static WritableMap convertJsonObjectToWriteable(JSONObject jsonObj) {
+    public static WritableMap convertJsonObjectToWritable(JSONObject jsonObj) {
         WritableMap map = Arguments.createMap();
         Iterator<String> it = jsonObj.keys();
         while(it.hasNext()){
@@ -83,9 +76,9 @@ public class CodePushUtils {
             }
 
             if (obj instanceof JSONObject)
-                map.putMap(key, convertJsonObjectToWriteable((JSONObject) obj));
+                map.putMap(key, convertJsonObjectToWritable((JSONObject) obj));
             else if (obj instanceof JSONArray)
-                map.putArray(key, convertJsonArrayToWriteable((JSONArray) obj));
+                map.putArray(key, convertJsonArrayToWritable((JSONArray) obj));
             else if (obj instanceof String)
                 map.putString(key, (String) obj);
             else if (obj instanceof Double)
@@ -105,7 +98,7 @@ public class CodePushUtils {
 
     public static WritableMap convertReadableMapToWritableMap(ReadableMap map) {
         JSONObject mapJSON = convertReadableToJsonObject(map);
-        return convertJsonObjectToWriteable(mapJSON);
+        return convertJsonObjectToWritable(mapJSON);
     }
 
     public static JSONArray convertReadableToJsonArray(ReadableArray arr) {
@@ -204,16 +197,13 @@ public class CodePushUtils {
     }
 
     public static WritableMap getWritableMapFromFile(String filePath) throws IOException {
-
         String content = FileUtils.readFileToString(filePath);
-        JSONObject json = null;
         try {
-            json = new JSONObject(content);
-            return convertJsonObjectToWriteable(json);
+            JSONObject json = new JSONObject(content);
+            return convertJsonObjectToWritable(json);
         } catch (JSONException jsonException) {
             throw new CodePushMalformedDataException(filePath, jsonException);
         }
-
     }
 
     public static void log(String message) {

--- a/android/app/src/main/java/com/microsoft/codepush/react/DownloadProgress.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/DownloadProgress.java
@@ -3,9 +3,9 @@ package com.microsoft.codepush.react;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
 
-public class DownloadProgress {
-    public long totalBytes;
-    public long receivedBytes;
+class DownloadProgress {
+    private long totalBytes;
+    private long receivedBytes;
 
     public DownloadProgress (long totalBytes, long receivedBytes){
         this.totalBytes = totalBytes;

--- a/android/app/src/main/java/com/microsoft/codepush/react/DownloadProgressCallback.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/DownloadProgressCallback.java
@@ -1,5 +1,5 @@
 package com.microsoft.codepush.react;
 
-public interface DownloadProgressCallback {
+interface DownloadProgressCallback {
     void call(DownloadProgress downloadProgress);
 }

--- a/android/app/src/main/java/com/microsoft/codepush/react/FileUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/FileUtils.java
@@ -9,12 +9,11 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 
 public class FileUtils {
 
-    public static final int WRITE_BUFFER_SIZE = 1024 * 8;
+    private static final int WRITE_BUFFER_SIZE = 1024 * 8;
 
     public static void copyDirectoryContents(String sourceDirectoryPath, String destinationDirectoryPath) throws IOException {
         File sourceDir = new File(sourceDirectoryPath);
@@ -55,21 +54,16 @@ public class FileUtils {
         }
     }
 
-    public static boolean createFolderAtPath(String filePath) {
-        File file = new File(filePath);
-        return file.mkdir();
-    }
-
     public static void deleteDirectory(File directory) {
         if (directory.exists()) {
             File[] files = directory.listFiles();
             if (files != null) {
-                for (int i=0; i<files.length; i++) {
-                    if(files[i].isDirectory()) {
-                        deleteDirectory(files[i]);
+                for (File file : files) {
+                    if(file.isDirectory()) {
+                        deleteDirectory(file);
                     }
                     else {
-                        files[i].delete();
+                        file.delete();
                     }
                 }
             }
@@ -88,12 +82,12 @@ public class FileUtils {
     public static void deleteFileOrFolderSilently(File file) {
         if (file.isDirectory()) {
             File[] files = file.listFiles();
-            for (int i = 0; i < files.length; i++) {
-                if (files[i].isDirectory()) {
-                    deleteFileOrFolderSilently(files[i]);
+            for (File fileEntry : files) {
+                if (fileEntry.isDirectory()) {
+                    deleteFileOrFolderSilently(fileEntry);
                 } else {
                     if (!file.delete()) {
-                        files[i].delete();
+                        fileEntry.delete();
                     }
                 }
             }


### PR DESCRIPTION
Gets rid of some lint warnings.

- spelling fixes (e.g "Writeable" -> "Writable")
- remove redundant variables
- make variable scoping tighter whenever possible
- prevent unchecked call to generic methods e.g. `AsyncTask` by explicitly declaring `AsyncTask<Void...>`
- make variables and methods private whenever possible