### PR TITLE
Propagate errors thrown in update dialog button press handler

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -354,7 +354,11 @@ async function syncInternal(options = {}, syncStatusChangeCallback, downloadProg
         const dialogButtons = [{
           text: null,
           onPress: async () => {
-            resolve(await doDownloadAndInstall());
+            try {
+              resolve(await doDownloadAndInstall());
+            } catch (downloadError) {
+              reject(downloadError);
+            }
           }
         }];
 

--- a/CodePush.js
+++ b/CodePush.js
@@ -353,12 +353,9 @@ async function syncInternal(options = {}, syncStatusChangeCallback, downloadProg
         let message = null;
         const dialogButtons = [{
           text: null,
-          onPress: async () => {
-            try {
-              resolve(await doDownloadAndInstall());
-            } catch (downloadError) {
-              reject(downloadError);
-            }
+          onPress:() => {
+            doDownloadAndInstall()
+              .then(resolve, reject);
           }
         }];
 


### PR DESCRIPTION
This ensures errors thrown in the `onPress` handler of the update dialog will get propagated and result in the rejection of the `sync` promise, instead of resulting in an unhandled promise rejection and leaving the main `sync` promise hanging. The problem that this fixes might be a root cause for https://github.com/Microsoft/react-native-code-push/issues/362.