### PR TITLE
Exclude CodePush assets from backups

### DIFF
--- a/ios/CodePush/CodePushPackage.m
+++ b/ios/CodePush/CodePushPackage.m
@@ -60,6 +60,11 @@ static NSString *const UnzippedFolderName = @"unzipped";
                                   withIntermediateDirectories:YES
                                                    attributes:nil
                                                         error:&error];
+                                                        
+        // Ensure that none of the CodePush updates we store on disk are
+        // ever included in the end users iTunes and/or iCloud backups
+        NSURL *codePushURL = [NSURL fileURLWithPath:[self getCodePushPath]];
+        [codePushURL setResourceValue:@YES forKey:NSURLIsExcludedFromBackupKey error:nil];
     }
     
     if (error) {


### PR DESCRIPTION
Addresses #320 by explicitly marking the CodePush directory as being excluded from any backups when it is first created. By excluding the entire directory, that will transitively exclude all child files and directories. Since we write all updates and metadata files to that directory, this change will result in none of the CodePush assets being synced to end users iCloud storage accounts.