### PR TITLE
codePush.getUpdateMetadata

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -387,52 +387,52 @@ let CodePush;
 // and therefore, it doesn't make sense initializing 
 // the JS interface when it wouldn't work anyways.
 if (NativeCodePush) {
-    CodePush = {
-        AcquisitionSdk: Sdk,
-        checkForUpdate,
-        getConfiguration,
-        getCurrentPackage,
-        getUpdateMetadata,
-        log,
-        notifyApplicationReady,
-        restartApp,
-        restartApplication: restartApp,
-        setUpTestDependencies,
-        sync,
-        InstallMode: {
-            IMMEDIATE: NativeCodePush.codePushInstallModeImmediate, // Restart the app immediately
-            ON_NEXT_RESTART: NativeCodePush.codePushInstallModeOnNextRestart, // Don't artificially restart the app. Allow the update to be "picked up" on the next app restart
-            ON_NEXT_RESUME: NativeCodePush.codePushInstallModeOnNextResume // Restart the app the next time it is resumed from the background
-        },
-        SyncStatus: {
-            CHECKING_FOR_UPDATE: 0,
-            AWAITING_USER_ACTION: 1,
-            DOWNLOADING_PACKAGE: 2,
-            INSTALLING_UPDATE: 3,
-            UP_TO_DATE: 4, // The running app is up-to-date
-            UPDATE_IGNORED: 5, // The app had an optional update and the end-user chose to ignore it
-            UPDATE_INSTALLED: 6, // The app had an optional/mandatory update that was successfully downloaded and is about to be installed.
-            SYNC_IN_PROGRESS: 7, // There is an ongoing "sync" operation in progress.
-            UNKNOWN_ERROR: -1
-        },
-        UpdateState: {
-          RUNNING: NativeCodePush.codePushUpdateStateRunning,
-          PENDING: NativeCodePush.codePushUpdateStatePending,
-          LATEST: NativeCodePush.codePushUpdateStateLatest
-        },
-        DEFAULT_UPDATE_DIALOG: {
-            appendReleaseDescription: false,
-            descriptionPrefix: " Description: ",
-            mandatoryContinueButtonLabel: "Continue",
-            mandatoryUpdateMessage: "An update is available that must be installed.",
-            optionalIgnoreButtonLabel: "Ignore",
-            optionalInstallButtonLabel: "Install",
-            optionalUpdateMessage: "An update is available. Would you like to install it?",
-            title: "Update available"
-        }
+  CodePush = {
+    AcquisitionSdk: Sdk,
+    checkForUpdate,
+    getConfiguration,
+    getCurrentPackage,
+    getUpdateMetadata,
+    log,
+    notifyAppReady: notifyApplicationReady,
+    notifyApplicationReady,
+    restartApp,
+    setUpTestDependencies,
+    sync,
+    InstallMode: {
+      IMMEDIATE: NativeCodePush.codePushInstallModeImmediate, // Restart the app immediately
+      ON_NEXT_RESTART: NativeCodePush.codePushInstallModeOnNextRestart, // Don't artificially restart the app. Allow the update to be "picked up" on the next app restart
+      ON_NEXT_RESUME: NativeCodePush.codePushInstallModeOnNextResume // Restart the app the next time it is resumed from the background
+    },
+    SyncStatus: {
+      CHECKING_FOR_UPDATE: 0,
+      AWAITING_USER_ACTION: 1,
+      DOWNLOADING_PACKAGE: 2,
+      INSTALLING_UPDATE: 3,
+      UP_TO_DATE: 4, // The running app is up-to-date
+      UPDATE_IGNORED: 5, // The app had an optional update and the end-user chose to ignore it
+      UPDATE_INSTALLED: 6, // The app had an optional/mandatory update that was successfully downloaded and is about to be installed.
+      SYNC_IN_PROGRESS: 7, // There is an ongoing "sync" operation in progress.
+      UNKNOWN_ERROR: -1
+    },
+    UpdateState: {
+      RUNNING: NativeCodePush.codePushUpdateStateRunning,
+      PENDING: NativeCodePush.codePushUpdateStatePending,
+      LATEST: NativeCodePush.codePushUpdateStateLatest
+    },
+    DEFAULT_UPDATE_DIALOG: {
+      appendReleaseDescription: false,
+      descriptionPrefix: " Description: ",
+      mandatoryContinueButtonLabel: "Continue",
+      mandatoryUpdateMessage: "An update is available that must be installed.",
+      optionalIgnoreButtonLabel: "Ignore",
+      optionalInstallButtonLabel: "Install",
+      optionalUpdateMessage: "An update is available. Would you like to install it?",
+      title: "Update available"
     }
+  };
 } else {
-    log("The CodePush module doesn't appear to be properly installed. Please double-check that everything is setup correctly.");
+  log("The CodePush module doesn't appear to be properly installed. Please double-check that everything is setup correctly.");
 }
 
 module.exports = CodePush;

--- a/CodePush.js
+++ b/CodePush.js
@@ -100,12 +100,16 @@ const getConfiguration = (() => {
 })();
 
 async function getCurrentPackage() {
-  const localPackage = await NativeCodePush.getCurrentPackage();
-  if (localPackage) {
-      localPackage.failedInstall = await NativeCodePush.isFailedUpdate(localPackage.packageHash);
-      localPackage.isFirstRun = await NativeCodePush.isFirstRun(localPackage.packageHash);
+  return await getUpdateMetadata(CodePush.UpdateState.LATEST);
+}
+
+async function getUpdateMetadata(updateState) {
+  const updateMetadata = await NativeCodePush.getUpdateMetadata(updateState || CodePush.UpdateState.RUNNING);
+  if (updateMetadata) {
+      updateMetadata.failedInstall = await NativeCodePush.isFailedUpdate(updateMetadata.packageHash);
+      updateMetadata.isFirstRun = await NativeCodePush.isFirstRun(updateMetadata.packageHash);
   }
-  return localPackage;
+  return updateMetadata;
 }
 
 function getPromisifiedSdk(requestFetchAdapter, config) {
@@ -388,9 +392,11 @@ if (NativeCodePush) {
         checkForUpdate,
         getConfiguration,
         getCurrentPackage,
+        getUpdateMetadata,
         log,
         notifyApplicationReady,
         restartApp,
+        restartApplication: restartApp,
         setUpTestDependencies,
         sync,
         InstallMode: {
@@ -408,6 +414,11 @@ if (NativeCodePush) {
             UPDATE_INSTALLED: 6, // The app had an optional/mandatory update that was successfully downloaded and is about to be installed.
             SYNC_IN_PROGRESS: 7, // There is an ongoing "sync" operation in progress.
             UNKNOWN_ERROR: -1
+        },
+        UpdateState: {
+          RUNNING: NativeCodePush.codePushUpdateStateRunning,
+          PENDING: NativeCodePush.codePushUpdateStatePending,
+          LATEST: NativeCodePush.codePushUpdateStateLatest
         },
         DEFAULT_UPDATE_DIALOG: {
             appendReleaseDescription: false,

--- a/CodePush.js
+++ b/CodePush.js
@@ -106,8 +106,8 @@ async function getCurrentPackage() {
 async function getUpdateMetadata(updateState) {
   const updateMetadata = await NativeCodePush.getUpdateMetadata(updateState || CodePush.UpdateState.RUNNING);
   if (updateMetadata) {
-      updateMetadata.failedInstall = await NativeCodePush.isFailedUpdate(updateMetadata.packageHash);
-      updateMetadata.isFirstRun = await NativeCodePush.isFirstRun(updateMetadata.packageHash);
+    updateMetadata.failedInstall = await NativeCodePush.isFailedUpdate(updateMetadata.packageHash);
+    updateMetadata.isFirstRun = await NativeCodePush.isFirstRun(updateMetadata.packageHash);
   }
   return updateMetadata;
 }

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ Example Usage:
 ```javascript
 // Check if there is currently a CodePush update running, and if
 // so, register it with the HockeyApp SDK (https://github.com/slowpath/react-native-hockeyapp)
-//  so that crash reports will correctly display the JS bundle version the user was running.
+// so that crash reports will correctly display the JS bundle version the user was running.
 codePush.getUpdateMetadata().then((update) => {
     if (update) {
         hockeyApp.addMetadata({ CodePushRelease: update.label });

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -519,8 +519,7 @@ public class CodePush implements ReactPackage {
                         // The current package satisfies the request:
                         // 1) Caller wanted a pending, and there is a pending update
                         // 2) Caller wanted the running update, and there isn't a pending
-                        // 3) Calers wants the latest update, regardless if it's pending or not
-                        
+                        // 3) Caller wants the latest update, regardless if it's pending or not
                         if (isRunningBinaryVersion) {
                             // This only matters in Debug builds. Since we do not clear "outdated" updates,
                             // we need to indicate to the JS side that somehow we have a current update on
@@ -528,8 +527,7 @@ public class CodePush implements ReactPackage {
                             currentPackage.putBoolean("_isDebugOnly", true);
                         }
 
-                        // To support differentiating pending vs. non-pending updates
-                        // when request an update state of LATEST, provide an isPending flag
+                        // Enable differentiating pending vs. non-pending updates
                         currentPackage.putBoolean("isPending", currentUpdateIsPending);
                         promise.resolve(currentPackage);
                     }

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushPackage.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushPackage.java
@@ -18,7 +18,6 @@ import java.net.URL;
 import java.nio.ByteBuffer;
 
 public class CodePushPackage {
-
     private final String CODE_PUSH_FOLDER_PREFIX = "CodePush";
     private final String CURRENT_PACKAGE_KEY = "currentPackage";
     private final String DIFF_MANIFEST_FILE_NAME = "hotcodepush.json";
@@ -124,18 +123,21 @@ public class CodePushPackage {
     }
 
     public WritableMap getCurrentPackage() {
-        String folderPath = getCurrentPackageFolderPath();
-        if (folderPath == null) {
+        String packageHash = getCurrentPackageHash();
+        if (packageHash == null) {
             return null;
         }
-
-        String packagePath = CodePushUtils.appendPathComponent(folderPath, PACKAGE_FILE_NAME);
-        try {
-            return CodePushUtils.getWritableMapFromFile(packagePath);
-        } catch (IOException e) {
-            // Should not happen unless the update metadata was somehow deleted.
+        
+        return getPackage(packageHash);
+    }
+    
+    public WritableMap getPreviousPackage() {
+        String packageHash = getPreviousPackageHash();
+        if (packageHash == null) {
             return null;
         }
+        
+        return getPackage(packageHash);
     }
 
     public WritableMap getPackage(String packageHash) {
@@ -340,8 +342,6 @@ public class CodePushPackage {
     }
 
     public void clearUpdates() {
-        File statusFile = new File(getStatusFilePath());
-        statusFile.delete();
         FileUtils.deleteDirectoryAtPath(getCodePushPath());
     }
 }

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateState.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateState.java
@@ -1,0 +1,15 @@
+package com.microsoft.codepush.react;
+
+public enum CodePushUpdateState {
+    RUNNING(0),
+    PENDING(1),
+    LATEST(2);
+
+    private final int value;
+    CodePushUpdateState(int value) {
+        this.value = value;
+    }
+    public int getValue() {
+        return this.value;
+    }
+}

--- a/ios/CodePush.xcodeproj/project.pbxproj
+++ b/ios/CodePush.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		13BE3DEE1AC21097009241FE /* CodePush.m in Sources */ = {isa = PBXBuildFile; fileRef = 13BE3DED1AC21097009241FE /* CodePush.m */; };
 		1B23B9141BF9267B000BB2F0 /* RCTConvert+CodePushInstallMode.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B23B9131BF9267B000BB2F0 /* RCTConvert+CodePushInstallMode.m */; };
 		1B762E901C9A5E9A006EF800 /* CodePushErrorUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B762E8F1C9A5E9A006EF800 /* CodePushErrorUtils.m */; };
+		1BCC09A71CC19EB700DDC0DD /* RCTConvert+CodePushUpdateState.m in Sources */ = {isa = PBXBuildFile; fileRef = 1BCC09A61CC19EB700DDC0DD /* RCTConvert+CodePushUpdateState.m */; };
 		540D20121C7684FE00D6EF41 /* CodePushUpdateUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 540D20111C7684FE00D6EF41 /* CodePushUpdateUtils.m */; };
 		5421FE311C58AD5A00986A55 /* CodePushTelemetryManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5421FE301C58AD5A00986A55 /* CodePushTelemetryManager.m */; };
 		54A0026C1C0E2880004C3CEC /* aescrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 54A0024C1C0E2880004C3CEC /* aescrypt.c */; };
@@ -49,6 +50,7 @@
 		13BE3DED1AC21097009241FE /* CodePush.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CodePush.m; path = CodePush/CodePush.m; sourceTree = "<group>"; };
 		1B23B9131BF9267B000BB2F0 /* RCTConvert+CodePushInstallMode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "RCTConvert+CodePushInstallMode.m"; path = "CodePush/RCTConvert+CodePushInstallMode.m"; sourceTree = "<group>"; };
 		1B762E8F1C9A5E9A006EF800 /* CodePushErrorUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CodePushErrorUtils.m; path = CodePush/CodePushErrorUtils.m; sourceTree = "<group>"; };
+		1BCC09A61CC19EB700DDC0DD /* RCTConvert+CodePushUpdateState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "RCTConvert+CodePushUpdateState.m"; path = "CodePush/RCTConvert+CodePushUpdateState.m"; sourceTree = "<group>"; };
 		540D20111C7684FE00D6EF41 /* CodePushUpdateUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CodePushUpdateUtils.m; path = CodePush/CodePushUpdateUtils.m; sourceTree = "<group>"; };
 		5421FE301C58AD5A00986A55 /* CodePushTelemetryManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CodePushTelemetryManager.m; path = CodePush/CodePushTelemetryManager.m; sourceTree = "<group>"; };
 		54A0024A1C0E2880004C3CEC /* aes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aes.h; sourceTree = "<group>"; };
@@ -168,16 +170,17 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
-				54A002481C0E2880004C3CEC /* SSZipArchive */,
-				1B23B9131BF9267B000BB2F0 /* RCTConvert+CodePushInstallMode.m */,
+				13BE3DEC1AC21097009241FE /* CodePush.h */,
+				13BE3DED1AC21097009241FE /* CodePush.m */,
 				81D51F391B6181C2000DA084 /* CodePushConfig.m */,
 				54FFEDDF1BF550630061DD23 /* CodePushDownloadHandler.m */,
 				1B762E8F1C9A5E9A006EF800 /* CodePushErrorUtils.m */,
 				810D4E6C1B96935000B397E9 /* CodePushPackage.m */,
 				5421FE301C58AD5A00986A55 /* CodePushTelemetryManager.m */,
 				540D20111C7684FE00D6EF41 /* CodePushUpdateUtils.m */,
-				13BE3DEC1AC21097009241FE /* CodePush.h */,
-				13BE3DED1AC21097009241FE /* CodePush.m */,
+				1B23B9131BF9267B000BB2F0 /* RCTConvert+CodePushInstallMode.m */,
+				1BCC09A61CC19EB700DDC0DD /* RCTConvert+CodePushUpdateState.m */,
+				54A002481C0E2880004C3CEC /* SSZipArchive */,
 				134814211AA4EA7D00B7C361 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -242,6 +245,7 @@
 				540D20121C7684FE00D6EF41 /* CodePushUpdateUtils.m in Sources */,
 				54A0026E1C0E2880004C3CEC /* aestab.c in Sources */,
 				54A002761C0E2880004C3CEC /* mztools.c in Sources */,
+				1BCC09A71CC19EB700DDC0DD /* RCTConvert+CodePushUpdateState.m in Sources */,
 				54A002781C0E2880004C3CEC /* zip.c in Sources */,
 				54A002791C0E2880004C3CEC /* SSZipArchive.m in Sources */,
 				1B23B9141BF9267B000BB2F0 /* RCTConvert+CodePushInstallMode.m in Sources */,

--- a/ios/CodePush/CodePush.h
+++ b/ios/CodePush/CodePush.h
@@ -84,6 +84,7 @@ failCallback:(void (^)(NSError *err))failCallback;
 
 + (NSString *)getBinaryAssetsPath;
 + (NSDictionary *)getCurrentPackage:(NSError **)error;
++ (NSDictionary *)getPreviousPackage:(NSError **)error;
 + (NSString *)getCurrentPackageFolderPath:(NSError **)error;
 + (NSString *)getCurrentPackageBundlePath:(NSError **)error;
 + (NSString *)getCurrentPackageHash:(NSError **)error;
@@ -140,4 +141,10 @@ typedef NS_ENUM(NSInteger, CodePushInstallMode) {
     CodePushInstallModeImmediate,
     CodePushInstallModeOnNextRestart,
     CodePushInstallModeOnNextResume
+};
+
+typedef NS_ENUM(NSInteger, CodePushUpdateState) {
+    CodePushUpdateStateRunning,
+    CodePushUpdateStatePending,
+    CodePushUpdateStateLatest
 };

--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -544,7 +544,7 @@ RCT_EXPORT_METHOD(getUpdateMetadata:(CodePushUpdateState)updateState
 {
     NSError *error;
     NSMutableDictionary *package = [[CodePushPackage getCurrentPackage:&error] mutableCopy];
-    
+
     if (error) {
         return reject([NSString stringWithFormat: @"%lu", (long)error.code], error.localizedDescription, error);
     } else if (package == nil) {
@@ -570,13 +570,17 @@ RCT_EXPORT_METHOD(getUpdateMetadata:(CodePushUpdateState)updateState
         // 1) Caller wanted a pending, and there is a pending update
         // 2) Caller wanted the running update, and there isn't a pending
         // 3) Calers wants the latest update, regardless if it's pending or not
+        
         if (isRunningBinaryVersion) {
             // This only matters in Debug builds. Since we do not clear "outdated" updates,
             // we need to indicate to the JS side that somehow we have a current update on
             // disk that is not actually running.
             [package setObject:@(YES) forKey:@"_isDebugOnly"];
         }
-        
+    
+        // To support differentiating pending vs. non-pending updates
+        // when request an update state of LATEST, provide an isPending flag
+        [package setObject:@(currentUpdateIsPending) forKey:PackageIsPendingKey];
         resolve(package);
     }
 }

--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -180,12 +180,16 @@ static NSString *bundleResourceName = @"main";
  */
 - (NSDictionary *)constantsToExport
 {
-    // Export the values of the CodePushInstallMode enum
-    // so that the script-side can easily stay in sync
+    // Export the values of the CodePushInstallMode and CodePushUpdateState
+    // enums so that the script-side can easily stay in sync
     return @{
              @"codePushInstallModeOnNextRestart":@(CodePushInstallModeOnNextRestart),
              @"codePushInstallModeImmediate": @(CodePushInstallModeImmediate),
-             @"codePushInstallModeOnNextResume": @(CodePushInstallModeOnNextResume)
+             @"codePushInstallModeOnNextResume": @(CodePushInstallModeOnNextResume),
+             
+             @"codePushUpdateStateRunning": @(CodePushUpdateStateRunning),
+             @"codePushUpdateStatePending": @(CodePushUpdateStatePending),
+             @"codePushUpdateStateLatest": @(CodePushUpdateStateLatest)
             };
 };
 
@@ -532,35 +536,49 @@ RCT_EXPORT_METHOD(getConfiguration:(RCTPromiseResolveBlock)resolve
 }
 
 /*
- * This method is the native side of the CodePush.getCurrentPackage method.
+ * This method is the native side of the CodePush.getUpdateMetadata method.
  */
-RCT_EXPORT_METHOD(getCurrentPackage:(RCTPromiseResolveBlock)resolve
+RCT_EXPORT_METHOD(getUpdateMetadata:(CodePushUpdateState)updateState
+                           resolver:(RCTPromiseResolveBlock)resolve
                            rejecter:(RCTPromiseRejectBlock)reject)
 {
     NSError *error;
     NSMutableDictionary *package = [[CodePushPackage getCurrentPackage:&error] mutableCopy];
     
     if (error) {
-        reject([NSString stringWithFormat: @"%lu", (long)error.code], error.localizedDescription, error);
-        return;
+        return reject([NSString stringWithFormat: @"%lu", (long)error.code], error.localizedDescription, error);
     } else if (package == nil) {
+        // The app hasn't downloaded any CodePush updates yet,
+        // so we simply return nil regardless if the user
+        // wanted to retrieve the pending or running update.
+        return resolve(nil);
+    }
+    
+    // We have a CodePush update, so let's see if it's currently in a pending state.
+    BOOL currentUpdateIsPending = [self isPendingUpdate:[package objectForKey:PackageHashKey]];
+   
+    if (updateState == CodePushUpdateStatePending && !currentUpdateIsPending) {
+        // The caller wanted a pending update
+        // but there isn't currently one.
         resolve(nil);
-        return;
+    } else if (updateState == CodePushUpdateStateRunning && currentUpdateIsPending) {
+        // The caller wants the running update, but the current
+        // one is pending, so we need to grab the previous.
+        resolve([CodePushPackage getPreviousPackage:nil]);
+    } else {
+        // The current package satisfies the request:
+        // 1) Caller wanted a pending, and there is a pending update
+        // 2) Caller wanted the running update, and there isn't a pending
+        // 3) Calers wants the latest update, regardless if it's pending or not
+        if (isRunningBinaryVersion) {
+            // This only matters in Debug builds. Since we do not clear "outdated" updates,
+            // we need to indicate to the JS side that somehow we have a current update on
+            // disk that is not actually running.
+            [package setObject:@(YES) forKey:@"_isDebugOnly"];
+        }
+        
+        resolve(package);
     }
-    
-    if (isRunningBinaryVersion) {
-        // This only matters in Debug builds. Since we do not clear "outdated" updates,
-        // we need to indicate to the JS side that somehow we have a current update on
-        // disk that is not actually running.
-        [package setObject:@(YES) forKey:@"_isDebugOnly"];
-    }
-    
-    // Add the "isPending" virtual property to the package at this point, so that
-    // the script-side doesn't need to immediately call back into native to populate it.
-    BOOL isPendingUpdate = [self isPendingUpdate:[package objectForKey:PackageHashKey]];
-    [package setObject:@(isPendingUpdate) forKey:PackageIsPendingKey];
-    
-    resolve(package);
 }
 
 /*

--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -569,8 +569,7 @@ RCT_EXPORT_METHOD(getUpdateMetadata:(CodePushUpdateState)updateState
         // The current package satisfies the request:
         // 1) Caller wanted a pending, and there is a pending update
         // 2) Caller wanted the running update, and there isn't a pending
-        // 3) Calers wants the latest update, regardless if it's pending or not
-        
+        // 3) Caller wants the latest update, regardless if it's pending or not
         if (isRunningBinaryVersion) {
             // This only matters in Debug builds. Since we do not clear "outdated" updates,
             // we need to indicate to the JS side that somehow we have a current update on
@@ -578,8 +577,7 @@ RCT_EXPORT_METHOD(getUpdateMetadata:(CodePushUpdateState)updateState
             [package setObject:@(YES) forKey:@"_isDebugOnly"];
         }
     
-        // To support differentiating pending vs. non-pending updates
-        // when request an update state of LATEST, provide an isPending flag
+        // Enable differentiating pending vs. non-pending updates
         [package setObject:@(currentUpdateIsPending) forKey:PackageIsPendingKey];
         resolve(package);
     }

--- a/ios/CodePush/CodePushPackage.m
+++ b/ios/CodePush/CodePushPackage.m
@@ -17,7 +17,6 @@ static NSString *const UnzippedFolderName = @"unzipped";
 + (void)clearUpdates
 {
     [[NSFileManager defaultManager] removeItemAtPath:[self getCodePushPath] error:nil];
-    [[NSFileManager defaultManager] removeItemAtPath:[self getStatusFilePath] error:nil];
 }
 
 + (void)downloadAndReplaceCurrentBundle:(NSString *)remoteBundleUrl
@@ -290,27 +289,8 @@ static NSString *const UnzippedFolderName = @"unzipped";
 
 + (NSDictionary *)getCurrentPackage:(NSError **)error
 {
-    NSString *folderPath = [CodePushPackage getCurrentPackageFolderPath:error];
-    if (!*error) {
-        if (!folderPath) {
-            return nil;
-        }
-        
-        NSString *packagePath = [folderPath stringByAppendingPathComponent:@"app.json"];
-        NSString *content = [NSString stringWithContentsOfFile:packagePath
-                                                      encoding:NSUTF8StringEncoding
-                                                         error:error];
-        if (!*error) {
-            NSData *data = [content dataUsingEncoding:NSUTF8StringEncoding];
-            NSDictionary* jsonDict = [NSJSONSerialization JSONObjectWithData:data
-                                                                     options:kNilOptions
-                                                                       error:error];
-            
-            return jsonDict;
-        }
-    }
-    
-    return nil;
+    NSString *packageHash = [CodePushPackage getCurrentPackageHash:error];
+    return [CodePushPackage getPackage:packageHash error:error];
 }
 
 + (NSString *)getCurrentPackageBundlePath:(NSError **)error
@@ -421,6 +401,12 @@ static NSString *const UnzippedFolderName = @"unzipped";
 + (NSString *)getPackageFolderPath:(NSString *)packageHash
 {
     return [[self getCodePushPath] stringByAppendingPathComponent:packageHash];
+}
+
++ (NSDictionary *)getPreviousPackage:(NSError **)error
+{
+    NSString *packageHash = [CodePushPackage getPreviousPackageHash:error];
+    return [CodePushPackage getPackage:packageHash error:error];
 }
 
 + (NSString *)getPreviousPackageHash:(NSError **)error

--- a/ios/CodePush/RCTConvert+CodePushUpdateState.m
+++ b/ios/CodePush/RCTConvert+CodePushUpdateState.m
@@ -1,0 +1,15 @@
+#import "CodePush.h"
+#import "RCTConvert.h"
+
+// Extending the RCTConvert class allows the React Native
+// bridge to handle args of type "CodePushUpdateState"
+@implementation RCTConvert (CodePushUpdateState)
+
+RCT_ENUM_CONVERTER(CodePushUpdateState, (@{ @"codePushUpdateStateRunning": @(CodePushUpdateStateRunning),
+                                            @"codePushUpdateStatePending": @(CodePushUpdateStatePending),
+                                            @"codePushUpdateStateLatest": @(CodePushUpdateStateLatest)
+                                          }),
+                   CodePushUpdateStateRunning, // Default enum value
+                   integerValue)
+
+@end

--- a/react-native-code-push.d.ts
+++ b/react-native-code-push.d.ts
@@ -193,11 +193,13 @@ declare namespace CodePush {
      * @param deploymentKey The deployment key to use to query the CodePush server for an update.
      */
     function checkForUpdate(deploymentKey?: string): ReactNativePromise<RemotePackage>;  
-    
+
     /**
-     * Retrieves the metadata about the currently installed update (e.g. description, installation time, size).
+     * Retrieves the metadata for an installed update (e.g. description, mandatory).
+     * 
+     * @param updateState The state of the update you want to retrieve the metadata for. Defaults to UpdateState.RUNNING.
      */
-    function getCurrentPackage(): ReactNativePromise<LocalPackage>;
+    function getUpdateMetadata(updateState?: UpdateState) : ReactNativePromise<LocalPackage>;
     
     /**
      * Notifies the CodePush runtime that an installed update is considered successful.
@@ -218,7 +220,7 @@ declare namespace CodePush {
      * @param syncStatusChangedCallback An optional callback that allows tracking the status of the sync operation, as opposed to simply checking the resolved state via the returned Promise.
      * @param downloadProgressCallback An optional callback that allows tracking the progress of an update while it is being downloaded.
      */
-    function sync(options?: SyncOptions, syncStatusChangedCallback?: SyncStatusChangedCallback, downloadProgressCallback?: DowloadProgressCallback): __React.Promise<SyncStatus>;
+    function sync(options?: SyncOptions, syncStatusChangedCallback?: SyncStatusChangedCallback, downloadProgressCallback?: DowloadProgressCallback): ReactNativePromise<SyncStatus>;
 
     /**
      * Indicates when you would like an installed update to actually be applied.
@@ -241,6 +243,9 @@ declare namespace CodePush {
         ON_NEXT_RESUME
     }
     
+    /**
+     * Indicates the current status of a sync operation.
+     */
     enum SyncStatus {
         /**
          * The CodePush server is being queried for an update.
@@ -290,6 +295,29 @@ declare namespace CodePush {
          * The sync operation encountered an unknown error.
          */
         UNKNOWN_ERROR
+    }
+    
+    /**
+     * Indicates the state that an update is currently in.
+     */
+    enum UpdateState {
+        /**
+         * Indicates that an update represents the
+         * version of the app that is currently running. 
+         */
+        RUNNING,
+        
+        /**
+         * Indicates than an update has been installed, but the
+         * app hasn't been restarted yet in order to apply it.
+         */
+        PENDING,
+        
+        /**
+         * Indicates than an update represents the latest available
+         * release, and can be either currently running or pending.
+         */
+        LATEST
     }
 }
 

--- a/react-native-code-push.d.ts
+++ b/react-native-code-push.d.ts
@@ -204,7 +204,7 @@ declare namespace CodePush {
     /**
      * Notifies the CodePush runtime that an installed update is considered successful.
      */
-    function notifyApplicationReady(): ReactNativePromise<void>;
+    function notifyAppReady(): ReactNativePromise<void>;
     
     /**
      * Immediately restarts the app.


### PR DESCRIPTION
This PR implements a new JS API method called `getUpdateMetadata` which allows an app to request the metadata specifically for either the currently running update, a pending update or the latest update (regardless if it is pending or not). The primary motivation behind this is to provide a deterministic way to retrieve the metadata of the currently running update, regardless if there is a pending update or not (which is currently a flaw with `getCurrentPackage`).

Example usages:

```javascript
import codePush, { UpdateState } from "react-native-code-push";

// Retrieve the metadata of the running update. 
// This is the primary benefit of this new method, since `getCurrentPackage`
// will return a pending update if there is one, so you can no longer retrieve
// the metadata of the currently running update
codePush.getUpdateMetadata(); 

// Same as above, since `RUNNING` is the default update state
codePush.getUpdateMetadata(UpdateState.RUNNING); 

// Retrieve the metadata of the pending update, or null if there isn't a pending update. 
// This replaces the need to call `getCurrentPackage` and then check `sPending` simply
// in order to determine if there is a pending update or not
codePush.getUpdateMetadata(UpdateState.PENDING); 

// Retrieve the metadata of the latest update, regardless if it's pending or not. 
// This behaves in the same way that `getCurrentPackage` currently does.
codePush.getUpdateMetadata(UpdateState.LATEST);
```

Note that I chose not to remove `getCurrentPackage` since I'm a little cautious about introducing breaking changes moving forward. I think we can remove it from our docs, and generally not prescribe it anymore, but it seemed largely harmless to me to simply make `getCurrentPackage` an alias for calling `getUpdateMetadata(codePush.UpdateState.LATEST)`. Additionally, I left the `isPending` property on the `*Package` objects, for three reasons:

1. Backwards compatibility (primary motivation)
2. It enables calling `getUpdateMetadata` with the `LATEST` state, and differentiating between whether the update is pending or not
3. Regardless which `UpdateState` you request, if you pass the `Package` object as an argument to another function, that function may want/need to understand if it's pending or not.

### Misc. Changes

1. Removing the logic that deletes the status file in the `clearUpdates` method of the Java/Obj-C `CodePushPackage` classes, since it actually isn't needed (deleting the entire CodePush folder will delete this file as well)

2. I introduced an alias for `restartApp` called `restartApplication`, which is the name that Cordova uses, and is admittedly more consistent with `notifyApplicationReady`

### Misc. Changes (iOS)

1. Replacing occurrences of `NULL` with `nil` (consistency!)

2. Extracting the `app.json` literal into a static const within the `CodePushPackage` class (Android already had this)

3. Re-organizaing the files in our `xcodeproj` alphabetically (this is the reason for some of the churn in this file)