### PR TITLE
Fixed README docs to refer to CodePush.getBundleUrl()

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ public class MainApplication extends Application implements ReactApplication {
         // bundle location from on each app start
         @Override
         protected String getJSBundleFile() {
-            return CodePush.getJSBundleFile();
+            return CodePush.getBundleUrl();
         }
 
         @Override
@@ -309,7 +309,7 @@ public class MainActivity extends ReactActivity {
     // bundle location from on each app start
     @Override
     protected String getJSBundleFile() {
-        return CodePush.getJSBundleFile();
+        return CodePush.getBundleUrl();
     }
 
     @Override


### PR DESCRIPTION
Originally the docs wrote to use CodePush.getJSBundleFile(), which does not exist. Referring to https://github.com/Microsoft/react-native-code-push/issues/304