### PR TITLE
Change the plugin's build.gradle to depend on RN 0.19.+

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -22,5 +22,5 @@ android {
 dependencies {
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
-    compile "com.facebook.react:react-native:+"
+    compile "com.facebook.react:react-native:0.19.+"
 }


### PR DESCRIPTION
Using `"com.facebook.react:react-native:+"` causes apps that using RN 0.19 to crash on start, because our plugin would pull the latest version from maven central, which is somehow incompatible.

I verified that if we keep it as `"com.facebook.react:react-native:0.19.+"`, a RN 0.29 app still runs fine. The [camera plugin](https://github.com/lwansbrough/react-native-camera/blob/master/android/build.gradle#L34) also uses this syntax.

Ideally, we want to use the same version of React Native that the app uses, which is the one shipped in the node_modules folder. However, shipping the library files together via NPM was something RN only started doing after 0.19.