### PR TITLE
[Android] Guarding against NPEs in getConfiguration

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -80,6 +80,8 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
     }
 
     private void loadBundleLegacy(final Activity currentActivity) {
+        CodePushUtils.log("Legacy restart logic being used");
+
         mCodePush.invalidateCurrentInstance();
 
         currentActivity.runOnUiThread(new Runnable() {
@@ -240,19 +242,23 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void getConfiguration(Promise promise) {
-        Activity currentActivity = getCurrentActivity();
         WritableNativeMap configMap = new WritableNativeMap();
         configMap.putString("appVersion", mCodePush.getAppVersion());
         configMap.putString("deploymentKey", mCodePush.getDeploymentKey());
         configMap.putString("serverUrl", mCodePush.getServerUrl());
-        configMap.putString("clientUniqueId",
-                Settings.Secure.getString(currentActivity.getContentResolver(),
-                        android.provider.Settings.Secure.ANDROID_ID));
-        String binaryHash = CodePushUpdateUtils.getHashForBinaryContents(currentActivity, mCodePush.isDebugMode());
-        if (binaryHash != null) {
-            // binaryHash will be null if the React Native assets were not bundled into the APK
-            // (e.g. in Debug builds)
-            configMap.putString(CodePushConstants.PACKAGE_HASH_KEY, binaryHash);
+
+        Activity currentActivity = getCurrentActivity();
+        if (currentActivity != null) {
+            configMap.putString("clientUniqueId",
+                    Settings.Secure.getString(currentActivity.getContentResolver(),
+                            android.provider.Settings.Secure.ANDROID_ID));
+
+            String binaryHash = CodePushUpdateUtils.getHashForBinaryContents(currentActivity, mCodePush.isDebugMode());
+            if (binaryHash != null) {
+                // binaryHash will be null if the React Native assets were not bundled into the APK
+                // (e.g. in Debug builds)
+                configMap.putString(CodePushConstants.PACKAGE_HASH_KEY, binaryHash);
+            }
         }
 
         promise.resolve(configMap);

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -80,8 +80,6 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
     }
 
     private void loadBundleLegacy(final Activity currentActivity) {
-        CodePushUtils.log("Legacy restart logic being used");
-
         mCodePush.invalidateCurrentInstance();
 
         currentActivity.runOnUiThread(new Runnable() {

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateUtils.java
@@ -1,6 +1,6 @@
 package com.microsoft.codepush.react;
 
-import android.app.Activity;
+import android.content.Context;
 
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.WritableMap;
@@ -98,9 +98,9 @@ public class CodePushUpdateUtils {
         return null;
     }
 
-    public static String getHashForBinaryContents(Activity mainActivity, boolean isDebugMode) {
+    public static String getHashForBinaryContents(Context context, boolean isDebugMode) {
         try {
-            return CodePushUtils.getStringFromInputStream(mainActivity.getAssets().open(CodePushConstants.CODE_PUSH_HASH_FILE_NAME));
+            return CodePushUtils.getStringFromInputStream(context.getAssets().open(CodePushConstants.CODE_PUSH_HASH_FILE_NAME));
         } catch (IOException e) {
             if (!isDebugMode) {
                 // Only print this message in "Release" mode. In "Debug", we may not have the


### PR DESCRIPTION
This PR addresses the tactical element of #414 by safeguarding the `getConfiguration` native module method against NPEs. It's still unclear when and why `getCurrentActivity` could return `null` (while the app is still in the foreground), but in general, we should strive to prevent any and all crashes, and we know from customer reports that `getCurrentActivity` can sometimes return `null`, so we should enable "progressive enhancement" in our plugin whenever we can access the `Activity`, and not fail completely when we can't.

Since the device ID is really important (i.e. it enables install metrics and rollout), and cheap to compute, I moved it to be captured as part of the native module being created, at which point, we shouldn't ever have an issue. However, since generating the binary hash is a little more expensive, I left that to happen lazily as part of `getConfiguration`, and therefore, if `getCurrentActivity` returns `null`, the worst case scenario is that binary hashing will stop working.

As pointed out by @geof90, React Native core modules also do `null` checks when calling `getCurrentActivity`, so in general, this seems like a reasonable change to make.