### PR TITLE
Explicitly mark SSZipArchive headers as private

### DIFF
--- a/CodePush.podspec
+++ b/CodePush.podspec
@@ -17,13 +17,6 @@ Pod::Spec.new do |s|
 
   s.dependency 'React'
 
-  s.default_subspec = 'Full'
-
-  s.subspec 'Full' do |ss|
-    ss.dependency 'CodePush/Core'
-    ss.dependency 'CodePush/SSZipArchive'
-  end
-
   s.subspec 'Core' do |ss|
     ss.source_files = 'ios/CodePush/*.{h,m}'
     ss.public_header_files = ['ios/CodePush/CodePush.h']

--- a/CodePush.podspec
+++ b/CodePush.podspec
@@ -20,11 +20,11 @@ Pod::Spec.new do |s|
   s.default_subspec = 'Full'
 
   s.subspec 'Full' do |ss|
-    ss.dependency 'CodePush/NoZip'
+    ss.dependency 'CodePush/Core'
     ss.dependency 'CodePush/SSZipArchive'
   end
 
-  s.subspec 'NoZip' do |ss|
+  s.subspec 'Core' do |ss|
     ss.source_files = 'ios/CodePush/*.{h,m}'
     ss.public_header_files = ['ios/CodePush/CodePush.h']
   end

--- a/CodePush.podspec
+++ b/CodePush.podspec
@@ -4,27 +4,34 @@ package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
 
-  s.name                = 'CodePush'
-  s.version             = package['version'].sub('-beta', '')
-  s.summary             = 'React Native module for the CodePush service'
-  s.author              = 'Microsoft Corporation'
-  s.license             = 'MIT'
-  s.homepage            = 'http://microsoft.github.io/code-push/'
-  s.source              = { :git => 'https://github.com/Microsoft/react-native-code-push.git', :tag => "v#{s.version}-beta" }
-  s.platform            = :ios, '7.0'
-  s.public_header_files = 'ios/CodePush/CodePush.h'
-  s.preserve_paths      = '*.js'
-  s.library             = 'z'
+  s.name           = 'CodePush'
+  s.version        = package['version'].sub('-beta', '')
+  s.summary        = 'React Native module for the CodePush service'
+  s.author         = 'Microsoft Corporation'
+  s.license        = 'MIT'
+  s.homepage       = 'http://microsoft.github.io/code-push/'
+  s.source         = { :git => 'https://github.com/Microsoft/react-native-code-push.git', :tag => "v#{s.version}-beta"}
+  s.platform       = :ios, '7.0'
+  s.preserve_paths = '*.js'
+  s.library        = 'z'
+
   s.dependency 'React'
-  
+
   s.default_subspec = 'Full'
-  
+
   s.subspec 'Full' do |ss|
-    ss.source_files = 'ios/CodePush/*.{h,m}', 'ios/CodePush/SSZipArchive/*.{h,m}', 'ios/CodePush/SSZipArchive/aes/*.{h,c}', 'ios/CodePush/SSZipArchive/minizip/*.{h,c}'    
+    ss.dependency 'CodePush/NoZip'
+    ss.dependency 'CodePush/SSZipArchive'
   end
-  
+
   s.subspec 'NoZip' do |ss|
-    ss.source_files = 'ios/CodePush/*.{h,m}'    
+    ss.source_files = 'ios/CodePush/*.{h,m}'
+    ss.public_header_files = ['ios/CodePush/CodePush.h']
   end
-  
+
+  s.subspec 'SSZipArchive' do |ss|
+    ss.source_files = 'ios/CodePush/SSZipArchive/*.{h,m}', 'ios/CodePush/SSZipArchive/aes/*.{h,c}', 'ios/CodePush/SSZipArchive/minizip/*.{h,c}'
+    ss.private_header_files = 'ios/CodePush/SSZipArchive/*.h', 'ios/CodePush/SSZipArchive/aes/*.h', 'ios/CodePush/SSZipArchive/minizip/*.h'
+  end
+
 end


### PR DESCRIPTION
This allows the pod to be built as a framework (the SSZipArchive headers were previously being included in the umbrella header for the framework by cocoapods, which causes compile errors "non modular header").  E.g. when the dependent's `Podfile` includes `use_frameworks!`

Also, moved SSZipArchive into its own subspec for clarity.

FYI I tested the few configurations I can where I'm _not_ using `use_frameworks!` - but you should verify this does't bust that