### PR TITLE
Syncing Podspec version with package.json

### DIFF
--- a/CodePush.podspec
+++ b/CodePush.podspec
@@ -1,8 +1,12 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
 Pod::Spec.new do |s|
 
   s.name                = 'CodePush'
-  s.version             = '1.10.4'
-  s.summary             = 'React Native plugin for the CodePush service'
+  s.version             = package['version'].sub('-beta', '')
+  s.summary             = 'React Native module for the CodePush service'
   s.author              = 'Microsoft Corporation'
   s.license             = 'MIT'
   s.homepage            = 'http://microsoft.github.io/code-push/'


### PR DESCRIPTION
This updates our `Podspec` to pull its version from the `package.json` file. This way we can simply update a single version whenever we rev the module. I was inspired to do this after reading the `Podspec` of the `react-native-video` module, and realized how useful this is since we've occasionally forgotten to version the `Podspec` when shipping an update to NPM.

The "-beta" stripping logic is meant to maintain the fix for iTunes Connect not supporting frameworks whose version name includes a pre-release tag. I tested this change out in a native iOS project and it works beautifully :)