### PR TITLE
Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ After installing the plugin and syncing your Android Studio project with Gradle,
     }
     ```
     
-2. If you used RNPM to install/link the CodePush plugin, there are two additional changes you'll need to make due to the fact that RNPM makes some assumptions about the CodePush plugin that we don't currently support. If you're not using RNPM then simply skip to step #3:
+2. If you used RNPM to install/link the CodePush plugin, there are two additional changes you'll need to make due to the fact that RNPM makes some assumptions about 3rd party modules that we don't currently support. If you're not using RNPM then simply skip to step #3:
 
     ```java
     ...

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ After installing the plugin and syncing your Android Studio project with Gradle,
     }
     ```
     
-3. If you used RNPM to install/link the CodePush plugin, there are a two additional changes you'll need to make due to the fact thsat RNPM makes some assupmtions about the CodePush plugin that aren't currently true. Otherwise, skip to step #3:
+2. If you used RNPM to install/link the CodePush plugin, there are a two additional changes you'll need to make due to the fact thsat RNPM makes some assupmtions about the CodePush plugin that aren't currently true. Otherwise, skip to step #3:
 
     ```java
     ...
@@ -346,7 +346,7 @@ After installing the plugin and syncing your Android Studio project with Gradle,
     }
     ```
 
-2. Ensure that the `android.defaultConfig.versionName` property in your `android/app/build.gradle` file is set to a semver compliant value. Note that if the value provided is missing a patch version, the CodePush server will assume it is `0`, i.e. `1.0` will be treated as `1.0.0`.
+3. Ensure that the `android.defaultConfig.versionName` property in your `android/app/build.gradle` file is set to a semver compliant value. Note that if the value provided is missing a patch version, the CodePush server will assume it is `0`, i.e. `1.0` will be treated as `1.0.0`.
     
     ```gradle
     android {

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ After installing the plugin and syncing your Android Studio project with Gradle,
         ...
     }
     ```
-
+    
 ### Plugin Configuration (Android - React Native v0.18.0+)
 
 *NOTE: These instructions are specific to apps that are using React Native v0.18.0+. If you are using v0.15.0-v0.17.0, then refer to the previous section.*
@@ -321,6 +321,27 @@ After installing the plugin and syncing your Android Studio project with Gradle,
                 new MainReactPackage(), this._codePush.getReactPackage());
         }
 
+        ...
+    }
+    ```
+    
+3. If you used RNPM to install/link the CodePush plugin, there are a two additional changes you'll need to make due to the fact thsat RNPM makes some assupmtions about the CodePush plugin that aren't currently true. Otherwise, skip to step #3:
+
+    ```java
+    ...
+    // 1. Remove the following import statement
+    import com.microsoft.codepush.react.CodePushReactPackage;
+    ...
+    public class MainActivity extends ReactActivity {
+        ...
+        @Override
+        protected List<ReactPackage> getPackages() {
+            return Arrays.<ReactPackage>asList(
+                ...
+                new CodePushReactPackage() // 2. Remove this line
+                ...
+            );
+        }
         ...
     }
     ```

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ After installing the plugin and syncing your Android Studio project with Gradle,
     }
     ```
     
-2. If you used RNPM to install/link the CodePush plugin, there are a two additional changes you'll need to make due to the fact thsat RNPM makes some assupmtions about the CodePush plugin that aren't currently true. Otherwise, skip to step #3:
+2. If you used RNPM to install/link the CodePush plugin, there are two additional changes you'll need to make due to the fact that RNPM makes some assumptions about the CodePush plugin that we don't currently support. If you're not using RNPM then simply skip to step #3:
 
     ```java
     ...


### PR DESCRIPTION
This addresses #247 by adding the necessary detail to our Android installation steps for devs that are using RNPM. Hopefully we can remove these docs at some point, once we better support RNPM's assumptions, but until then, this is necessary.