### PR TITLE
Clean up gradle file

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'com.android.library'
+apply plugin: "com.android.library"
 
 android {
     compileSdkVersion 23
@@ -11,16 +11,11 @@ android {
         versionName "1.0"
     }
 
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
+    lintOptions {
+        abortOnError false
     }
 }
 
 dependencies {
-    compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:23.0.1"
     compile "com.facebook.react:react-native:0.19.+"
 }


### PR DESCRIPTION
This PR primarily ensures that any lint errors within our plugin don't break the build of a hosting app. We had a user-reported issue related to this over the weekend, and other React Native plugins disable this (e.g. react-native-vector-icons), so it seems like a good change to make in general.

While making this change, I also cleaned up some of the stuff that isn't necessary as a first step towards "converting" our Android implementation into a library project, instead of the app structure that it currently has (e.g. we can delete our `settings.gradle` and local grade copy, etc.).