### PR TITLE
Binary hash (iOS)

### DIFF
--- a/ios/CodePush/CodePushUpdateUtils.m
+++ b/ios/CodePush/CodePushUpdateUtils.m
@@ -40,6 +40,16 @@ NSString * const ManifestFolderPrefix = @"CodePush";
     }
 }
 
++ (void)addFileToManifest:(NSURL *)fileURL
+                 manifest:(NSMutableArray *)manifest
+{
+    if ([[NSFileManager defaultManager] fileExistsAtPath:[fileURL path]]) {
+        NSData *fileContents = [NSData dataWithContentsOfURL:fileURL];
+        NSString *fileContentsHash = [self computeHashForData:fileContents];
+        [manifest addObject:[NSString stringWithFormat:@"%@/%@:%@", [self manifestFolderPrefix], [fileURL lastPathComponent], fileContentsHash]];
+    }
+}
+
 + (NSString *)computeFinalHashFromManifest:(NSMutableArray *)manifest
                                      error:(NSError **)error
 {
@@ -190,9 +200,9 @@ NSString * const ManifestFolderPrefix = @"CodePush";
         }
     }
     
-    NSData *jsBundleContents = [NSData dataWithContentsOfURL:binaryBundleUrl];
-    NSString *jsBundleContentsHash = [self computeHashForData:jsBundleContents];
-    [manifest addObject:[[NSString stringWithFormat:@"%@/%@:", [self manifestFolderPrefix], [binaryBundleUrl lastPathComponent]] stringByAppendingString:jsBundleContentsHash]];
+    [self addFileToManifest:binaryBundleUrl manifest:manifest];
+    [self addFileToManifest:[binaryBundleUrl URLByAppendingPathExtension:@"meta"] manifest:manifest];
+
     binaryHash = [self computeFinalHashFromManifest:manifest error:error];
     
     // Cache the hash in user preferences. This assumes that the modified date for the


### PR DESCRIPTION
This fixes the binary hashing feature for apps using React Native 0.29.0+ by accounting for the new `*.meta` file which is generated as part of the bundle. I verified that it works perfectly with this fix, and the fix that the RN team made to 0.29.0-RC.