### PR TITLE
Add resume listener for immediate installs

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -388,7 +388,7 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
                     // if the current activity is backgrounded, we want to reload the bundle when
                     // it comes back into the foreground.
                     installMode == CodePushInstallMode.IMMEDIATE.getValue()) {
-                    
+
                     // Store the minimum duration on the native module as an instance
                     // variable instead of relying on a closure below, so that any
                     // subsequent resume-based installs could override it.
@@ -401,15 +401,19 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
 
                             @Override
                             public void onHostResume() {
-                                // Determine how long the app was in the background and ensure
-                                // that it meets the minimum duration amount of time.
-                                long durationInBackground = 0;
-                                if (lastPausedDate != null) {
-                                    durationInBackground = (new Date().getTime() - lastPausedDate.getTime()) / 1000;
-                                }
-
-                                if (durationInBackground >= CodePushNativeModule.this.mMinimumBackgroundDuration) {
+                                if (installMode == CodePushInstallMode.IMMEDIATE.getValue()) {
                                     loadBundle();
+                                } else {
+                                    // Determine how long the app was in the background and ensure
+                                    // that it meets the minimum duration amount of time.
+                                    long durationInBackground = 0;
+                                    if (lastPausedDate != null) {
+                                        durationInBackground = (new Date().getTime() - lastPausedDate.getTime()) / 1000;
+                                    }
+
+                                    if (durationInBackground >= CodePushNativeModule.this.mMinimumBackgroundDuration) {
+                                        loadBundle();
+                                    }
                                 }
                             }
 


### PR DESCRIPTION
This fixes https://github.com/Microsoft/react-native-code-push/issues/423.

- No-op `loadBundle()` if `getCurrentActivity()` returns `null`, preventing a `NullPointerException`.
- Add the resume listener even for `InstallMode = IMMEDIATE` installs.

**There can be two situations when `getCurrentActivity` returns `null`:** 

1. The current activity gets backgrounded (e.g. by starting a new native Activity), so [React Native sets it to `null` in the `onHostPause` listener](https://github.com/facebook/react-native/blob/e3b594839262ffecb4e90a075d46df52c4d33350/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java#L181)

2. The current activity is killed (either by the OS, or explicitly).

**Why I think this is the right fix:**

- If 1. happens, when the app goes back to the current activity after it was backgrounded, the resume listener will kick in and automatically restart the app, picking up the new update. This works because [when the activity comes back to the foreground, React Native resets the `currentActivity`](https://github.com/facebook/react-native/blob/e3b594839262ffecb4e90a075d46df52c4d33350/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java#L159).

- If 2. happens, we really don't have to do anything beyond letting `loadBundle` no-op, because when the activity next gets started "naturally", React Native's initialization will happen and it will load the latest JS bundle for us for free.

- If neither happens, `restartApp` gets called immediately after the update is downloaded, which is the happy path :) The resume listener that we set would no longer take effect because the React context is torn down and restarted.