### PR TITLE
Expose status reports via notifyAppReady()

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -429,6 +429,10 @@ if (NativeCodePush) {
       PENDING: NativeCodePush.codePushUpdateStatePending,
       LATEST: NativeCodePush.codePushUpdateStateLatest
     },
+    DeploymentStatus: {
+      FAILED: "DeploymentFailed",
+      SUCCEEDED: "DeploymentSucceeded",
+    },
     DEFAULT_UPDATE_DIALOG: {
       appendReleaseDescription: false,
       descriptionPrefix: " Description: ",

--- a/CodePush.js
+++ b/CodePush.js
@@ -172,50 +172,41 @@ const notifyApplicationReady = (() => {
 
 async function notifyApplicationReadyInternal() {
   await NativeCodePush.notifyApplicationReady();
-  tryReportStatus();
+  const statusReport = await NativeCodePush.getNewStatusReport();
+  tryReportStatus(statusReport); // Don't wait for this to complete.
+
+  return statusReport;
 }
 
-async function tryReportStatus(resumeListener) {
-  const statusReport = await NativeCodePush.getNewStatusReport();
-  if (statusReport) {
-    const config = await getConfiguration();
-    const previousLabelOrAppVersion = statusReport.previousLabelOrAppVersion;
-    const previousDeploymentKey = statusReport.previousDeploymentKey || config.deploymentKey;
-    try {
-      if (statusReport.appVersion) {
-        log(`Reporting binary update (${statusReport.appVersion})`);
-        
-        const sdk = getPromisifiedSdk(requestFetchAdapter, config);
-        await sdk.reportStatusDeploy(/* deployedPackage */ null, /* status */ null, previousLabelOrAppVersion, previousDeploymentKey);
-      } else {
-        const label = statusReport.package.label;
-        if (statusReport.status === "DeploymentSucceeded") {
-          log(`Reporting CodePush update success (${label})`);
-        } else {
-          log(`Reporting CodePush update rollback (${label})`);
-        }
-      
-        config.deploymentKey = statusReport.package.deploymentKey;
-        const sdk = getPromisifiedSdk(requestFetchAdapter, config);
-        await sdk.reportStatusDeploy(statusReport.package, statusReport.status, previousLabelOrAppVersion, previousDeploymentKey);
-      }
-      
-      NativeCodePush.recordStatusReported(statusReport);
-      resumeListener && AppState.removeEventListener("change", resumeListener);
-    } catch (e) {
-      log(`Report status failed: ${JSON.stringify(statusReport)}`);
-      NativeCodePush.saveStatusReportForRetry(statusReport);
-      // Try again when the app resumes
-      if (!resumeListener) {
-        resumeListener = (newState) => {
-          newState === "active" && tryReportStatus(resumeListener);
-        };
+async function tryReportStatus(statusReport) {
+  if (!statusReport) return;
 
-        AppState.addEventListener("change", resumeListener);
+  const config = await getConfiguration();
+  const previousLabelOrAppVersion = statusReport.previousLabelOrAppVersion;
+  const previousDeploymentKey = statusReport.previousDeploymentKey || config.deploymentKey;
+  try {
+    if (statusReport.appVersion) {
+      log(`Reporting binary update (${statusReport.appVersion})`);
+
+      const sdk = getPromisifiedSdk(requestFetchAdapter, config);
+      await sdk.reportStatusDeploy(/* deployedPackage */ null, /* status */ null, previousLabelOrAppVersion, previousDeploymentKey);
+    } else {
+      const label = statusReport.package.label;
+      if (statusReport.status === "DeploymentSucceeded") {
+        log(`Reporting CodePush update success (${label})`);
+      } else {
+        log(`Reporting CodePush update rollback (${label})`);
       }
+
+      config.deploymentKey = statusReport.package.deploymentKey;
+      const sdk = getPromisifiedSdk(requestFetchAdapter, config);
+      await sdk.reportStatusDeploy(statusReport.package, statusReport.status, previousLabelOrAppVersion, previousDeploymentKey);
     }
-  } else {
-    resumeListener && AppState.removeEventListener("change", resumeListener);
+
+    NativeCodePush.recordStatusReported(statusReport);
+  } catch (e) {
+    log(`Report status failed: ${JSON.stringify(statusReport)}`);
+    NativeCodePush.saveStatusReportForRetry(statusReport);
   }
 }
 

--- a/typings/react-native-code-push.d.ts
+++ b/typings/react-native-code-push.d.ts
@@ -3,14 +3,14 @@
 interface Promise<T> {
     /**
      * Append a rejection handler callback to the promise.
-     * 
+     *
      * @param onRejected Callback to be triggered when the promise is rejected.
      */
     catch(onRejected?: (reason: any) => Promise<T>): Promise<T>;
-    
+
     /**
      * Append a fulfillment and/or rejection handler to the promise.
-     * 
+     *
      * @param onFulfilled Callback to be triggered when the promise is fulfilled.
      * @param onRejected Callback to be triggered when the promise is rejected.
      */
@@ -25,7 +25,7 @@ export interface DownloadProgress {
      * The total number of bytes expected to be received for this update.
      */
     totalBytes: number;
-    
+
     /**
      * The number of bytes downloaded thus far.
      */
@@ -35,81 +35,81 @@ export interface DownloadProgress {
 export interface LocalPackage extends Package {
     /**
      * Installs the update by saving it to the location on disk where the runtime expects to find the latest version of the app.
-     * 
+     *
      * @param installMode Indicates when you would like the update changes to take affect for the end-user.
      * @param minimumBackgroundDuration For resume-based installs, this specifies the number of seconds the app needs to be in the background before forcing a restart. Defaults to 0 if unspecified.
      */
     install(installMode: CodePush.InstallMode, minimumBackgroundDuration?: number): Promise<void>;
 }
-    
+
 export interface Package {
     /**
      * The app binary version that this update is dependent on. This is the value that was
      * specified via the appStoreVersion parameter when calling the CLI's release command.
      */
     appVersion: string;
-    
+
     /**
      * The deployment key that was used to originally download this update.
      */
     deploymentKey: string;
-    
+
     /**
      * The description of the update. This is the same value that you specified in the CLI when you released the update.
      */
     description: string;
-    
+
     /**
      * Indicates whether this update has been previously installed but was rolled back.
      */
     failedInstall: boolean;
-    
+
     /**
      * Indicates whether this is the first time the update has been run after being installed.
      */
     isFirstRun: boolean;
-    
+
     /**
      * Indicates whether the update is considered mandatory. This is the value that was specified in the CLI when the update was released.
      */
     isMandatory: boolean;
-    
+
     /**
      * Indicates whether this update is in a "pending" state. When true, that means the update has been downloaded and installed, but the app restart
-     * needed to apply it hasn't occurred yet, and therefore, its changes aren't currently visible to the end-user. 
+     * needed to apply it hasn't occurred yet, and therefore, its changes aren't currently visible to the end-user.
      */
     isPending: boolean;
-    
+
     /**
      * The internal label automatically given to the update by the CodePush server. This value uniquely identifies the update within its deployment.
      */
     label: string;
-    
+
     /**
      * The SHA hash value of the update.
      */
     packageHash: string;
-    
+
     /**
      * The size of the code contained within the update, in bytes.
      */
     packageSize: number;
 }
-    
+
 export interface RemotePackage extends Package {
     /**
-     * Downloads the available update from the CodePush service. 
-     * 
+     * Downloads the available update from the CodePush service.
+     *
      * @param downloadProgressCallback An optional callback that allows tracking the progress of the update while it is being downloaded.
      */
     download(downloadProgressCallback?: DowloadProgressCallback): Promise<LocalPackage>;
-    
+
     /**
      * The URL at which the package is available for download.
      */
     downloadUrl: string;
 }
-    
+
 export interface SyncOptions {
     /**
      * Specifies the deployment key you want to query for an update against. By default, this value is derived from the Info.plist
@@ -117,27 +117,27 @@ export interface SyncOptions {
      * dynamically use a different deployment for a specific call to sync.
      */
     deploymentKey?: string;
-    
+
     /**
      * Specifies when you would like to install optional updates (i.e. those that aren't marked as mandatory).
      * Defaults to codePush.InstallMode.ON_NEXT_RESTART.
      */
     installMode?: CodePush.InstallMode;
-    
+
     /**
      * Specifies when you would like to install updates which are marked as mandatory.
      * Defaults to codePush.InstallMode.IMMEDIATE.
      */
     mandatoryInstallMode?: CodePush.InstallMode;
-    
+
     /**
      * Specifies the minimum number of seconds that the app needs to have been in the background before restarting the app. This property
      * only applies to updates which are installed using `InstallMode.ON_NEXT_RESUME`, and can be useful for getting your update in front
-     * of end users sooner, without being too obtrusive. Defaults to `0`, which has the effect of applying the update immediately after a 
+     * of end users sooner, without being too obtrusive. Defaults to `0`, which has the effect of applying the update immediately after a
      * resume, regardless how long it was in the background.
      */
     minimumBackgroundDuration?: number;
-    
+
     /**
      * An "options" object used to determine whether a confirmation dialog should be displayed to the end user when an update is available,
      * and if so, what strings to use. Defaults to null, which has the effect of disabling the dialog completely. Setting this to any truthy
@@ -146,46 +146,46 @@ export interface SyncOptions {
      */
     updateDialog?: UpdateDialog;
 }
-    
+
 export interface UpdateDialog {
     /**
      * Indicates whether you would like to append the description of an available release to the
      * notification message which is displayed to the end user. Defaults to false.
      */
     appendReleaseDescription?: boolean;
-    
+
     /**
      * Indicates the string you would like to prefix the release description with, if any, when
      * displaying the update notification to the end user. Defaults to " Description: "
      */
     descriptionPrefix?: string;
-    
+
     /**
      * The text to use for the button the end user must press in order to install a mandatory update. Defaults to "Continue".
      */
     mandatoryContinueButtonLabel?: string;
-    
+
     /**
      * The text used as the body of an update notification, when the update is specified as mandatory.
      * Defaults to "An update is available that must be installed.".
      */
     mandatoryUpdateMessage?: string;
-    
+
     /**
      * The text to use for the button the end user can press in order to ignore an optional update that is available. Defaults to "Ignore".
      */
     optionalIgnoreButtonLabel?: string;
-    
+
     /**
      * The text to use for the button the end user can press in order to install an optional update. Defaults to "Install".
      */
     optionalInstallButtonLabel?: string;
-    
+
     /**
      * The text used as the body of an update notification, when the update is optional. Defaults to "An update is available. Would you like to install it?".
      */
     optionalUpdateMessage?: string;
-    
+
     /**
      * The text used as the header of an update notification that is displayed to the end user. Defaults to "Update available".
      */
@@ -220,21 +220,21 @@ declare namespace CodePush {
      * an update dialog is configured to be displayed.
      */
     var DEFAULT_UPDATE_DIALOG: UpdateDialog;
-    
+
     /**
      * Asks the CodePush service whether the configured app deployment has an update available.
-     * 
+     *
      * @param deploymentKey The deployment key to use to query the CodePush server for an update.
      */
-    function checkForUpdate(deploymentKey?: string): Promise<RemotePackage>;  
+    function checkForUpdate(deploymentKey?: string): Promise<RemotePackage>;
 
     /**
      * Retrieves the metadata for an installed update (e.g. description, mandatory).
-     * 
+     *
      * @param updateState The state of the update you want to retrieve the metadata for. Defaults to UpdateState.RUNNING.
      */
     function getUpdateMetadata(updateState?: UpdateState) : Promise<LocalPackage>;
-    
+
     /**
      * Notifies the CodePush runtime that an installed update is considered successful.
      */
@@ -252,14 +252,14 @@ declare namespace CodePush {
 
     /**
      * Immediately restarts the app.
-     * 
+     *
      * @param onlyIfUpdateIsPending Indicates whether you want the restart to no-op if there isn't currently a pending update.
      */
     function restartApp(onlyIfUpdateIsPending?: boolean): void;
-    
+
     /**
      * Allows checking for an update, downloading it and installing it, all with a single call.
-     * 
+     *
      * @param options Options used to configure the end-user update experience (e.g. show an prompt?, install the update immediately?).
      * @param syncStatusChangedCallback An optional callback that allows tracking the status of the sync operation, as opposed to simply checking the resolved state via the returned Promise.
      * @param downloadProgressCallback An optional callback that allows tracking the progress of an update while it is being downloaded.
@@ -271,22 +271,22 @@ declare namespace CodePush {
      */
     enum InstallMode {
         /**
-         * Indicates that you want to install the update and restart the app immediately. 
+         * Indicates that you want to install the update and restart the app immediately.
          */
         IMMEDIATE,
-        
+
         /**
-         * Indicates that you want to install the update, but not forcibly restart the app. 
+         * Indicates that you want to install the update, but not forcibly restart the app.
          */
         ON_NEXT_RESTART,
-        
+
         /**
          * Indicates that you want to install the update, but don't want to restart the
          * app until the next time the end user resumes it from the background.
          */
         ON_NEXT_RESUME
     }
-    
+
     /**
      * Indicates the current status of a sync operation.
      */

--- a/typings/react-native-code-push.d.ts
+++ b/typings/react-native-code-push.d.ts
@@ -369,7 +369,7 @@ declare namespace CodePush {
      */
     enum DeploymentStatus {
         /**
-         * The deployment failed.
+         * The deployment failed (and was rolled back).
          */
         FAILED,
 

--- a/typings/react-native-code-push.d.ts
+++ b/typings/react-native-code-push.d.ts
@@ -199,9 +199,14 @@ export interface StatusReport {
     status: CodePush.DeploymentStatus;
 
     /**
+     * The version of the app that was deployed (for a native app upgrade).
+     */
+    appVersion?: string;
+
+    /**
      * Details of the package that was deployed (or attempted to).
      */
-    package: Package;
+    package?: Package;
 
     /**
      * Deployment key used when deploying the previous package.

--- a/typings/react-native-code-push.d.ts
+++ b/typings/react-native-code-push.d.ts
@@ -191,8 +191,30 @@ export interface UpdateDialog {
      */
     title?: string;
 }
-      
-declare namespace CodePush { 
+
+export interface StatusReport {
+    /**
+     * Whether the deployment succeeded or failed.
+     */
+    status: CodePush.DeploymentStatus;
+
+    /**
+     * Details of the package that was deployed (or attempted to).
+     */
+    package: Package;
+
+    /**
+     * Deployment key used when deploying the previous package.
+     */
+    previousDeploymentKey?: string;
+
+    /**
+     * The label (v#) of the package that was upgraded from.
+     */
+    previousLabelOrAppVersion?: string;
+}
+
+declare namespace CodePush {
     /**
      * Represents the default settings that will be used by the sync method if
      * an update dialog is configured to be displayed.
@@ -216,7 +238,7 @@ declare namespace CodePush {
     /**
      * Notifies the CodePush runtime that an installed update is considered successful.
      */
-    function notifyAppReady(): Promise<void>;
+    function notifyAppReady(): Promise<StatusReport>;
 
     /**
      * Allow CodePush to restart the app.
@@ -273,73 +295,88 @@ declare namespace CodePush {
          * The CodePush server is being queried for an update.
          */
         CHECKING_FOR_UPDATE,
-        
+
         /**
          * An update is available, and a confirmation dialog was shown
          * to the end user. (This is only applicable when the updateDialog is used)
          */
         AWAITING_USER_ACTION,
-        
+
         /**
          * An available update is being downloaded from the CodePush server.
          */
         DOWNLOADING_PACKAGE,
-        
+
         /**
          * An available update was downloaded and is about to be installed.
          */
         INSTALLING_UPDATE,
-        
-        /** 
+
+        /**
          * The app is up-to-date with the CodePush server.
          */
         UP_TO_DATE,
-        
+
         /**
          * The app had an optional update which the end user chose to ignore.
          * (This is only applicable when the updateDialog is used)
          */
         UPDATE_IGNORED,
-        
+
         /**
          * An available update has been installed and will be run either immediately after the
          * syncStatusChangedCallback function returns or the next time the app resumes/restarts,
          * depending on the InstallMode specified in SyncOptions
          */
         UPDATE_INSTALLED,
-        
+
         /**
          * There is an ongoing sync operation running which prevents the current call from being executed.
          */
         SYNC_IN_PROGRESS,
-        
+
         /**
          * The sync operation encountered an unknown error.
          */
         UNKNOWN_ERROR
     }
-    
+
     /**
      * Indicates the state that an update is currently in.
      */
     enum UpdateState {
         /**
          * Indicates that an update represents the
-         * version of the app that is currently running. 
+         * version of the app that is currently running.
          */
         RUNNING,
-        
+
         /**
          * Indicates than an update has been installed, but the
          * app hasn't been restarted yet in order to apply it.
          */
         PENDING,
-        
+
         /**
          * Indicates than an update represents the latest available
          * release, and can be either currently running or pending.
          */
         LATEST
+    }
+
+    /**
+     * Indicates the status of a deployment (after installing and restarting).
+     */
+    enum DeploymentStatus {
+        /**
+         * The deployment failed.
+         */
+        FAILED,
+
+        /**
+         * The deployment succeeded.
+         */
+        SUCCEEDED
     }
 }
 


### PR DESCRIPTION
Handy for tracking whether a deployment succeeded/failed!  We're using this to emit analytics (Mixpanel) events on subsequent launches (success or rollback)

---

Note that I removed the `resumeListener` references, as it was completely unused; lemme know if you want me to preserve it instead!  Ditto the whitespace changes