### PR TITLE
Fixing isFirstRun on Android

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -233,9 +233,12 @@ public class CodePush implements ReactPackage {
     }
 
     private void initializeUpdateAfterRestart() {
+        // Re-set the state that indicates that
+        // the app was just updated.
+        didUpdate = false;
+        
         JSONObject pendingUpdate = getPendingUpdate();
         if (pendingUpdate != null) {
-            didUpdate = true;
             try {
                 boolean updateIsLoading = pendingUpdate.getBoolean(PENDING_UPDATE_IS_LOADING_KEY);
                 if (updateIsLoading) {
@@ -245,6 +248,10 @@ public class CodePush implements ReactPackage {
                     needToReportRollback = true;
                     rollbackPackage();
                 } else {
+                    // There is in fact a new update running for the first
+                    // time, so update the local state to ensure isFirstRun works
+                    didUpdate = true;
+                    
                     // Mark that we tried to initialize the new update, so that if it crashes,
                     // we will know that we need to rollback when the app next starts.
                     savePendingUpdate(pendingUpdate.getString(PENDING_UPDATE_HASH_KEY),

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -233,8 +233,8 @@ public class CodePush implements ReactPackage {
     }
 
     private void initializeUpdateAfterRestart() {
-        // Re-set the state that indicates that
-        // the app was just updated.
+        // Reset the state which indicates that
+        // the app was just freshly updated.
         didUpdate = false;
         
         JSONObject pendingUpdate = getPendingUpdate();
@@ -249,7 +249,7 @@ public class CodePush implements ReactPackage {
                     rollbackPackage();
                 } else {
                     // There is in fact a new update running for the first
-                    // time, so update the local state to ensure isFirstRun works
+                    // time, so update the local state to ensure the client knows.
                     didUpdate = true;
                     
                     // Mark that we tried to initialize the new update, so that if it crashes,


### PR DESCRIPTION
This change ensures that `isFirstRun` is set to `false` after a rollback happens (which is how iOS behaves). Now that we call `initializeUpdateAfterRestart` in both the cold start and restart scenarios, I'm using it to manage the state for `isFirstRun`. Now, `didUpdate` is always reset to `false` every time the app is restarted for any reason, and it is only ever set to `true` is an update is actually running for the first time. Therefore, if a rollback happens, `didUpdate` would be reset to `false` and not set to `true` since there wouldn't be a pending update.
