### PR TITLE
Update `android` part when using `rnpm`

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,6 @@ public class MainActivity extends ReactActivity {
         // have it, you can run "code-push deployment ls <appName> -k" to retrieve your key.
         return Arrays.<ReactPackage>asList(
             new MainReactPackage(),
-            // new CodePush() <-- remove this generated line if you used RNPM for plugin installation.
             new CodePush("deployment-key-here", this, BuildConfig.DEBUG)
         );
     }


### PR DESCRIPTION
Hey,

So recent PR (#279) added params to be used with `rnpm` - that means we no longer generate an empty `new CodePush`, but ask user for development token instead as well.

I am thinking we might either remove that comment or mention `if you are using RNPM < 1.6`

What you think?