### PR TITLE
Adding RNPM config

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,9 @@
   "dependencies": {
     "code-push": "1.8.0-beta"
   },
-  "peerDependencies": {
-    "react-native": ">=0.19.0"
-  },
   "rnpm": {
       "android": {
-          "packageInstance": "new CodePush('${androidDeployment}', this, BuildConfig.DEBUG)"
+          "packageInstance": "new CodePush(${androidDeploymentKey}, this, BuildConfig.DEBUG)"
       },
       "ios": {
         "sharedLibraries": ["libz"]  
@@ -31,7 +28,7 @@
       "params": [{
         "type": "input",
         "name": "androidDeploymentKey",
-        "message": "What is your CodePush deployment key for Android"   
+        "message": "What is your CodePush deployment key for Android (hit <ENTER> to ignore)"   
       }]
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,20 @@
   "dependencies": {
     "code-push": "1.8.0-beta"
   },
-  "devDependencies": {
-    "react-native": "0.19.0"
+  "peerDependencies": {
+    "react-native": ">=0.19.0"
+  },
+  "rnpm": {
+      "android": {
+          "packageInstance": "new CodePush('${androidDeployment}', this, BuildConfig.DEBUG)"
+      },
+      "ios": {
+        "sharedLibraries": ["libz"]  
+      },
+      "params": [{
+        "type": "input",
+        "name": "androidDeploymentKey",
+        "message": "What is your CodePush deployment key for Android"   
+      }]
   }
 }


### PR DESCRIPTION
This change primarily introduces RNPM config to the module which will enable the following scenarios:

1. Generating the right constructor call within the `MainActivity` file for Android projects, which sources the deployment key from the end user via a prompt 

2. Automatically linking the `libz` dependency for iOS projects. This feature isn't enabled yet in RNPM, so I'm adding this as an optimistic feature that will light up soon