### PR TITLE
Fix ENOTEMPTY warning

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/FileUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/FileUtils.java
@@ -86,9 +86,7 @@ public class FileUtils {
                 if (fileEntry.isDirectory()) {
                     deleteFileOrFolderSilently(fileEntry);
                 } else {
-                    if (!file.delete()) {
-                        fileEntry.delete();
-                    }
+                    fileEntry.delete();
                 }
             }
         }

--- a/android/app/src/main/java/com/microsoft/codepush/react/FileUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/FileUtils.java
@@ -54,25 +54,11 @@ public class FileUtils {
         }
     }
 
-    public static void deleteDirectory(File directory) {
-        if (directory.exists()) {
-            File[] files = directory.listFiles();
-            if (files != null) {
-                for (File file : files) {
-                    if(file.isDirectory()) {
-                        deleteDirectory(file);
-                    }
-                    else {
-                        file.delete();
-                    }
-                }
-            }
-        }
-        directory.delete();
-    }
-
     public static void deleteDirectoryAtPath(String directoryPath) {
-        deleteDirectory(new File(directoryPath));
+        File file = new File(directoryPath);
+        if (file.exists()) {
+            deleteFileOrFolderSilently(file);
+        }
     }
 
     public static void deleteFileAtPathSilently(String path) {
@@ -145,7 +131,7 @@ public class FileUtils {
 
             File destinationFolder = new File(destination);
             if (destinationFolder.exists()) {
-                deleteDirectory(destinationFolder);
+                deleteFileOrFolderSilently(destinationFolder);
             }
             
             destinationFolder.mkdirs();


### PR DESCRIPTION
A customer reported seeing a warning of the format `W System.err: remove failed: ENOTEMPTY (Directory not empty)`. We thought it was caused by line 89 of the original `FileUtils.java`, which may attempt to delete a directory before it is empty. I'm removing it, because line 96 will ensure that it's deleted anyway.

Now that I think about it more though, I'm not sure there was actually any problem with the original code, as `file.delete()` will not raise any kind of exception, it'll simply return false if it did not delete.

As a side note, I've refactored out the `deleteDirectory()` function, as it effectively does the same thing as `deleteFileOrFolderSilently()` (aside from the logging if it fails). There is probably more refactoring I can do here, but I'd like to minimize the scope of the changes.