### PR TITLE
Retry Report Status if failed

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -159,62 +159,59 @@ function log(message) {
   console.log(`[CodePush] ${message}`)
 }
 
-// This ensures that the native call to notifyApplicationReady
-// only happens once in the lifetime of this module instance.
+// This ensures that notifyApplicationReadyInternal is only called once
+// in the lifetime of this module instance.
 const notifyApplicationReady = (() => {
   let notifyApplicationReadyPromise;
   return () => {
     if (!notifyApplicationReadyPromise) {
-      notifyApplicationReadyPromise = NativeCodePush.notifyApplicationReady();
+      notifyApplicationReadyPromise = notifyApplicationReadyInternal();
     }
 
-    return notifyApplicationReadyPromise
-      .then(() => {
-        tryReportStatus();
-      });
+    return notifyApplicationReadyPromise;
   };
 })();
 
-let tryReportStatus = (function() {
-  let resumeListener;
-  return async function () {
-    const statusReport = await NativeCodePush.getNewStatusReport();
-    if (statusReport) {
-      const config = await getConfiguration();
-      const previousLabelOrAppVersion = statusReport.previousLabelOrAppVersion;
-      const previousDeploymentKey = statusReport.previousDeploymentKey || config.deploymentKey;
-      try {
-        if (statusReport.appVersion) {
-          const sdk = getPromisifiedSdk(requestFetchAdapter, config);
-          await sdk.reportStatusDeploy(/* deployedPackage */ null, /* status */ null, previousLabelOrAppVersion, previousDeploymentKey);
-        } else {
-          config.deploymentKey = statusReport.package.deploymentKey;
-          const sdk = getPromisifiedSdk(requestFetchAdapter, config);
-          await sdk.reportStatusDeploy(statusReport.package, statusReport.status, previousLabelOrAppVersion, previousDeploymentKey);
-        }
+async function notifyApplicationReadyInternal() {
+  await NativeCodePush.notifyApplicationReady();
+  tryReportStatus();
+}
 
-        log(`Reported status: ${JSON.stringify(statusReport)}`);
-        NativeCodePush.recordStatusReported(statusReport);
-        resumeListener && AppState.removeEventListener("change", resumeListener);
-        resumeListener = null;
-      } catch (e) {
-        log(`Report status failed: ${JSON.stringify(statusReport)}`);
-        NativeCodePush.saveStatusReportForRetry(statusReport);
-        // Try again when the app resumes
-        if (!resumeListener) {
-          resumeListener = (newState) => {
-            newState === "active" && tryReportStatus(resumeListener);
-          };
-
-          AppState.addEventListener("change", resumeListener);
-        }
+async function tryReportStatus(resumeListener) {
+  const statusReport = await NativeCodePush.getNewStatusReport();
+  if (statusReport) {
+    const config = await getConfiguration();
+    const previousLabelOrAppVersion = statusReport.previousLabelOrAppVersion;
+    const previousDeploymentKey = statusReport.previousDeploymentKey || config.deploymentKey;
+    try {
+      if (statusReport.appVersion) {
+        const sdk = getPromisifiedSdk(requestFetchAdapter, config);
+        await sdk.reportStatusDeploy(/* deployedPackage */ null, /* status */ null, previousLabelOrAppVersion, previousDeploymentKey);
+      } else {
+        config.deploymentKey = statusReport.package.deploymentKey;
+        const sdk = getPromisifiedSdk(requestFetchAdapter, config);
+        await sdk.reportStatusDeploy(statusReport.package, statusReport.status, previousLabelOrAppVersion, previousDeploymentKey);
       }
-    } else {
+
+      log(`Reported status: ${JSON.stringify(statusReport)}`);
+      NativeCodePush.recordStatusReported(statusReport);
       resumeListener && AppState.removeEventListener("change", resumeListener);
-      resumeListener = null;
+    } catch (e) {
+      log(`Report status failed: ${JSON.stringify(statusReport)}`);
+      NativeCodePush.saveStatusReportForRetry(statusReport);
+      // Try again when the app resumes
+      if (!resumeListener) {
+        resumeListener = (newState) => {
+          newState === "active" && tryReportStatus(resumeListener);
+        };
+
+        AppState.addEventListener("change", resumeListener);
+      }
     }
+  } else {
+    resumeListener && AppState.removeEventListener("change", resumeListener);
   }
-})();
+}
 
 function restartApp(onlyIfUpdateIsPending = false) {
   NativeCodePush.restartApp(onlyIfUpdateIsPending);

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -626,6 +626,12 @@ public class CodePush implements ReactPackage {
                             promise.resolve(newAppVersionStatusReport);
                             return null;
                         }
+                    } else {
+                        WritableMap retryStatusReport = codePushTelemetryManager.getRetryStatusReport();
+                        if (retryStatusReport != null) {
+                            promise.resolve(retryStatusReport);
+                            return null;
+                        }
                     }
 
                     promise.resolve("");
@@ -721,12 +727,22 @@ public class CodePush implements ReactPackage {
         }
 
         @ReactMethod
+        public void recordStatusReported(ReadableMap statusReport) {
+            codePushTelemetryManager.recordStatusReported(statusReport);
+        }
+
+        @ReactMethod
         public void restartApp(boolean onlyIfUpdateIsPending) {
             // If this is an unconditional restart request, or there
             // is current pending update, then reload the app.
             if (!onlyIfUpdateIsPending || CodePush.this.isPendingUpdate(null)) {
                 loadBundle();
             }
+        }
+
+        @ReactMethod
+        public void saveStatusReportForRetry(ReadableMap statusReport) {
+            codePushTelemetryManager.saveStatusReportForRetry(statusReport);
         }
 
         @ReactMethod

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushTelemetryManager.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushTelemetryManager.java
@@ -33,14 +33,14 @@ public class CodePushTelemetryManager {
 
     public WritableMap getBinaryUpdateReport(String appVersion) {
         String previousStatusReportIdentifier = this.getPreviousStatusReportIdentifier();
+        WritableNativeMap reportMap = null;
         if (previousStatusReportIdentifier == null) {
             this.clearRetryStatusReport();
-            WritableNativeMap reportMap = new WritableNativeMap();
+            reportMap = new WritableNativeMap();
             reportMap.putString(APP_VERSION_KEY, appVersion);
-            return reportMap;
         } else if (!previousStatusReportIdentifier.equals(appVersion)) {
             this.clearRetryStatusReport();
-            WritableNativeMap reportMap = new WritableNativeMap();
+            reportMap = new WritableNativeMap();
             if (this.isStatusReportIdentifierCodePushLabel(previousStatusReportIdentifier)) {
                 String previousDeploymentKey = this.getDeploymentKeyFromStatusReportIdentifier(previousStatusReportIdentifier);
                 String previousLabel = this.getVersionLabelFromStatusReportIdentifier(previousStatusReportIdentifier);
@@ -52,10 +52,9 @@ public class CodePushTelemetryManager {
                 reportMap.putString(APP_VERSION_KEY, appVersion);
                 reportMap.putString(PREVIOUS_LABEL_OR_APP_VERSION_KEY, previousStatusReportIdentifier);
             }
-            return reportMap;
         }
 
-        return null;
+        return reportMap;
     }
 
     public WritableMap getRetryStatusReport() {
@@ -68,7 +67,6 @@ public class CodePushTelemetryManager {
                 return CodePushUtils.convertJsonObjectToWritable(retryStatusReport);
             } catch (JSONException e) {
                 e.printStackTrace();
-                return null;
             }
         }
 
@@ -85,36 +83,33 @@ public class CodePushTelemetryManager {
     public WritableMap getUpdateReport(WritableMap currentPackage) {
         String currentPackageIdentifier = this.getPackageStatusReportIdentifier(currentPackage);
         String previousStatusReportIdentifier = this.getPreviousStatusReportIdentifier();
+        WritableNativeMap reportMap = null;
         if (currentPackageIdentifier != null) {
             if (previousStatusReportIdentifier == null) {
                 this.clearRetryStatusReport();
-                WritableNativeMap reportMap = new WritableNativeMap();
+                reportMap = new WritableNativeMap();
                 reportMap.putMap(PACKAGE_KEY, currentPackage);
                 reportMap.putString(STATUS_KEY, DEPLOYMENT_SUCCEEDED_STATUS);
-                return reportMap;
             } else if (!previousStatusReportIdentifier.equals(currentPackageIdentifier)) {
                 this.clearRetryStatusReport();
+                reportMap = new WritableNativeMap();
                 if (this.isStatusReportIdentifierCodePushLabel(previousStatusReportIdentifier)) {
                     String previousDeploymentKey = this.getDeploymentKeyFromStatusReportIdentifier(previousStatusReportIdentifier);
                     String previousLabel = this.getVersionLabelFromStatusReportIdentifier(previousStatusReportIdentifier);
-                    WritableNativeMap reportMap = new WritableNativeMap();
                     reportMap.putMap(PACKAGE_KEY, currentPackage);
                     reportMap.putString(STATUS_KEY, DEPLOYMENT_SUCCEEDED_STATUS);
                     reportMap.putString(PREVIOUS_DEPLOYMENT_KEY_KEY, previousDeploymentKey);
                     reportMap.putString(PREVIOUS_LABEL_OR_APP_VERSION_KEY, previousLabel);
-                    return reportMap;
                 } else {
                     // Previous status report was with a binary app version.
-                    WritableNativeMap reportMap = new WritableNativeMap();
                     reportMap.putMap(PACKAGE_KEY, currentPackage);
                     reportMap.putString(STATUS_KEY, DEPLOYMENT_SUCCEEDED_STATUS);
                     reportMap.putString(PREVIOUS_LABEL_OR_APP_VERSION_KEY, previousStatusReportIdentifier);
-                    return reportMap;
                 }
             }
         }
 
-        return null;
+        return reportMap;
     }
 
     public void recordStatusReported(ReadableMap statusReport) {

--- a/ios/CodePush/CodePush.h
+++ b/ios/CodePush/CodePush.h
@@ -112,8 +112,11 @@ failCallback:(void (^)(NSError *err))failCallback;
 @interface CodePushTelemetryManager : NSObject
 
 + (NSDictionary *)getBinaryUpdateReport:(NSString *)appVersion;
++ (NSDictionary *)getRetryStatusReport;
 + (NSDictionary *)getRollbackReport:(NSDictionary *)lastFailedPackage;
 + (NSDictionary *)getUpdateReport:(NSDictionary *)currentPackage;
++ (void)recordStatusReported:(NSDictionary *)statusReport;
++ (void)saveStatusReportForRetry:(NSDictionary *)statusReport;
 
 @end
 

--- a/ios/CodePush/CodePushDownloadHandler.m
+++ b/ios/CodePush/CodePushDownloadHandler.m
@@ -20,7 +20,7 @@ failCallback:(void (^)(NSError *err))failCallback {
     return self;
 }
 
--(void)download:(NSString*)url {
+- (void)download:(NSString*)url {
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:url]
                                              cachePolicy:NSURLRequestUseProtocolCachePolicy
                                          timeoutInterval:60.0];
@@ -47,12 +47,12 @@ failCallback:(void (^)(NSError *err))failCallback {
     return nil;
 }
 
--(void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response {
+- (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response {
     self.expectedContentLength = response.expectedContentLength;
     [self.outputFileStream open];
 }
 
--(void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data {
+- (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data {
     if (self.receivedContentLength < 4) {
         for (int i = 0; i < [data length]; i++) {
             int headerOffset = (int)self.receivedContentLength + i;
@@ -97,7 +97,7 @@ failCallback:(void (^)(NSError *err))failCallback {
     self.failCallback(error);
 }
 
--(void)connectionDidFinishLoading:(NSURLConnection *)connection {
+- (void)connectionDidFinishLoading:(NSURLConnection *)connection {
     // expectedContentLength might be -1 when NSURLConnection don't know the length(e.g. response encode with gzip)
     if (self.expectedContentLength > 0) {
         // We should have received all of the bytes if this is called.

--- a/ios/CodePush/CodePushTelemetryManager.m
+++ b/ios/CodePush/CodePushTelemetryManager.m
@@ -57,7 +57,6 @@ static NSString *const StatusKey = @"status";
 
 + (NSDictionary *)getRollbackReport:(NSDictionary *)lastFailedPackage
 {
-    [self clearRetryStatusReport];
     return @{
               PackageKey: lastFailedPackage,
               StatusKey: DeploymentFailed
@@ -76,10 +75,10 @@ static NSString *const StatusKey = @"status";
                       StatusKey: DeploymentSucceeded
                     };
         } else if (![previousStatusReportIdentifier isEqualToString:currentPackageIdentifier]) {
+            [self clearRetryStatusReport];
             if ([self isStatusReportIdentifierCodePushLabel:previousStatusReportIdentifier]) {
                 NSString *previousDeploymentKey = [self getDeploymentKeyFromStatusReportIdentifier:previousStatusReportIdentifier];
                 NSString *previousLabel = [self getVersionLabelFromStatusReportIdentifier:previousStatusReportIdentifier];
-                [self clearRetryStatusReport];
                 return @{
                           PackageKey: currentPackage,
                           StatusKey: DeploymentSucceeded,
@@ -87,7 +86,6 @@ static NSString *const StatusKey = @"status";
                           PreviousLabelOrAppVersionKey: previousLabel
                         };
             } else {
-                [self clearRetryStatusReport];
                 // Previous status report was with a binary app version.
                 return @{
                           PackageKey: currentPackage,


### PR DESCRIPTION
This PR improves the reportStatus mechanism in order to make sure that metrics reporting calls are not lost due to bad network conditions. If the call to the server fails/times out, we will save a copy of the statusReport in the Preferences, and retry again the next time the app resumes.