### PR TITLE
Adding nozip option to podspec

### DIFF
--- a/CodePush.podspec
+++ b/CodePush.podspec
@@ -12,10 +12,19 @@ Pod::Spec.new do |s|
   s.homepage            = 'http://microsoft.github.io/code-push/'
   s.source              = { :git => 'https://github.com/Microsoft/react-native-code-push.git', :tag => "v#{s.version}-beta" }
   s.platform            = :ios, '7.0'
-  s.source_files        = 'ios/CodePush/*.{h,m}', 'ios/CodePush/SSZipArchive/*.{h,m}', 'ios/CodePush/SSZipArchive/aes/*.{h,c}', 'ios/CodePush/SSZipArchive/minizip/*.{h,c}'
   s.public_header_files = 'ios/CodePush/CodePush.h'
   s.preserve_paths      = '*.js'
   s.library             = 'z'
   s.dependency 'React'
-
+  
+  s.default_subspec = 'Full'
+  
+  s.subspec 'Full' do |ss|
+    s.source_files = 'ios/CodePush/*.{h,m}', 'ios/CodePush/SSZipArchive/*.{h,m}', 'ios/CodePush/SSZipArchive/aes/*.{h,c}', 'ios/CodePush/SSZipArchive/minizip/*.{h,c}'    
+  end
+  
+  s.subspec 'NoZip' do |ss|
+    s.source_files = 'ios/CodePush/*.{h,m}'    
+  end
+  
 end

--- a/README.md
+++ b/README.md
@@ -118,12 +118,18 @@ We hope to eventually remove the need for steps #2-4, but in the meantime, RNPM 
     pod 'CodePush', :path => './node_modules/react-native-code-push'
     ```
     
-    *NOTE: The above path needs to be relative to your app's `Podfile`, so adjust it as neccessary.*
+    CodePush depends on an internal copy of the `SSZipArchive` library, so if your project already includes that (either directly or via a transitive dependency), then you can install a version of CodePush which excludes its by using the following subspec:
+    
+    ```ruby
+    pod 'CodePush', :path => './node_modules/react-native-code-push', :subspecs => ['NoZip']
+    ```
+    
+    *NOTE: The above paths needs to be relative to your app's `Podfile`, so adjust it as neccessary.*
     
 2. Run `pod install`
 
 *NOTE: The CodePush `.podspec` depends on the `React` pod, and so in order to ensure that it can correctly use the version of React Native that your app is built with, please make sure to define the `React` dependency in your app's `Podfile` as explained [here](http://facebook.github.io/react-native/docs/embedded-app-ios.html#install-react-native-using-cocoapods).*
-
+    
 #### Plugin Installation (iOS - Manual)
 
 1. Open your app's Xcode project

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ We hope to eventually remove the need for steps #2-4, but in the meantime, RNPM 
     pod 'CodePush', :path => './node_modules/react-native-code-push'
     ```
     
-    CodePush depends on an internal copy of the `SSZipArchive` library, so if your project already includes that (either directly or via a transitive dependency), then you can install a version of CodePush which excludes its by using the following subspec:
+    CodePush depends on an internal copy of the `SSZipArchive` library, so if your project already includes that (either directly or via a transitive dependency), then you can install a version of CodePush which excludes it by using the following subspec:
     
     ```ruby
     pod 'CodePush', :path => './node_modules/react-native-code-push', :subspecs => ['NoZip']


### PR DESCRIPTION
This addresses issue #337 by adding a new subspace for CocoaPods users to easily exclude the `SSZipArchive` dependency.