### PR TITLE
Remove "More than one CodePush instance" message

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -104,10 +104,6 @@ public class CodePush implements ReactPackage {
             throw new CodePushUnknownException("Unable to get package info for " + applicationContext.getPackageName(), e);
         }
 
-        if (currentInstance != null) {
-            CodePushUtils.log("More than one CodePush instance has been initialized. Please use the instance method codePush.getBundleUrlInternal() to get the correct bundleURL for a particular instance.");
-        }
-
         currentInstance = this;
 
         clearDebugCacheIfNeeded();


### PR DESCRIPTION
This PR simply removes the "More than one CodePush instance" error because it is confusing as indicated in https://github.com/Microsoft/react-native-code-push/issues/335.