### PR TITLE
Simplify android setup

### DIFF
--- a/Examples/CodePushDemoApp/android/app/src/main/java/com/microsoft/codepushdemoapp/MainActivity.java
+++ b/Examples/CodePushDemoApp/android/app/src/main/java/com/microsoft/codepushdemoapp/MainActivity.java
@@ -1,7 +1,5 @@
 package com.microsoft.codepushdemoapp;
 
-import android.os.Bundle;
-
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
@@ -12,17 +10,9 @@ import java.util.List;
 
 public class MainActivity extends ReactActivity {
 
-    private CodePush codePush;
-
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        codePush = new CodePush("deployment-key-here", this, BuildConfig.DEBUG);
-        super.onCreate(savedInstanceState);
-    }
-
     @Override
     protected String getJSBundleFile() {
-        return this.codePush.getBundleUrl("index.android.bundle");
+        return CodePush.getBundleUrl("index.android.bundle");
     }
 
     /**
@@ -51,7 +41,7 @@ public class MainActivity extends ReactActivity {
     protected List<ReactPackage> getPackages() {
         return Arrays.<ReactPackage>asList(
                 new MainReactPackage(),
-                this.codePush.getReactPackage()
+                new CodePush("deployment-key-here", this, BuildConfig.DEBUG)
         );
     }
 }

--- a/README.md
+++ b/README.md
@@ -297,12 +297,7 @@ After installing the plugin and syncing your Android Studio project with Gradle,
     import com.microsoft.codepush.react.CodePush;
 
     public class MainActivity extends ReactActivity {
-        // 2. Define a private field to hold the CodePush runtime instance
-        private CodePush _codePush;
-
-        ...
-
-        // 3. Override the getJSBundleFile method in order to let
+        // 2. Override the getJSBundleFile method in order to let
         // the CodePush runtime determine where to get the JS
         // bundle location from on each app start
         @Override
@@ -312,41 +307,20 @@ After installing the plugin and syncing your Android Studio project with Gradle,
 
         @Override
         protected List<ReactPackage> getPackages() {
-            // 4. Instantiate an instance of the CodePush runtime, using the right deployment key. If you don't
-            // already have it, you can run "code-push deployment ls <appName> -k" to retrieve your key.
-            this._codePush = new CodePush("0dsIDongIcoH0mqAmoR0CYb5FhBZNy1w4Bf-l", this, BuildConfig.DEBUG);
-
-            // 5. Add the CodePush package to the list of existing packages
+            // 3. Instantiate an instance of the CodePush runtime and add it to the list of
+            // existing packages, specifying the right deployment key. If you don't already 
+            // have it, you can run "code-push deployment ls <appName> -k" to retrieve your key.
             return Arrays.<ReactPackage>asList(
-                new MainReactPackage(), this._codePush.getReactPackage());
-        }
-
-        ...
-    }
-    ```
-    
-2. If you used RNPM to install/link the CodePush plugin, there are two additional changes you'll need to make due to the fact that RNPM makes some assumptions about 3rd party modules that we don't currently support. If you're not using RNPM then simply skip to step #3:
-
-    ```java
-    ...
-    // 1. Remove the following import statement
-    import com.microsoft.codepush.react.CodePushReactPackage;
-    ...
-    public class MainActivity extends ReactActivity {
-        ...
-        @Override
-        protected List<ReactPackage> getPackages() {
-            return Arrays.<ReactPackage>asList(
-                ...
-                new CodePushReactPackage() // 2. Remove this line
-                ...
+                new MainReactPackage(), 
+                new CodePush("0dsIDongIcoH0mqAmoR0CYb5FhBZNy1w4Bf-l", this, BuildConfig.DEBUG)
             );
         }
+
         ...
     }
     ```
 
-3. Ensure that the `android.defaultConfig.versionName` property in your `android/app/build.gradle` file is set to a semver compliant value. Note that if the value provided is missing a patch version, the CodePush server will assume it is `0`, i.e. `1.0` will be treated as `1.0.0`.
+2. Ensure that the `android.defaultConfig.versionName` property in your `android/app/build.gradle` file is set to a semver compliant value. Note that if the value provided is missing a patch version, the CodePush server will assume it is `0`, i.e. `1.0` will be treated as `1.0.0`.
     
     ```gradle
     android {

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ After installing the plugin and syncing your Android Studio project with Gradle,
     }
     ```
 
-2. Ensure that the `android.defaultConfig.versionName` property in your `android/app/build.gradle` file is set to a semver compliant value. Note that if the value provided is missing a patch version, the CodePush server will assume it is `0`, i.e. `1.0` will be treated as `1.0.0`.
+2. Ensure that the `android.defaultConfig.versionName` property in your `android/app/build.gradle` file is set to a semver-compliant value. Note that if the value provided is missing a patch version, the CodePush server will assume it is `0`, i.e. `1.0` will be treated as `1.0.0`.
     
     ```gradle
     android {
@@ -312,7 +312,7 @@ After installing the plugin and syncing your Android Studio project with Gradle,
             // have it, you can run "code-push deployment ls <appName> -k" to retrieve your key.
             return Arrays.<ReactPackage>asList(
                 new MainReactPackage(), 
-                new CodePush("0dsIDongIcoH0mqAmoR0CYb5FhBZNy1w4Bf-l", this, BuildConfig.DEBUG)
+                new CodePush("deployment-key-here", this, BuildConfig.DEBUG)
             );
         }
 
@@ -320,7 +320,7 @@ After installing the plugin and syncing your Android Studio project with Gradle,
     }
     ```
 
-2. Ensure that the `android.defaultConfig.versionName` property in your `android/app/build.gradle` file is set to a semver compliant value. Note that if the value provided is missing a patch version, the CodePush server will assume it is `0`, i.e. `1.0` will be treated as `1.0.0`.
+2. Ensure that the `android.defaultConfig.versionName` property in your `android/app/build.gradle` file is set to a semver-compliant value. Note that if the value provided is missing a patch version, the CodePush server will assume it is `0`, i.e. `1.0` will be treated as `1.0.0`.
     
     ```gradle
     android {

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -101,6 +101,10 @@ public class CodePush implements ReactPackage {
         }
 
         initializeUpdateAfterRestart();
+        if (currentInstance != null) {
+            CodePushUtils.log("More than one CodePush instances has been initialized, please use the non-static method codePush.getBundleUrlInternal() to get the correct bundleURL for a particular instance.");
+        }
+
         currentInstance = this;
     }
 

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -102,7 +102,7 @@ public class CodePush implements ReactPackage {
 
         initializeUpdateAfterRestart();
         if (currentInstance != null) {
-            CodePushUtils.log("More than one CodePush instances has been initialized, please use the non-static method codePush.getBundleUrlInternal() to get the correct bundleURL for a particular instance.");
+            CodePushUtils.log("More than one CodePush instance has been initialized. Please use the instance method codePush.getBundleUrlInternal() to get the correct bundleURL for a particular instance.");
         }
 
         currentInstance = this;

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -39,7 +39,7 @@ import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-public class CodePush {
+public class CodePush implements ReactPackage {
     private static boolean needToReportRollback = false;
     private static boolean isRunningBinaryVersion = false;
     private static boolean testConfigurationFlag = false;
@@ -48,8 +48,8 @@ public class CodePush {
 
     private String assetsBundleFileName;
 
-    private final String ASSETS_BUNDLE_PREFIX = "assets://";
-    private final String BINARY_MODIFIED_TIME_KEY = "binaryModifiedTime";
+    private static final String ASSETS_BUNDLE_PREFIX = "assets://";
+    private static final String BINARY_MODIFIED_TIME_KEY = "binaryModifiedTime";
     private final String CODE_PUSH_PREFERENCES = "CodePush";
     private final String DOWNLOAD_PROGRESS_EVENT_NAME = "CodePushDownloadProgress";
     private final String FAILED_UPDATES_KEY = "CODE_PUSH_FAILED_UPDATES";
@@ -65,7 +65,6 @@ public class CodePush {
     // Helper classes.
     private CodePushNativeModule codePushNativeModule;
     private CodePushPackage codePushPackage;
-    private CodePushReactPackage codePushReactPackage;
     private CodePushTelemetryManager codePushTelemetryManager;
 
     // Config properties.
@@ -77,6 +76,8 @@ public class CodePush {
     private Activity mainActivity;
     private Context applicationContext;
     private final boolean isDebugMode;
+
+    private static CodePush currentInstance;
 
     public CodePush(String deploymentKey, Activity mainActivity) {
         this(deploymentKey, mainActivity, false);
@@ -100,6 +101,7 @@ public class CodePush {
         }
 
         initializeUpdateAfterRestart();
+        currentInstance = this;
     }
 
     private void clearReactDevBundleCache() {
@@ -129,13 +131,21 @@ public class CodePush {
         }
     }
 
-    public String getBundleUrl(String assetsBundleFileName) {
+    public static String getBundleUrl(String assetsBundleFileName) {
+        if (currentInstance == null) {
+            throw new CodePushNotInitializedException("A CodePush instance has not been created yet. Have you added it to your app's list of ReactPackages?");
+        }
+
+        return currentInstance.getBundleUrlInternal(assetsBundleFileName);
+    }
+
+    public String getBundleUrlInternal(String assetsBundleFileName) {
         this.assetsBundleFileName = assetsBundleFileName;
         String binaryJsBundleUrl = ASSETS_BUNDLE_PREFIX + assetsBundleFileName;
-        long binaryResourcesModifiedTime = getBinaryResourcesModifiedTime();
+        long binaryResourcesModifiedTime = this.getBinaryResourcesModifiedTime();
 
         try {
-            String packageFilePath = codePushPackage.getCurrentPackageBundlePath();
+            String packageFilePath = this.codePushPackage.getCurrentPackageBundlePath();
             if (packageFilePath == null) {
                 // There has not been any downloaded updates.
                 CodePushUtils.logBundleUrl(binaryJsBundleUrl);
@@ -143,7 +153,7 @@ public class CodePush {
                 return binaryJsBundleUrl;
             }
 
-            ReadableMap packageMetadata = codePushPackage.getCurrentPackage();
+            ReadableMap packageMetadata = this.codePushPackage.getCurrentPackage();
             Long binaryModifiedDateDuringPackageInstall = null;
             String binaryModifiedDateDuringPackageInstallString = CodePushUtils.tryGetString(packageMetadata, BINARY_MODIFIED_TIME_KEY);
             if (binaryModifiedDateDuringPackageInstallString != null) {
@@ -159,7 +169,7 @@ public class CodePush {
                 return packageFilePath;
             } else {
                 // The binary version is newer.
-                didUpdate = false;
+                this.didUpdate = false;
                 if (!this.isDebugMode || !this.appVersion.equals(packageAppVersion)) {
                     this.clearUpdates();
                 }
@@ -205,13 +215,6 @@ public class CodePush {
                     " stored in SharedPreferences");
             return null;
         }
-    }
-
-    public ReactPackage getReactPackage() {
-        if (codePushReactPackage == null) {
-            codePushReactPackage = new CodePushReactPackage();
-        }
-        return codePushReactPackage;
     }
     
     private void initializeUpdateAfterRestart() {
@@ -349,6 +352,7 @@ public class CodePush {
             Intent intent = mainActivity.getIntent();
             mainActivity.finish();
             mainActivity.startActivity(intent);
+            currentInstance = null;
         }
 
         @ReactMethod
@@ -439,7 +443,6 @@ public class CodePush {
 
         @ReactMethod
         public void getNewStatusReport(final Promise promise) {
-
             AsyncTask<Void, Void, Void> asyncTask = new AsyncTask<Void, Void, Void>() {
                 @Override
                 protected Void doInBackground(Void... params) {
@@ -605,27 +608,25 @@ public class CodePush {
         }
     }
 
-    private class CodePushReactPackage implements ReactPackage {
-        @Override
-        public List<NativeModule> createNativeModules(ReactApplicationContext reactApplicationContext) {
-            List<NativeModule> nativeModules = new ArrayList<>();
-            CodePush.this.codePushNativeModule = new CodePushNativeModule(reactApplicationContext);
-            CodePushDialog dialogModule = new CodePushDialog(reactApplicationContext, mainActivity);
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactApplicationContext) {
+        List<NativeModule> nativeModules = new ArrayList<>();
+        this.codePushNativeModule = new CodePushNativeModule(reactApplicationContext);
+        CodePushDialog dialogModule = new CodePushDialog(reactApplicationContext, mainActivity);
 
-            nativeModules.add(CodePush.this.codePushNativeModule);
-            nativeModules.add(dialogModule);
+        nativeModules.add(this.codePushNativeModule);
+        nativeModules.add(dialogModule);
 
-            return nativeModules;
-        }
+        return nativeModules;
+    }
 
-        @Override
-        public List<Class<? extends JavaScriptModule>> createJSModules() {
-            return new ArrayList<>();
-        }
+    @Override
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return new ArrayList<>();
+    }
 
-        @Override
-        public List<ViewManager> createViewManagers(ReactApplicationContext reactApplicationContext) {
-            return new ArrayList<>();
-        }
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactApplicationContext) {
+        return new ArrayList<>();
     }
 }

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNotInitializedException.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNotInitializedException.java
@@ -1,6 +1,6 @@
 package com.microsoft.codepush.react;
 
-public class CodePushNotInitializedException extends RuntimeException {
+public final class CodePushNotInitializedException extends RuntimeException {
 
     public CodePushNotInitializedException(String message, Throwable cause) {
         super(message, cause);

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNotInitializedException.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNotInitializedException.java
@@ -1,0 +1,12 @@
+package com.microsoft.codepush.react;
+
+public class CodePushNotInitializedException extends RuntimeException {
+
+    public CodePushNotInitializedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public CodePushNotInitializedException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
This makes our plugin more compatible with RNPM by making the `CodePush` class itself implement `ReactPackage`. That way, users don't have to modify the auto-generated import statement, or keep a reference to the CodePush instance in their MainActivity.