### PR TITLE
Check and clear updates if needed during init if running JS bundle from dev server

### DIFF
--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -247,6 +247,20 @@ static NSString *bundleResourceName = @"main";
  */
 - (void)initializeUpdateAfterRestart
 {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if ([_bridge.bundleURL.scheme hasPrefix:@"http"]) {
+            NSError *error;
+            NSString *binaryAppVersion = [[CodePushConfig current] appVersion];
+            NSDictionary *currentPackageMetadata = [CodePushPackage getCurrentPackage:&error];
+            if (currentPackageMetadata) {
+                NSString *packageAppVersion = [currentPackageMetadata objectForKey:AppVersionKey];
+                if (![binaryAppVersion isEqualToString:packageAppVersion]) {
+                    [CodePush clearUpdates];
+                }
+            }
+        }
+    });
+    
     NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
     NSDictionary *pendingUpdate = [preferences objectForKey:PendingUpdateKey];
     if (pendingUpdate) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-code-push",
-  "version": "1.10.2-beta",
+  "version": "1.10.3-beta",
   "description": "React Native plugin for the CodePush service",
   "main": "CodePush.js",
   "homepage": "https://microsoft.github.io/code-push",
@@ -23,12 +23,12 @@
           "packageInstance": "new CodePush(${androidDeploymentKey}, this, BuildConfig.DEBUG)"
       },
       "ios": {
-        "sharedLibraries": ["libz"]  
+        "sharedLibraries": ["libz"]
       },
       "params": [{
         "type": "input",
         "name": "androidDeploymentKey",
-        "message": "What is your CodePush deployment key for Android (hit <ENTER> to ignore)"   
+        "message": "What is your CodePush deployment key for Android (hit <ENTER> to ignore)"
       }]
   }
 }


### PR DESCRIPTION
This fixes an issue brought up in https://github.com/Microsoft/react-native-code-push/issues/297. If the app is configured to run the version from the dev server, `[CodePush bundleURL]` is never called, and outdated updates are hence never cleared. This causes `checkForUpdate` requests to still use outdated updates which could be installed under a different appVersion from the actual binary, and updates that actually apply to the binary will not be acquired.