### PR TITLE
Prepend subdirectory to assets path

### DIFF
--- a/ios/CodePush/CodePush.h
+++ b/ios/CodePush/CodePush.h
@@ -27,6 +27,8 @@
 
 + (NSString *)getApplicationSupportDirectory;
 
++ (NSString *)bundleAssetsPath;
+
 /*
  * This methods allows dynamically setting the app's
  * deployment key, in addition to setting it via
@@ -89,7 +91,6 @@ failCallback:(void (^)(NSError *err))failCallback;
            doneCallback:(void (^)())doneCallback
            failCallback:(void (^)(NSError *err))failCallback;
 
-+ (NSString *)getBinaryAssetsPath;
 + (NSDictionary *)getCurrentPackage:(NSError **)error;
 + (NSDictionary *)getPreviousPackage:(NSError **)error;
 + (NSString *)getCurrentPackageFolderPath:(NSError **)error;

--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -67,6 +67,16 @@ static NSString *bundleResourceSubdirectory = nil;
                                     subdirectory:bundleResourceSubdirectory];
 }
 
++ (NSString *)bundleAssetsPath
+{
+    NSString *resourcePath = [[NSBundle mainBundle] resourcePath];
+    if (bundleResourceSubdirectory) {
+        resourcePath = [resourcePath stringByAppendingPathComponent:bundleResourceSubdirectory];
+    }
+    
+    return [resourcePath stringByAppendingPathComponent:[CodePushUpdateUtils assetsFolderName]];
+}
+
 + (NSURL *)bundleURL
 {
     return [self bundleURLForResource:bundleResourceName];

--- a/ios/CodePush/CodePushPackage.m
+++ b/ios/CodePush/CodePushPackage.m
@@ -128,7 +128,7 @@ static NSString *const UnzippedFolderName = @"unzipped";
                                                                     return;
                                                                 }
                                                                 
-                                                                [[NSFileManager defaultManager] copyItemAtPath:[self getBinaryAssetsPath]
+                                                                [[NSFileManager defaultManager] copyItemAtPath:[CodePush bundleAssetsPath]
                                                                                                         toPath:[newUpdateCodePushPath stringByAppendingPathComponent:[CodePushUpdateUtils assetsFolderName]]
                                                                                                          error:&error];
                                                                 if (error) {
@@ -278,11 +278,6 @@ static NSString *const UnzippedFolderName = @"unzipped";
                                                 failCallback:failCallback];
     
     [downloadHandler download:updatePackage[@"downloadUrl"]];
-}
-
-+ (NSString *)getBinaryAssetsPath
-{
-    return [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:[CodePushUpdateUtils assetsFolderName]];
 }
 
 + (NSString *)getCodePushPath

--- a/ios/CodePush/CodePushUpdateUtils.m
+++ b/ios/CodePush/CodePushUpdateUtils.m
@@ -189,7 +189,7 @@ NSString * const ManifestFolderPrefix = @"CodePush";
     
     // If the app is using assets, then add
     // them to the generated content manifest.
-    NSString *assetsPath = [CodePushPackage getBinaryAssetsPath];
+    NSString *assetsPath = [CodePush bundleAssetsPath];
     if ([[NSFileManager defaultManager] fileExistsAtPath:assetsPath]) {
         [self addContentsOfFolderToManifest:assetsPath
                                  pathPrefix:[NSString stringWithFormat:@"%@/%@", [self manifestFolderPrefix], @"assets"]


### PR DESCRIPTION
Fixes https://github.com/Microsoft/react-native-code-push/issues/427

https://github.com/Microsoft/react-native-code-push/pull/428 added support for obtaining the URL to the binary packaged JS bundle within a subdirectory. However, if anyone used that feature, it would prevents diff updates from being installed correctly because we did not also prepend the subdirectory to the path to the assets folder.

@joshuafeldman