### PR TITLE
Fix for iOS7

### DIFF
--- a/ios/CodePush/CodePushDownloadHandler.m
+++ b/ios/CodePush/CodePushDownloadHandler.m
@@ -1,5 +1,4 @@
 #import "CodePush.h"
-#import <UIKit/UIKit.h>
 
 @implementation CodePushDownloadHandler {
     // Header chars used to determine if the file is a zip.
@@ -36,7 +35,7 @@ failCallback:(void (^)(NSError *err))failCallback {
         [connection scheduleInRunLoop:[NSRunLoop mainRunLoop]
                               forMode:NSDefaultRunLoopMode];
     }
-    
+
     [connection start];
 }
 

--- a/ios/CodePush/CodePushDownloadHandler.m
+++ b/ios/CodePush/CodePushDownloadHandler.m
@@ -1,4 +1,5 @@
 #import "CodePush.h"
+#import <UIKit/UIKit.h>
 
 @implementation CodePushDownloadHandler {
     // Header chars used to determine if the file is a zip.
@@ -27,9 +28,15 @@ failCallback:(void (^)(NSError *err))failCallback {
     NSURLConnection *connection = [[NSURLConnection alloc] initWithRequest:request
                                                                   delegate:self
                                                           startImmediately:NO];
-    NSOperationQueue *delegateQueue = [NSOperationQueue new];
-    delegateQueue.underlyingQueue = self.operationQueue;
-    [connection setDelegateQueue:delegateQueue];
+    if ([NSOperationQueue respondsToSelector:@selector(setUnderlyingQueue:)]) {
+        NSOperationQueue *delegateQueue = [NSOperationQueue new];
+        delegateQueue.underlyingQueue = self.operationQueue;
+        [connection setDelegateQueue:delegateQueue];
+    } else {
+        [connection scheduleInRunLoop:[NSRunLoop mainRunLoop]
+                              forMode:NSDefaultRunLoopMode];
+    }
+    
     [connection start];
 }
 

--- a/ios/CodePush/CodePushDownloadHandler.m
+++ b/ios/CodePush/CodePushDownloadHandler.m
@@ -27,7 +27,7 @@ failCallback:(void (^)(NSError *err))failCallback {
     NSURLConnection *connection = [[NSURLConnection alloc] initWithRequest:request
                                                                   delegate:self
                                                           startImmediately:NO];
-    if ([NSOperationQueue respondsToSelector:@selector(setUnderlyingQueue:)]) {
+    if ([NSOperationQueue instancesRespondToSelector:@selector(setUnderlyingQueue:)]) {
         NSOperationQueue *delegateQueue = [NSOperationQueue new];
         delegateQueue.underlyingQueue = self.operationQueue;
         [connection setDelegateQueue:delegateQueue];

--- a/ios/CodePush/CodePushTelemetryManager.m
+++ b/ios/CodePush/CodePushTelemetryManager.m
@@ -114,7 +114,7 @@ static NSString *const LastDeploymentReportKey = @"CODE_PUSH_LAST_DEPLOYMENT_REP
 
 + (BOOL)isStatusReportIdentifierCodePushLabel:(NSString *)statusReportIdentifier
 {
-    return statusReportIdentifier != nil && [statusReportIdentifier containsString:@":"];
+    return statusReportIdentifier != nil && [statusReportIdentifier rangeOfString:@":"].location != NSNotFound;
 }
 
 + (void)recordDeploymentStatusReported:(NSString *)appVersionOrPackageIdentifier


### PR DESCRIPTION
This fixes https://github.com/Microsoft/code-push/issues/216.

We are using two Obj-C APIs that are only supported in iOS 8+: `[string containsString]` and `[operationQueue setUnderlyingQueue]`. This fix simply changes our implementation to use the iOS7 workarounds if necessary.