### PR TITLE
Removing use of ReflectiveOperationException

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -30,7 +30,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.lang.Exception;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -30,7 +30,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.lang.ReflectiveOperationException;
+import java.lang.Exception;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
@@ -413,7 +413,7 @@ public class CodePush implements ReactPackage {
                         try {
                             recreateMethod.invoke(instanceManager);
                         }
-                        catch (ReflectiveOperationException e) {
+                        catch (Exception e) {
                             // The recreation method threw an unknown exception
                             // so just simply fallback to restarting the Activity
                             loadBundleLegacy();
@@ -421,7 +421,7 @@ public class CodePush implements ReactPackage {
                     }
                 });
             }
-            catch (ReflectiveOperationException e) {
+            catch (Exception e) {
                 // Our reflection logic failed somewhere
                 // so fall back to restarting the Activity
                 loadBundleLegacy();


### PR DESCRIPTION
The `ReflectiveOperationException` class was introduced in Android KitKat (API level 19), and therefore, we can't catch exceptions of that type and expect the code to work on older versions of Android. Since we want to support JellyBean+, this PR replaces the use of this exception type in order to resolve issue #286.

`ReflectiveOperationException` was the nearest common ancestor of all of the checked exceptions that the reflection APIs used in `loadBundle` can throw, and therefore, once we aren't catching that, we would either need to catch a handful of individual exception types, or just add a catch all. Since we want to fall back on the legacy restart logic in all failure cases, at this point, I feel more comfortable with just catching `Exception`, but am open to other opinions.