### PR TITLE
Fix - App crashes when backgrounded before an app is installed

### DIFF
--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -175,7 +175,7 @@ static NSString *bundleResourceName = @"main";
 /*
  * This method is used to clear updates that are installed
  * under a different app version and hence don't apply anymore,
- * during a debug run configuration and when the bridge is 
+ * during a debug run configuration and when the bridge is
  * running the JS bundle from the dev server.
  */
 - (void)clearDebugUpdates
@@ -273,7 +273,7 @@ static NSString *bundleResourceName = @"main";
 #ifdef DEBUG
     [self clearDebugUpdates];
 #endif
-    
+
     NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
     NSDictionary *pendingUpdate = [preferences objectForKey:PendingUpdateKey];
     if (pendingUpdate) {
@@ -456,7 +456,11 @@ static NSString *bundleResourceName = @"main";
 {
     // Determine how long the app was in the background and ensure
     // that it meets the minimum duration amount of time.
-    int durationInBackground = [[NSDate date] timeIntervalSinceDate:_lastResignedDate];
+    int durationInBackground = 0;
+    if (_lastResignedDate) {
+        durationInBackground = [[NSDate date] timeIntervalSinceDate:_lastResignedDate];
+    }
+
     if (durationInBackground >= _minimumBackgroundDuration) {
         [self loadBundle];
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-code-push",
-  "version": "1.10.3-beta",
+  "version": "1.10.4-beta",
   "description": "React Native plugin for the CodePush service",
   "main": "CodePush.js",
   "homepage": "https://microsoft.github.io/code-push",


### PR DESCRIPTION
Please ignore the whitespace changes, I changed an editor setting.

This PR potentially fixes #305. The problem sometimes happens when an app gets backgrounded before it gets installed, in which case, when the app resumes, the lastPausedDate is null, triggering a NullPointerException during the OnResume lifecycle event which does a date comparison against the lastPausedDate to calculate the background duration.