### PR TITLE
bind 'this' to the react component in the callbacks codePushStatusDid…

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -428,8 +428,8 @@ function codePushify(options = {}) {
           CodePush.notifyAppReady();
         } else {
           let rootComponentInstance = this.refs.rootComponent;
-          let syncStatusCallback = rootComponentInstance && rootComponentInstance.codePushStatusDidChange;
-          let downloadProgressCallback = rootComponentInstance && rootComponentInstance.codePushDownloadDidProgress;
+          let syncStatusCallback = rootComponentInstance && rootComponentInstance.codePushStatusDidChange.bind(rootComponentInstance);
+          let downloadProgressCallback = rootComponentInstance && rootComponentInstance.codePushDownloadDidProgress.bind(rootComponentInstance);
           CodePush.sync(options, syncStatusCallback, downloadProgressCallback);
           if (options.checkFrequency === CodePush.CheckFrequency.ON_APP_RESUME) {
             ReactNative.AppState.addEventListener("change", (newState) => {

--- a/CodePush.js
+++ b/CodePush.js
@@ -428,8 +428,15 @@ function codePushify(options = {}) {
           CodePush.notifyAppReady();
         } else {
           let rootComponentInstance = this.refs.rootComponent;
-          let syncStatusCallback = rootComponentInstance && rootComponentInstance.codePushStatusDidChange.bind(rootComponentInstance);
-          let downloadProgressCallback = rootComponentInstance && rootComponentInstance.codePushDownloadDidProgress.bind(rootComponentInstance);
+          if (rootComponentInstance && rootComponentInstance.codePushStatusDidChange) {
+            syncStatusCallback = rootComponentInstance.codePushStatusDidChange.bind(rootComponentInstance);
+          }
+
+          let downloadProgressCallback;
+          if (rootComponentInstance && rootComponentInstance.codePushDownloadDidProgress) {
+            downloadProgressCallback = rootComponentInstance.codePushDownloadDidProgress.bind(rootComponentInstance);
+          }
+          
           CodePush.sync(options, syncStatusCallback, downloadProgressCallback);
           if (options.checkFrequency === CodePush.CheckFrequency.ON_APP_RESUME) {
             ReactNative.AppState.addEventListener("change", (newState) => {

--- a/CodePush.js
+++ b/CodePush.js
@@ -428,6 +428,8 @@ function codePushify(options = {}) {
           CodePush.notifyAppReady();
         } else {
           let rootComponentInstance = this.refs.rootComponent;
+
+          let syncStatusCallback;
           if (rootComponentInstance && rootComponentInstance.codePushStatusDidChange) {
             syncStatusCallback = rootComponentInstance.codePushStatusDidChange.bind(rootComponentInstance);
           }
@@ -436,7 +438,7 @@ function codePushify(options = {}) {
           if (rootComponentInstance && rootComponentInstance.codePushDownloadDidProgress) {
             downloadProgressCallback = rootComponentInstance.codePushDownloadDidProgress.bind(rootComponentInstance);
           }
-          
+
           CodePush.sync(options, syncStatusCallback, downloadProgressCallback);
           if (options.checkFrequency === CodePush.CheckFrequency.ON_APP_RESUME) {
             ReactNative.AppState.addEventListener("change", (newState) => {


### PR DESCRIPTION
bind 'this' to the react component in the callbacks `codePushStatusDidChange(...)` and `codePushDownloadDidProgress(...)` to allow the callback to call `setState(...)` etc in the wrapped component.

for ex: 

```
class Main extends Component {

  constructor() {
    super();
    
    this.state = {
      isUpdating: false,
    };
  }

  codePushStatusDidChange(syncStatus) {
    switch (syncStatus) {
      case codePush.SyncStatus.DOWNLOADING_PACKAGE:
        this.setState({
          isUpdating: true
        });
        break;

      case codePush.SyncStatus.UP_TO_DATE:
        this.setState({
          isUpdating: false
        });
        break;

      case codePush.SyncStatus.UPDATE_INSTALLED:
        this.setState({
          isUpdating: false
        });
        break;
    }
  }

  render() {
    return (
      <View>
        {this.state.isUpdating ? <UpdateScreen /> : <App />}
      </View>
    );
  }
}

const codePushOptions = {
  updateDialog: true,
  installMode: codePush.InstallMode.IMMEDIATE,
  checkFrequency: codePush.CheckFrequency.ON_APP_RESUME,
};

export default codePush(codePushOptions)(Main);
```