### PR TITLE
Allow an app's binary version to be manually specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -1105,6 +1105,8 @@ Because of this behavior, you can safely deploy updates to both the app store(s)
 
 - __(NSURL \*)bundleURLForResource:(NSString \*)resourceName withExtension:(NSString \*)resourceExtension__: Equivalent to the `bundleURLForResource:` method, but also allows customizing the extension used by the JS bundle that is looked for within the app binary. This is useful if you aren't naming this file `*.jsbundle` (which is the default convention).
 
+- __(void)overrideAppVersion:(NSString \*)appVersionOverride__ - Sets the version of the application's binary interface, which would otherwise default to the App Store version specified as the `CFBundleShortVersionString` in the `Info.plist`. This should be called a single time, before the bundle URL is loaded.
+
 - __(void)setDeploymentKey:(NSString \*)deploymentKey__ - Sets the deployment key that the app should use when querying for updates. This is a dynamic alternative to setting the deployment key in your `Info.plist` and/or specifying a deployment key in JS when calling `checkForUpdate` or `sync`.
 
 ### Java API Reference (Android)
@@ -1130,6 +1132,8 @@ Constructs the CodePush client runtime and represents the `ReactPackage` instanc
 - __getBundleUrl()__ - Returns the path to the most recent version of your app's JS bundle file, assuming that the resource name is `index.android.bundle`. If your app is using a different bundle name, then use the overloaded version of this method which allows specifying it. This method has the same resolution behavior as the Objective-C equivalent described above.
 
 - __getBundleUrl(String bundleName)__ - Returns the path to the most recent version of your app's JS bundle file, using the specified resource name (e.g. `index.android.bundle`). This method has the same resolution behavior as the Objective-C equivalent described above.
+
+- __overrideAppVersion(String appVersionOverride)__ - Sets the version of the application's binary interface, which would otherwise default to the Play Store version specified as the `versionName` in the `build.gradle`. This should be called a single time, before the CodePush instance is constructed.
 
 ## Example Apps / Starters
 

--- a/ios/CodePush/CodePush.h
+++ b/ios/CodePush/CodePush.h
@@ -30,7 +30,14 @@
 + (NSString *)bundleAssetsPath;
 
 /*
- * This methods allows dynamically setting the app's
+ * This method allows the version of the app's binary interface
+ * to be specified, which would otherwise default to the
+ * App Store version of the app.
+ */
++ (void)overrideAppVersion:(NSString *)deploymentKey;
+
+/*
+ * This method allows dynamically setting the app's
  * deployment key, in addition to setting it via
  * the Info.plist file's CodePushDeploymentKey setting.
  */
@@ -45,7 +52,7 @@
 
 @interface CodePushConfig : NSObject
 
-@property (readonly) NSString *appVersion;
+@property (copy) NSString *appVersion;
 @property (readonly) NSString *buildVersion;
 @property (readonly) NSDictionary *configuration;
 @property (copy) NSString *deploymentKey;

--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -73,7 +73,7 @@ static NSString *bundleResourceSubdirectory = nil;
     if (bundleResourceSubdirectory) {
         resourcePath = [resourcePath stringByAppendingPathComponent:bundleResourceSubdirectory];
     }
-    
+
     return [resourcePath stringByAppendingPathComponent:[CodePushUpdateUtils assetsFolderName]];
 }
 
@@ -157,6 +157,11 @@ static NSString *bundleResourceSubdirectory = nil;
 {
     NSString *applicationSupportDirectory = [NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES) objectAtIndex:0];
     return applicationSupportDirectory;
+}
+
++ (void)overrideAppVersion:(NSString *)appVersion
+{
+    [CodePushConfig current].appVersion = appVersion;
 }
 
 + (void)setDeploymentKey:(NSString *)deploymentKey

--- a/ios/CodePush/CodePushConfig.m
+++ b/ios/CodePush/CodePushConfig.m
@@ -86,6 +86,11 @@ static NSString * const ServerURLConfigKey = @"serverUrl";
     return [_configDictionary objectForKey:ClientUniqueIDConfigKey];
 }
 
+- (void)setAppVersion:(NSString *)appVersion
+{
+    [_configDictionary setValue:appVersion forKey:AppVersionConfigKey];
+}
+
 - (void)setDeploymentKey:(NSString *)deploymentKey
 {
     [_configDictionary setValue:deploymentKey forKey:DeploymentKeyConfigKey];


### PR DESCRIPTION
As per requests on Discord and on #433, this change allows the binary version of an app to be manually specified. The static, native `overrideAppVersion()` function should ideally be called once before the bundle is loaded.

Note that it needs to be native, because if it were specified in JS, it would be pushed out over CodePush, which can cause unintended issues. We originally considered adding it as a constructor argument, but CodePush is a static instance in iOS, and in Android we didn't want to overload the constructor too much. We chose to implement it as a function rather than a parameter in a plist or gradle file, to allow for dynamic transformation of the app store version if desired. Any feedback welcome!

@jkrems @joshuafeldman if you're interested!