### PR TITLE
Metrics fix

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushTelemetryManager.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushTelemetryManager.java
@@ -114,8 +114,9 @@ public class CodePushTelemetryManager {
 
     public void recordStatusReported(ReadableMap statusReport) {
         // We don't need to record rollback reports, so exit early if that's what was specified.
-        if (statusReport.hasKey(STATUS_KEY) && DEPLOYMENT_FAILED_STATUS.equals(statusReport.getString(STATUS_KEY)))
+        if (statusReport.hasKey(STATUS_KEY) && DEPLOYMENT_FAILED_STATUS.equals(statusReport.getString(STATUS_KEY))) {
             return;
+        }
         
         if (statusReport.hasKey(APP_VERSION_KEY)) {
             saveStatusReportedForIdentifier(statusReport.getString(APP_VERSION_KEY));

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushTelemetryManager.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushTelemetryManager.java
@@ -113,13 +113,15 @@ public class CodePushTelemetryManager {
     }
 
     public void recordStatusReported(ReadableMap statusReport) {
-        if (statusReport.hasKey(STATUS_KEY) && DEPLOYMENT_SUCCEEDED_STATUS.equals(statusReport.getString(STATUS_KEY))) {
-            if (statusReport.hasKey(APP_VERSION_KEY)) {
-                saveStatusReportedForIdentifier(statusReport.getString(APP_VERSION_KEY));
-            } else if (statusReport.hasKey(PACKAGE_KEY)) {
-                String packageIdentifier = getPackageStatusReportIdentifier(statusReport.getMap(PACKAGE_KEY));
-                saveStatusReportedForIdentifier(packageIdentifier);
-            }
+        // We don't need to record rollback reports, so exit early if that's what was specified.
+        if (statusReport.hasKey(STATUS_KEY) && DEPLOYMENT_FAILED_STATUS.equals(statusReport.getString(STATUS_KEY)))
+            return;
+        
+        if (statusReport.hasKey(APP_VERSION_KEY)) {
+            saveStatusReportedForIdentifier(statusReport.getString(APP_VERSION_KEY));
+        } else if (statusReport.hasKey(PACKAGE_KEY)) {
+            String packageIdentifier = getPackageStatusReportIdentifier(statusReport.getMap(PACKAGE_KEY));
+            saveStatusReportedForIdentifier(packageIdentifier);
         }
     }
 

--- a/ios/CodePush/CodePushTelemetryManager.m
+++ b/ios/CodePush/CodePushTelemetryManager.m
@@ -101,13 +101,15 @@ static NSString *const StatusKey = @"status";
 
 + (void)recordStatusReported:(NSDictionary *)statusReport
 {
-    if ([DeploymentSucceeded isEqualToString:statusReport[StatusKey]]) {
-        if (statusReport[AppVersionKey]) {
-            [self saveStatusReportedForIdentifier:statusReport[AppVersionKey]];
-        } else if (statusReport[PackageKey]) {
-            NSString *packageIdentifier = [self getPackageStatusReportIdentifier:statusReport[PackageKey]];
-            [self saveStatusReportedForIdentifier:packageIdentifier];
-        }
+    // We don't need to record rollback reports, so exit early if that's what was specified.
+    if ([DeploymentFailed isEqualToString:statusReport[StatusKey]])
+        return;
+    
+    if (statusReport[AppVersionKey]) {
+        [self saveStatusReportedForIdentifier:statusReport[AppVersionKey]];
+    } else if (statusReport[PackageKey]) {
+        NSString *packageIdentifier = [self getPackageStatusReportIdentifier:statusReport[PackageKey]];
+        [self saveStatusReportedForIdentifier:packageIdentifier];
     }
 }
 

--- a/ios/CodePush/CodePushTelemetryManager.m
+++ b/ios/CodePush/CodePushTelemetryManager.m
@@ -102,8 +102,9 @@ static NSString *const StatusKey = @"status";
 + (void)recordStatusReported:(NSDictionary *)statusReport
 {
     // We don't need to record rollback reports, so exit early if that's what was specified.
-    if ([DeploymentFailed isEqualToString:statusReport[StatusKey]])
+    if ([DeploymentFailed isEqualToString:statusReport[StatusKey]]) {
         return;
+    }
     
     if (statusReport[AppVersionKey]) {
         [self saveStatusReportedForIdentifier:statusReport[AppVersionKey]];


### PR DESCRIPTION
Addresses #344. This issue occurres because binary version reports don't include a status field, and therefore, aren't being properly recorded as having been reported.

This is a regression that was caused by [this commit](https://github.com/Microsoft/react-native-code-push/commit/66a36071e537cf8b3b6c0c8ec5c275c952fc2370), which sought to prevent recording rollback reports, but in the process, also prevented recording binary version reports as well.