### PR TITLE
Improve download progress perf

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -238,7 +238,7 @@ public class CodePush implements ReactPackage {
         // Reset the state which indicates that
         // the app was just freshly updated.
         didUpdate = false;
-        
+
         JSONObject pendingUpdate = getPendingUpdate();
         if (pendingUpdate != null) {
             try {
@@ -253,7 +253,7 @@ public class CodePush implements ReactPackage {
                     // There is in fact a new update running for the first
                     // time, so update the local state to ensure the client knows.
                     didUpdate = true;
-                    
+
                     // Mark that we tried to initialize the new update, so that if it crashes,
                     // we will know that we need to rollback when the app next starts.
                     savePendingUpdate(pendingUpdate.getString(PENDING_UPDATE_HASH_KEY),
@@ -449,7 +449,7 @@ public class CodePush implements ReactPackage {
                         WritableMap mutableUpdatePackage = CodePushUtils.convertReadableMapToWritableMap(updatePackage);
                         mutableUpdatePackage.putString(BINARY_MODIFIED_TIME_KEY, "" + getBinaryResourcesModifiedTime());
                         codePushPackage.downloadPackage(mutableUpdatePackage, CodePush.this.assetsBundleFileName, new DownloadProgressCallback() {
-                            private boolean nextFrameBusy = false;
+                            private boolean hasScheduledNextFrame = false;
                             private DownloadProgress latestDownloadProgress = null;
 
                             @Override
@@ -459,11 +459,11 @@ public class CodePush implements ReactPackage {
                                 }
 
                                 this.latestDownloadProgress = downloadProgress;
-                                if (nextFrameBusy) {
+                                if (hasScheduledNextFrame) {
                                     return;
                                 }
 
-                                nextFrameBusy = true;
+                                hasScheduledNextFrame = true;
                                 mainActivity.runOnUiThread(new Runnable() {
                                     @Override
                                     public void run() {
@@ -473,7 +473,7 @@ public class CodePush implements ReactPackage {
                                                 getReactApplicationContext()
                                                         .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                                                         .emit(DOWNLOAD_PROGRESS_EVENT_NAME, latestDownloadProgress.createWritableMap());
-                                                nextFrameBusy = false;
+                                                hasScheduledNextFrame = false;
                                             }
                                         });
                                     }

--- a/android/app/src/main/java/com/microsoft/codepush/react/DownloadProgress.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/DownloadProgress.java
@@ -23,4 +23,8 @@ class DownloadProgress {
         }
         return map;
     }
+
+    public boolean isCompleted() {
+        return this.totalBytes == this.receivedBytes;
+    }
 }

--- a/ios/CodePush/CodePush.h
+++ b/ios/CodePush/CodePush.h
@@ -54,11 +54,13 @@
 @property (strong) NSOutputStream *outputFileStream;
 @property long long expectedContentLength;
 @property long long receivedContentLength;
+@property dispatch_queue_t usingQueue;
 @property (copy) void (^progressCallback)(long long, long long);
 @property (copy) void (^doneCallback)(BOOL);
 @property (copy) void (^failCallback)(NSError *err);
 
 - (id)init:(NSString *)downloadFilePath
+usingQueue:(dispatch_queue_t)usingQueue
 progressCallback:(void (^)(long long, long long))progressCallback
 doneCallback:(void (^)(BOOL))doneCallback
 failCallback:(void (^)(NSError *err))failCallback;
@@ -78,6 +80,7 @@ failCallback:(void (^)(NSError *err))failCallback;
 
 + (void)downloadPackage:(NSDictionary *)updatePackage
  expectedBundleFileName:(NSString *)expectedBundleFileName
+             usingQueue:(dispatch_queue_t)usingQueue
        progressCallback:(void (^)(long long, long long))progressCallback
            doneCallback:(void (^)())doneCallback
            failCallback:(void (^)(NSError *err))failCallback;

--- a/ios/CodePush/CodePush.h
+++ b/ios/CodePush/CodePush.h
@@ -54,13 +54,13 @@
 @property (strong) NSOutputStream *outputFileStream;
 @property long long expectedContentLength;
 @property long long receivedContentLength;
-@property dispatch_queue_t usingQueue;
+@property dispatch_queue_t operationQueue;
 @property (copy) void (^progressCallback)(long long, long long);
 @property (copy) void (^doneCallback)(BOOL);
 @property (copy) void (^failCallback)(NSError *err);
 
 - (id)init:(NSString *)downloadFilePath
-usingQueue:(dispatch_queue_t)usingQueue
+operationQueue:(dispatch_queue_t)operationQueue
 progressCallback:(void (^)(long long, long long))progressCallback
 doneCallback:(void (^)(BOOL))doneCallback
 failCallback:(void (^)(NSError *err))failCallback;
@@ -80,7 +80,7 @@ failCallback:(void (^)(NSError *err))failCallback;
 
 + (void)downloadPackage:(NSDictionary *)updatePackage
  expectedBundleFileName:(NSString *)expectedBundleFileName
-             usingQueue:(dispatch_queue_t)usingQueue
+         operationQueue:(dispatch_queue_t)operationQueue
        progressCallback:(void (^)(long long, long long))progressCallback
            doneCallback:(void (^)())doneCallback
            failCallback:(void (^)(NSError *err))failCallback;

--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -15,6 +15,8 @@
     BOOL _isFirstRunAfterUpdate;
     int _minimumBackgroundDuration;
     NSDate *_lastResignedDate;
+    
+    // Used to coordinate the dispatching of download progress events to JS.
     long long _latestExpectedContentLength;
     long long _latestReceivedConentLength;
     BOOL _didUpdateProgress;
@@ -174,6 +176,7 @@ static NSString *bundleResourceName = @"main";
 
 @synthesize bridge = _bridge;
 @synthesize methodQueue = _methodQueue;
+@synthesize pauseCallback = _pauseCallback;
 @synthesize paused = _paused;
 
 /*

--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -756,7 +756,7 @@ RCT_EXPORT_METHOD(getNewStatusReport:(RCTPromiseResolveBlock)resolve
     resolve(nil);
 }
 
-#pragma mark - Methods for handling dispatching of download progress events to JS (Private)
+#pragma mark - RCTFrameUpdateObserver Methods
 
 long long latestExpectedContentLength = -1;
 long long latestReceivedConentLength = -1;

--- a/ios/CodePush/CodePushDownloadHandler.m
+++ b/ios/CodePush/CodePushDownloadHandler.m
@@ -6,12 +6,14 @@
 }
 
 - (id)init:(NSString *)downloadFilePath
+usingQueue:(dispatch_queue_t)usingQueue
 progressCallback:(void (^)(long long, long long))progressCallback
 doneCallback:(void (^)(BOOL))doneCallback
 failCallback:(void (^)(NSError *err))failCallback {
     self.outputFileStream = [NSOutputStream outputStreamToFileAtPath:downloadFilePath
                                                               append:NO];
     self.receivedContentLength = 0;
+    self.usingQueue = usingQueue;
     self.progressCallback = progressCallback;
     self.doneCallback = doneCallback;
     self.failCallback = failCallback;
@@ -22,12 +24,12 @@ failCallback:(void (^)(NSError *err))failCallback {
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:url]
                                              cachePolicy:NSURLRequestUseProtocolCachePolicy
                                          timeoutInterval:60.0];
-    
+    NSOperationQueue *delegateQueue = [NSOperationQueue new];
+    delegateQueue.underlyingQueue = self.usingQueue;
     NSURLConnection *connection = [[NSURLConnection alloc] initWithRequest:request
                                                                   delegate:self
                                                           startImmediately:NO];
-    [connection scheduleInRunLoop:[NSRunLoop mainRunLoop]
-                          forMode:NSDefaultRunLoopMode];
+    [connection setDelegateQueue:delegateQueue];
     [connection start];
 }
 

--- a/ios/CodePush/CodePushDownloadHandler.m
+++ b/ios/CodePush/CodePushDownloadHandler.m
@@ -6,14 +6,14 @@
 }
 
 - (id)init:(NSString *)downloadFilePath
-usingQueue:(dispatch_queue_t)usingQueue
+operationQueue:(dispatch_queue_t)operationQueue
 progressCallback:(void (^)(long long, long long))progressCallback
 doneCallback:(void (^)(BOOL))doneCallback
 failCallback:(void (^)(NSError *err))failCallback {
     self.outputFileStream = [NSOutputStream outputStreamToFileAtPath:downloadFilePath
                                                               append:NO];
     self.receivedContentLength = 0;
-    self.usingQueue = usingQueue;
+    self.operationQueue = operationQueue;
     self.progressCallback = progressCallback;
     self.doneCallback = doneCallback;
     self.failCallback = failCallback;
@@ -25,7 +25,7 @@ failCallback:(void (^)(NSError *err))failCallback {
                                              cachePolicy:NSURLRequestUseProtocolCachePolicy
                                          timeoutInterval:60.0];
     NSOperationQueue *delegateQueue = [NSOperationQueue new];
-    delegateQueue.underlyingQueue = self.usingQueue;
+    delegateQueue.underlyingQueue = self.operationQueue;
     NSURLConnection *connection = [[NSURLConnection alloc] initWithRequest:request
                                                                   delegate:self
                                                           startImmediately:NO];

--- a/ios/CodePush/CodePushPackage.m
+++ b/ios/CodePush/CodePushPackage.m
@@ -41,6 +41,7 @@ static NSString *const UnzippedFolderName = @"unzipped";
 
 + (void)downloadPackage:(NSDictionary *)updatePackage
  expectedBundleFileName:(NSString *)expectedBundleFileName
+             usingQueue:(dispatch_queue_t)usingQueue
        progressCallback:(void (^)(long long, long long))progressCallback
            doneCallback:(void (^)())doneCallback
            failCallback:(void (^)(NSError *err))failCallback
@@ -71,6 +72,7 @@ static NSString *const UnzippedFolderName = @"unzipped";
     
     CodePushDownloadHandler *downloadHandler = [[CodePushDownloadHandler alloc]
                                                 init:downloadFilePath
+                                                usingQueue:usingQueue
                                                 progressCallback:progressCallback
                                                 doneCallback:^(BOOL isZip) {
                                                     NSError *error = nil;

--- a/ios/CodePush/CodePushPackage.m
+++ b/ios/CodePush/CodePushPackage.m
@@ -41,7 +41,7 @@ static NSString *const UnzippedFolderName = @"unzipped";
 
 + (void)downloadPackage:(NSDictionary *)updatePackage
  expectedBundleFileName:(NSString *)expectedBundleFileName
-             usingQueue:(dispatch_queue_t)usingQueue
+         operationQueue:(dispatch_queue_t)operationQueue
        progressCallback:(void (^)(long long, long long))progressCallback
            doneCallback:(void (^)())doneCallback
            failCallback:(void (^)(NSError *err))failCallback
@@ -72,7 +72,7 @@ static NSString *const UnzippedFolderName = @"unzipped";
     
     CodePushDownloadHandler *downloadHandler = [[CodePushDownloadHandler alloc]
                                                 init:downloadFilePath
-                                                usingQueue:usingQueue
+                                                operationQueue:operationQueue
                                                 progressCallback:progressCallback
                                                 doneCallback:^(BOOL isZip) {
                                                     NSError *error = nil;

--- a/package-mixins.js
+++ b/package-mixins.js
@@ -14,24 +14,24 @@ module.exports = (NativeCodePush) => {
 
         let downloadProgressSubscription;
         if (downloadProgressCallback) {
-          // Use event subscription to obtain download progress.   
+          // Use event subscription to obtain download progress.
           downloadProgressSubscription = DeviceEventEmitter.addListener(
             "CodePushDownloadProgress",
             downloadProgressCallback
           );
         }
-      
+
         // Use the downloaded package info. Native code will save the package info
         // so that the client knows what the current package version is.
-        try {  
-          const downloadedPackage = await NativeCodePush.downloadUpdate(this);
+        try {
+          const downloadedPackage = await NativeCodePush.downloadUpdate(this, !!downloadProgressCallback);
           reportStatusDownload && reportStatusDownload(this);
           return { ...downloadedPackage, ...local };
         } finally {
           downloadProgressSubscription && downloadProgressSubscription.remove();
         }
       },
-    
+
       isPending: false // A remote package could never be in a pending state
     };
   };
@@ -47,7 +47,7 @@ module.exports = (NativeCodePush) => {
         localPackage.isPending = true; // Mark the package as pending since it hasn't been applied yet
       }
     },
-    
+
     isPending: false // A local package wouldn't be pending until it was installed
   };
 


### PR DESCRIPTION
This PR fixes #303 by mitigating the perf impact caused by the firing of download progress events.

1. If no download progress handler is passed to the call to CodePush.sync, the native side will not send the progress events.

2. Throttles the firing of the events to be equal or less than the UI framerate.

3. Handle the download progress event handling on the methodQueue instead of the main thread (iOS)