### PR TITLE
Android reload refactor

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -396,7 +396,7 @@ public class CodePush implements ReactPackage {
             try {
                 // #1) Get the private ReactInstanceManager, which is what includes
                 //     the logic to reload the current React context.
-                Field instanceManagerField = ReactActivity.class.getDeclaredField("mReacInstanceManager");
+                Field instanceManagerField = ReactActivity.class.getDeclaredField("mReactInstanceManager");
                 instanceManagerField.setAccessible(true); // Make a private field accessible
                 final Object instanceManager = instanceManagerField.get(mainActivity);
 

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -152,7 +152,7 @@ public class CodePush implements ReactPackage {
         return currentInstance.getBundleUrlInternal(assetsBundleFileName);
     }
     
-    private String getBundleUrlInternal(String assetsBundleFileName) {
+    public String getBundleUrlInternal(String assetsBundleFileName) {
         this.assetsBundleFileName = assetsBundleFileName;
         String binaryJsBundleUrl = ASSETS_BUNDLE_PREFIX + assetsBundleFileName;
         long binaryResourcesModifiedTime = this.getBinaryResourcesModifiedTime();
@@ -381,7 +381,7 @@ public class CodePush implements ReactPackage {
         
         @Override
         public void initialize() {
-            currentInstance.initializeUpdateAfterRestart();
+            CodePush.this.initializeUpdateAfterRestart();
         }
     
         private void loadBundleLegacy() {
@@ -416,7 +416,7 @@ public class CodePush implements ReactPackage {
                         }
                         catch (ReflectiveOperationException e) {
                             // The recreation method threw an unknown exception
-                            // so just simply fallback to the old behavior
+                            // so just simply fallback to restarting the Activity
                             loadBundleLegacy();
                         }
                     }


### PR DESCRIPTION
This PR implements a new app reloading solution on Android that doesn't require restarting the `Activity`, and therefore, is less obtrusive to the user-experience. It works based on private reflection, and therefore, in order to be resilient to breaking changes, it will fall back to the old `Activity` restart logic if it fails for any reason.

After making this change, the `initializeUpdateAfterRestart` method needs to be called whenever the module is initialized, not when the `CodePush` class is constructed, since the `CodePush` class would only be constructed on the app load. Therefore, I moved the call to this method to the module's `initialize` method, which will be appropriately triggered on app start as well as after a programmatic restart. This change ends up mirroring the way that iOS already works.

Finally, I re-organized the methods a little bit in the module, which is why there is some churn on unrelated methods (e.g. `getConstants`, `getName`).