### PR TITLE
Improve podspec

### DIFF
--- a/CodePush.podspec
+++ b/CodePush.podspec
@@ -6,10 +6,10 @@ Pod::Spec.new do |s|
 
   s.name           = 'CodePush'
   s.version        = package['version'].sub('-beta', '')
-  s.summary        = 'React Native module for the CodePush service'
-  s.author         = 'Microsoft Corporation'
-  s.license        = 'MIT'
-  s.homepage       = 'http://microsoft.github.io/code-push/'
+  s.summary        = package['description']
+  s.author         = package['author']
+  s.license        = package['license']
+  s.homepage       = package['homepage']
   s.source         = { :git => 'https://github.com/Microsoft/react-native-code-push.git', :tag => "v#{s.version}-beta"}
   s.platform       = :ios, '7.0'
   s.preserve_paths = '*.js'


### PR DESCRIPTION
This PR simply reduces further duplication in our `CodePush.podspec` file by deriving the `summary`, `author`, `homepage` and `license` properties from the `package.json` file. 