### PR TITLE
Introduce simpler getBundleUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -771,7 +771,7 @@ Constructs the CodePush client runtime and includes methods for integrating Code
     
 ##### Methods
 
-- __getBundleUrl()__ - Returns the path to the most recent version of your app's JS bundle file, assuming that the resource name is `index.android.bundle`. If your app is using a different bundle name, then use the overloaded verison of this method which allows specifying it. This method has the same resolution behavior as the Objective-C equivalent described above.
+- __getBundleUrl()__ - Returns the path to the most recent version of your app's JS bundle file, assuming that the resource name is `index.android.bundle`. If your app is using a different bundle name, then use the overloaded version of this method which allows specifying it. This method has the same resolution behavior as the Objective-C equivalent described above.
 
 - __getBundleUrl(String bundleName)__ - Returns the path to the most recent version of your app's JS bundle file, using the specified resource name (e.g. `index.android.bundle`). This method has the same resolution behavior as the Objective-C equivalent described above.
 

--- a/README.md
+++ b/README.md
@@ -771,6 +771,8 @@ Constructs the CodePush client runtime and includes methods for integrating Code
     
 ##### Methods
 
+- __getBundleUrl()__ - Returns the path to the most recent version of your app's JS bundle file, assuming that the resource name is `index.android.bundle`. If your app is using a different bundle name, then use the overloaded verison of this method which allows specifying it. This method has the same resolution behavior as the Objective-C equivalent described above.
+
 - __getBundleUrl(String bundleName)__ - Returns the path to the most recent version of your app's JS bundle file, using the specified resource name (e.g. `index.android.bundle`). This method has the same resolution behavior as the Objective-C equivalent described above.
 
 - __getReactPackage()__ - Returns a `ReactPackage` object that should be added to your `ReactInstanceManager` via its `addPackage` method. Without this, the `react-native-code-push` JS module won't be available to your script.

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -136,7 +136,7 @@ public class CodePush implements ReactPackage {
     }
 
     public static String getBundleUrl() {
-        return currentInstance.getBundleUrlInternal("index.android.bundle");
+        return CodePush.getBundleUrl("index.android.bundle");
     }
     
     public static String getBundleUrl(String assetsBundleFileName) {

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -51,7 +51,7 @@ public class CodePush implements ReactPackage {
     private static final String ASSETS_BUNDLE_PREFIX = "assets://";
     private static final String BINARY_MODIFIED_TIME_KEY = "binaryModifiedTime";
     private final String CODE_PUSH_PREFERENCES = "CodePush";
-    private final String DEFAULT_JS_BUNDLE_NAME = "index.android.bundle";
+    private static final String DEFAULT_JS_BUNDLE_NAME = "index.android.bundle";
     private final String DOWNLOAD_PROGRESS_EVENT_NAME = "CodePushDownloadProgress";
     private final String FAILED_UPDATES_KEY = "CODE_PUSH_FAILED_UPDATES";
     private final String PACKAGE_HASH_KEY = "packageHash";

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -51,6 +51,7 @@ public class CodePush implements ReactPackage {
     private static final String ASSETS_BUNDLE_PREFIX = "assets://";
     private static final String BINARY_MODIFIED_TIME_KEY = "binaryModifiedTime";
     private final String CODE_PUSH_PREFERENCES = "CodePush";
+    private final String DEFAULT_JS_BUNDLE_NAME = "index.android.bundle";
     private final String DOWNLOAD_PROGRESS_EVENT_NAME = "CodePushDownloadProgress";
     private final String FAILED_UPDATES_KEY = "CODE_PUSH_FAILED_UPDATES";
     private final String PACKAGE_HASH_KEY = "packageHash";
@@ -136,7 +137,7 @@ public class CodePush implements ReactPackage {
     }
 
     public static String getBundleUrl() {
-        return getBundleUrl("index.android.bundle");
+        return getBundleUrl(DEFAULT_JS_BUNDLE_NAME);
     }
     
     public static String getBundleUrl(String assetsBundleFileName) {

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -135,6 +135,10 @@ public class CodePush implements ReactPackage {
         }
     }
 
+    public static String getBundleUrl() {
+        return currentInstance.getBundleUrlInternal("index.android.bundle");
+    }
+    
     public static String getBundleUrl(String assetsBundleFileName) {
         if (currentInstance == null) {
             throw new CodePushNotInitializedException("A CodePush instance has not been created yet. Have you added it to your app's list of ReactPackages?");

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -136,7 +136,7 @@ public class CodePush implements ReactPackage {
     }
 
     public static String getBundleUrl() {
-        return CodePush.getBundleUrl("index.android.bundle");
+        return getBundleUrl("index.android.bundle");
     }
     
     public static String getBundleUrl(String assetsBundleFileName) {


### PR DESCRIPTION
This PR simply introduces a version of the `CodePush.getBundleUrl` method that defaults to assuming you're JS bundle file is named `index.android.bundle`, instead of requiring you to explicitly specify it. This provides parity with the Objective-C API, which already has a no-parameter method which assumes your JS bundle is called `main.jsbundle`.