### PR TITLE
Prepend iOS native logs with "\n[CodePush] "

### DIFF
--- a/ios/CodePush.xcodeproj/project.pbxproj
+++ b/ios/CodePush.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		1BCC09A71CC19EB700DDC0DD /* RCTConvert+CodePushUpdateState.m in Sources */ = {isa = PBXBuildFile; fileRef = 1BCC09A61CC19EB700DDC0DD /* RCTConvert+CodePushUpdateState.m */; };
 		540D20121C7684FE00D6EF41 /* CodePushUpdateUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 540D20111C7684FE00D6EF41 /* CodePushUpdateUtils.m */; };
 		5421FE311C58AD5A00986A55 /* CodePushTelemetryManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5421FE301C58AD5A00986A55 /* CodePushTelemetryManager.m */; };
+		5498D8F61D21F14100B5EB43 /* CodePushUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 5498D8F51D21F14100B5EB43 /* CodePushUtils.m */; };
 		54A0026C1C0E2880004C3CEC /* aescrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 54A0024C1C0E2880004C3CEC /* aescrypt.c */; };
 		54A0026D1C0E2880004C3CEC /* aeskey.c in Sources */ = {isa = PBXBuildFile; fileRef = 54A0024D1C0E2880004C3CEC /* aeskey.c */; };
 		54A0026E1C0E2880004C3CEC /* aestab.c in Sources */ = {isa = PBXBuildFile; fileRef = 54A0024F1C0E2880004C3CEC /* aestab.c */; };
@@ -53,6 +54,7 @@
 		1BCC09A61CC19EB700DDC0DD /* RCTConvert+CodePushUpdateState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "RCTConvert+CodePushUpdateState.m"; path = "CodePush/RCTConvert+CodePushUpdateState.m"; sourceTree = "<group>"; };
 		540D20111C7684FE00D6EF41 /* CodePushUpdateUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CodePushUpdateUtils.m; path = CodePush/CodePushUpdateUtils.m; sourceTree = "<group>"; };
 		5421FE301C58AD5A00986A55 /* CodePushTelemetryManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CodePushTelemetryManager.m; path = CodePush/CodePushTelemetryManager.m; sourceTree = "<group>"; };
+		5498D8F51D21F14100B5EB43 /* CodePushUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CodePushUtils.m; path = CodePush/CodePushUtils.m; sourceTree = "<group>"; };
 		54A0024A1C0E2880004C3CEC /* aes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aes.h; sourceTree = "<group>"; };
 		54A0024B1C0E2880004C3CEC /* aes_via_ace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aes_via_ace.h; sourceTree = "<group>"; };
 		54A0024C1C0E2880004C3CEC /* aescrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aescrypt.c; sourceTree = "<group>"; };
@@ -170,6 +172,7 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
+				5498D8F51D21F14100B5EB43 /* CodePushUtils.m */,
 				13BE3DEC1AC21097009241FE /* CodePush.h */,
 				13BE3DED1AC21097009241FE /* CodePush.m */,
 				81D51F391B6181C2000DA084 /* CodePushConfig.m */,
@@ -263,6 +266,7 @@
 				54A0026C1C0E2880004C3CEC /* aescrypt.c in Sources */,
 				1B762E901C9A5E9A006EF800 /* CodePushErrorUtils.m in Sources */,
 				54A002701C0E2880004C3CEC /* fileenc.c in Sources */,
+				5498D8F61D21F14100B5EB43 /* CodePushUtils.m in Sources */,
 				810D4E6D1B96935000B397E9 /* CodePushPackage.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/CodePush/CodePush.h
+++ b/ios/CodePush/CodePush.h
@@ -143,6 +143,8 @@ failCallback:(void (^)(NSError *err))failCallback;
 
 @end
 
+void CPLog(NSString *formatString, ...);
+
 typedef NS_ENUM(NSInteger, CodePushInstallMode) {
     CodePushInstallModeImmediate,
     CodePushInstallModeOnNextRestart,

--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -91,7 +91,7 @@ static NSString *bundleResourceName = @"main";
     NSURL *binaryBundleURL = [self binaryBundleURL];
 
     if (error || !packageFile) {
-        NSLog(logMessageFormat, binaryBundleURL);
+        CPLog(logMessageFormat, binaryBundleURL);
         isRunningBinaryVersion = YES;
         return binaryBundleURL;
     }
@@ -99,7 +99,7 @@ static NSString *bundleResourceName = @"main";
     NSString *binaryAppVersion = [[CodePushConfig current] appVersion];
     NSDictionary *currentPackageMetadata = [CodePushPackage getCurrentPackage:&error];
     if (error || !currentPackageMetadata) {
-        NSLog(logMessageFormat, binaryBundleURL);
+        CPLog(logMessageFormat, binaryBundleURL);
         isRunningBinaryVersion = YES;
         return binaryBundleURL;
     }
@@ -110,7 +110,7 @@ static NSString *bundleResourceName = @"main";
     if ([[CodePushUpdateUtils modifiedDateStringOfFileAtURL:binaryBundleURL] isEqualToString:packageDate] && ([CodePush isUsingTestConfiguration] ||[binaryAppVersion isEqualToString:packageAppVersion])) {
         // Return package file because it is newer than the app store binary's JS bundle
         NSURL *packageUrl = [[NSURL alloc] initFileURLWithPath:packageFile];
-        NSLog(logMessageFormat, packageUrl);
+        CPLog(logMessageFormat, packageUrl);
         isRunningBinaryVersion = NO;
         return packageUrl;
     } else {
@@ -123,7 +123,7 @@ static NSString *bundleResourceName = @"main";
             [CodePush clearUpdates];
         }
 
-        NSLog(logMessageFormat, binaryBundleURL);
+        CPLog(logMessageFormat, binaryBundleURL);
         isRunningBinaryVersion = YES;
         return binaryBundleURL;
     }
@@ -310,7 +310,7 @@ static NSString *bundleResourceName = @"main";
         if (updateIsLoading) {
             // Pending update was initialized, but notifyApplicationReady was not called.
             // Therefore, deduce that it is a broken update and rollback.
-            NSLog(@"Update did not finish loading the last time, rolling back to a previous version.");
+            CPLog(@"Update did not finish loading the last time, rolling back to a previous version.");
             needToReportRollback = YES;
             [self rollbackPackage];
         } else {
@@ -582,7 +582,7 @@ RCT_EXPORT_METHOD(getConfiguration:(RCTPromiseResolveBlock)resolve
         // isRunningBinaryVersion will not get set to "YES" if running against the packager.
         NSString *binaryHash = [CodePushUpdateUtils getHashForBinaryContents:[CodePush binaryBundleURL] error:&error];
         if (error) {
-            NSLog(@"Error obtaining hash for binary contents: %@", error);
+            CPLog(@"Error obtaining hash for binary contents: %@", error);
             resolve(configuration);
             return;
         }

--- a/ios/CodePush/CodePushPackage.m
+++ b/ios/CodePush/CodePushPackage.m
@@ -29,7 +29,7 @@ static NSString *const UnzippedFolderName = @"unzipped";
                                                              error:&error];
     
     if (error) {
-        NSLog(@"Error downloading from URL %@", remoteBundleUrl);
+        CPLog(@"Error downloading from URL %@", remoteBundleUrl);
     } else {
         NSString *currentPackageBundlePath = [self getCurrentPackageBundlePath:&error];
         [downloadedBundle writeToFile:currentPackageBundlePath
@@ -101,7 +101,7 @@ static NSString *const UnzippedFolderName = @"unzipped";
                                                         [[NSFileManager defaultManager] removeItemAtPath:downloadFilePath
                                                                                                    error:&nonFailingError];
                                                         if (nonFailingError) {
-                                                            NSLog(@"Error deleting downloaded file: %@", nonFailingError);
+                                                            CPLog(@"Error deleting downloaded file: %@", nonFailingError);
                                                             nonFailingError = nil;
                                                         }
                                                         
@@ -198,7 +198,7 @@ static NSString *const UnzippedFolderName = @"unzipped";
                                                         [[NSFileManager defaultManager] removeItemAtPath:unzippedFolderPath
                                                                                                    error:&nonFailingError];
                                                         if (nonFailingError) {
-                                                            NSLog(@"Error deleting downloaded file: %@", nonFailingError);
+                                                            CPLog(@"Error deleting downloaded file: %@", nonFailingError);
                                                             nonFailingError = nil;
                                                         }
                                                         
@@ -462,7 +462,7 @@ static NSString *const UnzippedFolderName = @"unzipped";
             [[NSFileManager defaultManager] removeItemAtPath:currentPackageFolderPath
                                                        error:&deleteError];
             if (deleteError) {
-                NSLog(@"Error deleting pending package: %@", deleteError);
+                CPLog(@"Error deleting pending package: %@", deleteError);
             }
         }
     } else {
@@ -474,7 +474,7 @@ static NSString *const UnzippedFolderName = @"unzipped";
             [[NSFileManager defaultManager] removeItemAtPath:previousPackageFolderPath
                                                        error:&deleteError];
             if (deleteError) {
-                NSLog(@"Error deleting old package: %@", deleteError);
+                CPLog(@"Error deleting old package: %@", deleteError);
             }
         }
         [info setValue:info[@"currentPackage"] forKey:@"previousPackage"];
@@ -503,7 +503,7 @@ static NSString *const UnzippedFolderName = @"unzipped";
     [[NSFileManager defaultManager] removeItemAtPath:currentPackageFolderPath
                                                error:&deleteError];
     if (deleteError) {
-        NSLog(@"Error deleting current package contents at %@", currentPackageFolderPath);
+        CPLog(@"Error deleting current package contents at %@", currentPackageFolderPath);
     }
     
     [info setValue:info[@"previousPackage"] forKey:@"currentPackage"];

--- a/ios/CodePush/CodePushUtils.m
+++ b/ios/CodePush/CodePushUtils.m
@@ -1,0 +1,9 @@
+#import "CodePush.h"
+
+void CPLog(NSString *formatString, ...) {
+    va_list args;
+    va_start(args, formatString);
+    NSString *prependedFormatString = [NSString stringWithFormat:@"\n[CodePush] %@", formatString];
+    NSLogv(prependedFormatString, args);
+    va_end(args);
+}


### PR DESCRIPTION
This PR creates a `CPLog` C function which is used to prepend all the logs from native with `\n[CodePush] `. The line break is needed so that the `code-push debug` command picks them up, plus it looks nicer in the debug console anyway:

Without line break:
```
2016-06-27 17:44:11.708 CodePushDemoApp[10313:75249] [CodePush] Loading JS bundle from file:///***/main.jsbundle
```

With line break:
```
2016-06-27 17:44:11.708 CodePushDemoApp[10313:75249]
[CodePush] Loading JS bundle from file:///***/main.jsbundle
```

The `CPLog` function is implemented as a C function for convenience and API similarity with `NSLog`.