### PR TITLE
Improving "update is invalid" error message

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushPackage.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushPackage.java
@@ -253,7 +253,7 @@ public class CodePushPackage {
             String relativeBundlePath = CodePushUpdateUtils.findJSBundleInUpdateContents(newUpdateFolderPath, expectedBundleFileName);
 
             if (relativeBundlePath == null) {
-                throw new CodePushInvalidUpdateException("Update is invalid - A JS bundle file named \"" + expectedBundleFileName + "\" could not be found within the downloaded contents. Please check that you are releasing your CodePush updates using the exact same JS bundle file name that was shipped with your app's binary.");
+                throw new CodePushInvalidUpdateException("Update is invalid - A JS bundle file named \"" + expectedBundleFileName + "\" could not be found within the downloaded contents. Please ensure that your app is syncing with the correct deployment and that you are releasing your CodePush updates using the exact same JS bundle file name that was shipped with your app's binary.");
             } else {
                 if (FileUtils.fileAtPathExists(newUpdateMetadataPath)) {
                     File metadataFileFromOldUpdate = new File(newUpdateMetadataPath);

--- a/ios/CodePush/CodePushPackage.m
+++ b/ios/CodePush/CodePushPackage.m
@@ -214,7 +214,7 @@ static NSString *const UnzippedFolderName = @"unzipped";
                                                         if (relativeBundlePath) {
                                                             [mutableUpdatePackage setValue:relativeBundlePath forKey:RelativeBundlePathKey];
                                                         } else {
-                                                            NSString *errorMessage = [NSString stringWithFormat:@"Update is invalid - A JS bundle file named \"%@\" could not be found within the downloaded contents. Please check that you are releasing your CodePush updates using the exact same JS bundle file name that was shipped with your app's binary.", expectedBundleFileName];
+                                                            NSString *errorMessage = [NSString stringWithFormat:@"Update is invalid - A JS bundle file named \"%@\" could not be found within the downloaded contents. Please ensure that your app is syncing with the correct deployment and that you are releasing your CodePush updates using the exact same JS bundle file name that was shipped with your app's binary.", expectedBundleFileName];
                                                             
                                                             error = [CodePushErrorUtils errorWithMessage:errorMessage];
                                                             


### PR DESCRIPTION
This addresses #381 by improving our existing "Update is invalid" message to also mention the need to verify that the configured deployment is correct.