### PR TITLE
remote "-beta" from podspec -- itunesconnect error

### DIFF
--- a/CodePush.podspec
+++ b/CodePush.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.author              = 'Microsoft Corporation'
   s.license             = 'MIT'
   s.homepage            = 'http://microsoft.github.io/code-push/'
-  s.source              = { :git => 'https://github.com/Microsoft/react-native-code-push.git', :tag => "v#{s.version}" }
+  s.source              = { :git => 'https://github.com/Microsoft/react-native-code-push.git', :tag => "v#{s.version}-beta" }
   s.platform            = :ios, '7.0'
   s.source_files        = 'ios/CodePush/*.{h,m}', 'ios/CodePush/SSZipArchive/*.{h,m}', 'ios/CodePush/SSZipArchive/aes/*.{h,c}', 'ios/CodePush/SSZipArchive/minizip/*.{h,c}'
   s.public_header_files = 'ios/CodePush/CodePush.h'

--- a/CodePush.podspec
+++ b/CodePush.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                = 'CodePush'
-  s.version             = '1.10.1-beta'
+  s.version             = '1.10.1'
   s.summary             = 'React Native plugin for the CodePush service'
   s.author              = 'Microsoft Corporation'
   s.license             = 'MIT'


### PR DESCRIPTION
Hi there
Tried submitting a build w/ react-native-code-push (installed via Cocoapods, tag: 1.1.0-beta) to iTunesConnect, and got an error:
`[Transporter Error Output]: ERROR ITMS-90060: "This bundle is invalid. The value for key CFBundleShortVersionString '1.10.1-beta' in the Info.plist file must be a period-separated list of at most three non-negative integers."`

Renaming the version in the podspec to remove `-beta` resolved this error.