### PR TITLE
No-op in CodePushPackage.m / CodePushUpdateManager.java if the pending update is already installed

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateManager.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateManager.java
@@ -275,6 +275,13 @@ public class CodePushUpdateManager {
     public void installPackage(ReadableMap updatePackage, boolean removePendingUpdate) {
         String packageHash = CodePushUtils.tryGetString(updatePackage, CodePushConstants.PACKAGE_HASH_KEY);
         WritableMap info = getCurrentPackageInfo();
+
+        String currentPackageHash = CodePushUtils.tryGetString(info, CodePushConstants.CURRENT_PACKAGE_KEY);
+        if (packageHash != null && packageHash.equals(currentPackageHash)) {
+            // The current package is already the one being installed, so we should no-op.
+            return;
+        }
+
         if (removePendingUpdate) {
             String currentPackageFolderPath = getCurrentPackageFolderPath();
             if (currentPackageFolderPath != null) {

--- a/ios/CodePush/CodePushPackage.m
+++ b/ios/CodePush/CodePushPackage.m
@@ -454,6 +454,11 @@ static NSString *const UnzippedFolderName = @"unzipped";
         return;
     }
     
+    if (packageHash && [packageHash isEqualToString:info[@"currentPackage"]]) {
+        // The current package is already the one being installed, so we should no-op.
+        return;
+    }
+
     if (removePendingUpdate) {
         NSString *currentPackageFolderPath = [self getCurrentPackageFolderPath:error];
         if (!*error && currentPackageFolderPath) {


### PR DESCRIPTION
This PR fixes https://github.com/Microsoft/react-native-code-push/issues/378. When the same update is installed twice, we would previously delete the current package's contents erroneously.