### PR TITLE
[Android] Removing native module reference from CodePush class

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -35,7 +35,6 @@ public class CodePush implements ReactPackage {
     private String mAssetsBundleFileName;
 
     // Helper classes.
-    private CodePushNativeModule mNativeModule;
     private CodePushUpdateManager mUpdateManager;
     private CodePushTelemetryManager mTelemetryManager;
     private SettingsManager mSettingsManager;
@@ -278,13 +277,12 @@ public class CodePush implements ReactPackage {
 
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactApplicationContext) {
-        List<NativeModule> nativeModules = new ArrayList<>();
-        mNativeModule = new CodePushNativeModule(reactApplicationContext, this, mUpdateManager, mTelemetryManager, mSettingsManager);
+        CodePushNativeModule codePushModule = new CodePushNativeModule(reactApplicationContext, this, mUpdateManager, mTelemetryManager, mSettingsManager);
         CodePushDialog dialogModule = new CodePushDialog(reactApplicationContext);
 
-        nativeModules.add(mNativeModule);
+        List<NativeModule> nativeModules = new ArrayList<>();        
+        nativeModules.add(codePushModule);
         nativeModules.add(dialogModule);
-
         return nativeModules;
     }
 


### PR DESCRIPTION
This PR simply removes the unnecessary `CodePushNativeModule` reference that the `CodePush` class was holding on to, but not actually using for anything (after the recent refactoring). Since the `CodePush` class instance persists across app restarts, it shouldn't be holding on to instances of the `CodePushNativeModule` object, which wouldn't survive a restart, and therefore, could be getting accidentally leaked.