### PR TITLE
Bug fix for #379 where status report can be undefined on notifyApplicationReady

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -173,7 +173,7 @@ const notifyApplicationReady = (() => {
 async function notifyApplicationReadyInternal() {
   await NativeCodePush.notifyApplicationReady();
   const statusReport = await NativeCodePush.getNewStatusReport();
-  tryReportStatus(statusReport); // Don't wait for this to complete.
+  statusReport && tryReportStatus(statusReport); // Don't wait for this to complete.
 
   return statusReport;
 }

--- a/typings/react-native-code-push.d.ts
+++ b/typings/react-native-code-push.d.ts
@@ -243,7 +243,7 @@ declare namespace CodePush {
     /**
      * Notifies the CodePush runtime that an installed update is considered successful.
      */
-    function notifyAppReady(): Promise<StatusReport>;
+    function notifyAppReady(): Promise<StatusReport|void>;
 
     /**
      * Allow CodePush to restart the app.


### PR DESCRIPTION
I introduced a JS error on subsequent launches after an update is applied, where `getNewStatusReport()` returns nothing.  This fixes it!