### PR TITLE
Improve legacy restart logic

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -79,13 +79,13 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
         return false;
     }
 
-    private void loadBundleLegacy(final Activity activity) {
+    private void loadBundleLegacy(final Activity currentActivity) {
         mCodePush.invalidateCurrentInstance();
 
-        activity.runOnUiThread(new Runnable() {
+        currentActivity.runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                activity.recreate();
+                currentActivity.recreate();
             }
         });
     }

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -79,24 +79,26 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
         return false;
     }
 
-    private void loadBundleLegacy() {
-        Activity currentActivity = getCurrentActivity();
-        Intent intent = currentActivity.getIntent();
-        currentActivity.finish();
-        currentActivity.startActivity(intent);
-
+    private void loadBundleLegacy(final Activity activity) {
         mCodePush.invalidateCurrentInstance();
+
+        activity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.recreate();
+            }
+        });
     }
 
     private void loadBundle() {
         mCodePush.clearDebugCacheIfNeeded();
-        Activity currentActivity = getCurrentActivity();
+        final Activity currentActivity = getCurrentActivity();
 
         if (!ReactActivity.class.isInstance(currentActivity)) {
             // Our preferred reload logic relies on the user's Activity inheriting
             // from the core ReactActivity class, so if it doesn't, we fallback
             // early to our legacy behavior.
-            loadBundleLegacy();
+            loadBundleLegacy(currentActivity);
         } else {
             try {
                 ReactActivity reactActivity = (ReactActivity)currentActivity;
@@ -144,14 +146,14 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
                         catch (Exception e) {
                             // The recreation method threw an unknown exception
                             // so just simply fallback to restarting the Activity
-                            loadBundleLegacy();
+                            loadBundleLegacy(currentActivity);
                         }
                     }
                 });
             } catch (Exception e) {
                 // Our reflection logic failed somewhere
                 // so fall back to restarting the Activity
-                loadBundleLegacy();
+                loadBundleLegacy(currentActivity);
             }
         }
     }


### PR DESCRIPTION
This PR improves our legacy restart logic in two ways:

1. It re-uses the same `Activity` instance that was captured in the `loadBundle` method, which prevents it from failing victim to the `getCurrentActivity` method returning `null` by the time it is called. It's rare, but possible, so in general, it seems to make sense to capture a strong reference to the `Activity` once, and then re-use that throughout the lifecycle of the reload operation.

2. It uses the `Activity.recreate` method, instead of "manually" finishing the current `Activity` and then attempting to restart is via an `Intent`. This is the "official" way of doing this post-Honeycomb, and since we don't need to support Android versions older than that (or even as old as that!), we mine as well use it. Additionally, this safeguards us from potential issues where `Activity.getIntent()` returns `null` due to the `Activity` having been destroyed, and we are therefore not actually able to restart the `Activity` again.

As a side-effect, the user experience is actually much better, and the `Activity` doesn't "slide out" and then come back. The `recreate` method performs a "flash" update very similarly to what our reflection-based logic achieves, so in general, this seems to be much better then the existing solution for scenarios that we need to fall back to it.