### PR TITLE
Fix rollback status report

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushTelemetryManager.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushTelemetryManager.java
@@ -113,11 +113,13 @@ public class CodePushTelemetryManager {
     }
 
     public void recordStatusReported(ReadableMap statusReport) {
-        if (statusReport.hasKey(APP_VERSION_KEY)) {
-            saveStatusReportedForIdentifier(statusReport.getString(APP_VERSION_KEY));
-        } else if (statusReport.hasKey(PACKAGE_KEY)) {
-            String packageIdentifier = getPackageStatusReportIdentifier(statusReport.getMap(PACKAGE_KEY));
-            saveStatusReportedForIdentifier(packageIdentifier);
+        if (statusReport.hasKey(STATUS_KEY) && DEPLOYMENT_SUCCEEDED_STATUS.equals(statusReport.getString(STATUS_KEY))) {
+            if (statusReport.hasKey(APP_VERSION_KEY)) {
+                saveStatusReportedForIdentifier(statusReport.getString(APP_VERSION_KEY));
+            } else if (statusReport.hasKey(PACKAGE_KEY)) {
+                String packageIdentifier = getPackageStatusReportIdentifier(statusReport.getMap(PACKAGE_KEY));
+                saveStatusReportedForIdentifier(packageIdentifier);
+            }
         }
     }
 

--- a/ios/CodePush/CodePushTelemetryManager.m
+++ b/ios/CodePush/CodePushTelemetryManager.m
@@ -101,11 +101,13 @@ static NSString *const StatusKey = @"status";
 
 + (void)recordStatusReported:(NSDictionary *)statusReport
 {
-    if (statusReport[AppVersionKey]) {
-        [self saveStatusReportedForIdentifier:statusReport[AppVersionKey]];
-    } else if (statusReport[PackageKey]) {
-        NSString *packageIdentifier = [self getPackageStatusReportIdentifier:statusReport[PackageKey]];
-        [self saveStatusReportedForIdentifier:packageIdentifier];
+    if ([DeploymentSucceeded isEqualToString:statusReport[StatusKey]]) {
+        if (statusReport[AppVersionKey]) {
+            [self saveStatusReportedForIdentifier:statusReport[AppVersionKey]];
+        } else if (statusReport[PackageKey]) {
+            NSString *packageIdentifier = [self getPackageStatusReportIdentifier:statusReport[PackageKey]];
+            [self saveStatusReportedForIdentifier:packageIdentifier];
+        }
     }
 }
 


### PR DESCRIPTION
The RN plugin is missing this crucial logic in the Cordova Plugin (https://github.com/Microsoft/cordova-plugin-code-push/blob/master/src/ios/CodePushReportingManager.m#L90) that ensures that we do not erroneously record an upgrade to a new version in the case of a rollback status report.