### PR TITLE
installLocation property

### DIFF
--- a/README.md
+++ b/README.md
@@ -948,7 +948,7 @@ Contains details about an update that has been downloaded locally or already ins
 
 - __failedInstall__: Indicates whether this update has been previously installed but was rolled back. The `sync` method will automatically ignore updates which have previously failed, so you only need to worry about this property if using `checkForUpdate`. *(Boolean)*
 
-- __installLocation__: The absolute path to the directory where the update's contents are installed. This can be useful if you need to construct an absolute path for a file that is contained with a CodePush release, and therefore, you need to resolve the filename relative to the update it's contained within. *(String)*
+- __installLocation__: The absolute path to the directory where the update's contents are installed. This can be useful if you need to construct an absolute path for a file that is contained within a CodePush release. *(String)*
 
 - __isFirstRun__: Indicates whether this is the first time the update has been run after being installed. This is useful for determining whether you would like to show a "What's New?" UI to the end user after installing an update. *(Boolean)*
 

--- a/README.md
+++ b/README.md
@@ -939,15 +939,27 @@ The `checkForUpdate` and `getUpdateMetadata` methods return `Promise` objects, t
 Contains details about an update that has been downloaded locally or already installed. You can get a reference to an instance of this object either by calling the module-level `getUpdateMetadata` method, or as the value of the promise returned by the `RemotePackage.download` method.
 
 ###### Properties
+
 - __appVersion__: The app binary version that this update is dependent on. This is the value that was specified via the `appStoreVersion` parameter when calling the CLI's `release` command. *(String)*
+
 - __deploymentKey__: The deployment key that was used to originally download this update. *(String)*
+
 - __description__: The description of the update. This is the same value that you specified in the CLI when you released the update. *(String)*
+
 - __failedInstall__: Indicates whether this update has been previously installed but was rolled back. The `sync` method will automatically ignore updates which have previously failed, so you only need to worry about this property if using `checkForUpdate`. *(Boolean)*
+
+- __installLocation__: The absolute path to the directory where the update's contents are installed. This can be useful if you need to construct an absolute path for a file that is contained with a CodePush release, and therefore, you need to resolve the filename relative to the update it's contained within. *(String)*
+
 - __isFirstRun__: Indicates whether this is the first time the update has been run after being installed. This is useful for determining whether you would like to show a "What's New?" UI to the end user after installing an update. *(Boolean)*
+
 - __isMandatory__: Indicates whether the update is considered mandatory.  This is the value that was specified in the CLI when the update was released. *(Boolean)*
+
 - __isPending__: Indicates whether this update is in a "pending" state. When `true`, that means the update has been downloaded and installed, but the app restart needed to apply it hasn't occurred yet, and therefore, it's changes aren't currently visible to the end-user. *(Boolean)*
+
 - __label__: The internal label automatically given to the update by the CodePush server. This value uniquely identifies the update within it's deployment. *(String)*
+
 - __packageHash__: The SHA hash value of the update. *(String)*
+
 - __packageSize__: The size of the code contained within the update, in bytes. *(Number)*
 
 ###### Methods

--- a/ios/CodePush/CodePushPackage.m
+++ b/ios/CodePush/CodePushPackage.m
@@ -7,6 +7,7 @@
 
 static NSString *const DiffManifestFileName = @"hotcodepush.json";
 static NSString *const DownloadFileName = @"download.zip";
+static NSString *const InstallLocationKey = @"installLocation";
 static NSString *const RelativeBundlePathKey = @"bundlePath";
 static NSString *const StatusFile = @"codepush.json";
 static NSString *const UpdateBundleFileName = @"app.jsbundle";
@@ -81,8 +82,10 @@ static NSString *const UnzippedFolderName = @"unzipped";
                                                 progressCallback:progressCallback
                                                 doneCallback:^(BOOL isZip) {
                                                     NSError *error = nil;
-                                                    NSString * unzippedFolderPath = [CodePushPackage getUnzippedFolderPath];
-                                                    NSMutableDictionary * mutableUpdatePackage = [updatePackage mutableCopy];
+                                                    NSString *unzippedFolderPath = [CodePushPackage getUnzippedFolderPath];
+                                                    NSMutableDictionary *mutableUpdatePackage = [updatePackage mutableCopy];
+                                                    [mutableUpdatePackage setValue:newUpdateFolderPath forKey:InstallLocationKey];
+                                                    
                                                     if (isZip) {
                                                         if ([[NSFileManager defaultManager] fileExistsAtPath:unzippedFolderPath]) {
                                                             // This removes any unzipped download data that could have been left
@@ -261,6 +264,7 @@ static NSString *const UnzippedFolderName = @"unzipped";
                                                     NSData *updateSerializedData = [NSJSONSerialization dataWithJSONObject:mutableUpdatePackage
                                                                                                                    options:0
                                                                                                                      error:&error];
+                                                                                                                     
                                                     NSString *packageJsonString = [[NSString alloc] initWithData:updateSerializedData
                                                                                                         encoding:NSUTF8StringEncoding];
                                                     
@@ -268,6 +272,7 @@ static NSString *const UnzippedFolderName = @"unzipped";
                                                                         atomically:YES
                                                                           encoding:NSUTF8StringEncoding
                                                                              error:&error];
+                                                                             
                                                     if (error) {
                                                         failCallback(error);
                                                     } else {

--- a/typings/react-native-code-push.d.ts
+++ b/typings/react-native-code-push.d.ts
@@ -40,6 +40,11 @@ export interface LocalPackage extends Package {
      * @param minimumBackgroundDuration For resume-based installs, this specifies the number of seconds the app needs to be in the background before forcing a restart. Defaults to 0 if unspecified.
      */
     install(installMode: CodePush.InstallMode, minimumBackgroundDuration?: number): Promise<void>;
+    
+    /**
+     * The absolute path to the directory where the update's contents are installed.
+     */
+    installLocation: string;
 }
     
 export interface Package {


### PR DESCRIPTION
This PR adds a new property to the `LocalPackage` object called `installLocation`, which simply exposes the absolute path of the directory that the update's contents are installed within. This allows JS code to construct absolute URLs to files, which are relative to the current (or pending) update, and unblocks the use of APIs that require an absolute path, while still allowing updating these assets via CodePush.

For example, the following snippet shows how to use the [react-native-sound](https://github.com/zmxv/react-native-sound) plugin to play an MP3, in a way that also enables you to ship updates to the file via CodePush.

```javascript
const update = await codePush.getUpdateMetadata();
const sound = new Sound("sound.mp3", update.installLocation);
sound.play();
```