### PR TITLE
Prevent dialog from invoking callback twice

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushDialog.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushDialog.java
@@ -26,8 +26,15 @@ public class CodePushDialog extends ReactContextBaseJavaModule{
         builder.setCancelable(false);
 
         DialogInterface.OnClickListener clickListener = new DialogInterface.OnClickListener() {
+            private boolean callbackConsumed = false;
+
             @Override
-            public void onClick(DialogInterface dialog, int which) {
+            public synchronized void onClick(DialogInterface dialog, int which) {
+                if (callbackConsumed) {
+                    return;
+                }
+
+                callbackConsumed = true;
                 dialog.cancel();
                 switch (which) {
                     case DialogInterface.BUTTON_POSITIVE:


### PR DESCRIPTION
This might fix https://github.com/Microsoft/react-native-code-push/issues/371, although I had trouble repro-ing it. For reference, the [React Native dialog module does something similar](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/DialogModule.java#L157).