### PR TITLE
Binary hash w/o assets

### DIFF
--- a/ios/CodePush/CodePushUpdateUtils.m
+++ b/ios/CodePush/CodePushUpdateUtils.m
@@ -175,15 +175,19 @@ NSString * const ManifestFolderPrefix = @"CodePush";
     }
     
     binaryHashDictionary = [NSMutableDictionary dictionary];
-    
-    NSString *assetsPath = [CodePushPackage getBinaryAssetsPath];
     NSMutableArray *manifest = [NSMutableArray array];
-    [self addContentsOfFolderToManifest:assetsPath
-                             pathPrefix:[NSString stringWithFormat:@"%@/%@", [self manifestFolderPrefix], @"assets"]
-                               manifest:manifest
-                                  error:error];
-    if (*error) {
-        return nil;
+    
+    // If the app is using assets, then add
+    // them to the generated content manifest.
+    NSString *assetsPath = [CodePushPackage getBinaryAssetsPath];
+    if ([[NSFileManager defaultManager] fileExistsAtPath:assetsPath]) {
+        [self addContentsOfFolderToManifest:assetsPath
+                                 pathPrefix:[NSString stringWithFormat:@"%@/%@", [self manifestFolderPrefix], @"assets"]
+                                   manifest:manifest
+                                      error:error];
+        if (*error) {
+            return nil;
+        }
     }
     
     NSData *jsBundleContents = [NSData dataWithContentsOfURL:binaryBundleUrl];


### PR DESCRIPTION
The binary hashing logic assumes an app is using assets, and if it isn't (the `assets` folder doesn't exist), then it short circuits generating the hash. This PR simply checks for the existence of the assets, so that the hash can still be generated even if they don't exist.