### PR TITLE
Name the 'appVersion' parameter consistently

### DIFF
--- a/ios/CodePush/CodePush.h
+++ b/ios/CodePush/CodePush.h
@@ -34,7 +34,7 @@
  * to be specified, which would otherwise default to the
  * App Store version of the app.
  */
-+ (void)overrideAppVersion:(NSString *)deploymentKey;
++ (void)overrideAppVersion:(NSString *)appVersion;
 
 /*
  * This method allows dynamically setting the app's


### PR DESCRIPTION
This parameter is misnamed in the interface, addressing it as per #453. 