### PR TITLE
Remove SoLoader and fix 0.31 compat

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -4,10 +4,7 @@ import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.ViewManager;
-import com.facebook.soloader.SoLoader;
 
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
@@ -54,7 +51,6 @@ public class CodePush implements ReactPackage {
     }
 
     public CodePush(String deploymentKey, Context context, boolean isDebugMode) {
-        SoLoader.init(context, false);
         mContext = context.getApplicationContext();
 
         mUpdateManager = new CodePushUpdateManager(context.getFilesDir().getAbsolutePath());
@@ -169,14 +165,14 @@ public class CodePush implements ReactPackage {
                 return binaryJsBundleUrl;
             }
 
-            ReadableMap packageMetadata = this.mUpdateManager.getCurrentPackage();
+            JSONObject packageMetadata = this.mUpdateManager.getCurrentPackage();
             Long binaryModifiedDateDuringPackageInstall = null;
-            String binaryModifiedDateDuringPackageInstallString = CodePushUtils.tryGetString(packageMetadata, CodePushConstants.BINARY_MODIFIED_TIME_KEY);
+            String binaryModifiedDateDuringPackageInstallString = packageMetadata.optString(CodePushConstants.BINARY_MODIFIED_TIME_KEY, null);
             if (binaryModifiedDateDuringPackageInstallString != null) {
                 binaryModifiedDateDuringPackageInstall = Long.parseLong(binaryModifiedDateDuringPackageInstallString);
             }
 
-            String packageAppVersion = CodePushUtils.tryGetString(packageMetadata, "appVersion");
+            String packageAppVersion = packageMetadata.optString("appVersion", null);
             if (binaryModifiedDateDuringPackageInstall != null &&
                     binaryModifiedDateDuringPackageInstall == binaryResourcesModifiedTime &&
                     (isUsingTestConfiguration() || sAppVersion.equals(packageAppVersion))) {
@@ -256,7 +252,7 @@ public class CodePush implements ReactPackage {
     }
 
     private void rollbackPackage() {
-        WritableMap failedPackage = mUpdateManager.getCurrentPackage();
+        JSONObject failedPackage = mUpdateManager.getCurrentPackage();
         mSettingsManager.saveFailedUpdate(failedPackage);
         mUpdateManager.rollbackPackage();
         mSettingsManager.removePendingUpdate();

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushTelemetryManager.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushTelemetryManager.java
@@ -3,9 +3,9 @@ package com.microsoft.codepush.react;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.bridge.WritableNativeMap;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -30,14 +30,14 @@ public class CodePushTelemetryManager {
 
     public WritableMap getBinaryUpdateReport(String appVersion) {
         String previousStatusReportIdentifier = this.getPreviousStatusReportIdentifier();
-        WritableNativeMap reportMap = null;
+        WritableMap reportMap = null;
         if (previousStatusReportIdentifier == null) {
             this.clearRetryStatusReport();
-            reportMap = new WritableNativeMap();
+            reportMap = Arguments.createMap();
             reportMap.putString(APP_VERSION_KEY, appVersion);
         } else if (!previousStatusReportIdentifier.equals(appVersion)) {
             this.clearRetryStatusReport();
-            reportMap = new WritableNativeMap();
+            reportMap = Arguments.createMap();
             if (this.isStatusReportIdentifierCodePushLabel(previousStatusReportIdentifier)) {
                 String previousDeploymentKey = this.getDeploymentKeyFromStatusReportIdentifier(previousStatusReportIdentifier);
                 String previousLabel = this.getVersionLabelFromStatusReportIdentifier(previousStatusReportIdentifier);
@@ -70,7 +70,7 @@ public class CodePushTelemetryManager {
     }
 
     public WritableMap getRollbackReport(WritableMap lastFailedPackage) {
-        WritableNativeMap reportMap = new WritableNativeMap();
+        WritableMap reportMap =  Arguments.createMap();
         reportMap.putMap(PACKAGE_KEY, lastFailedPackage);
         reportMap.putString(STATUS_KEY, DEPLOYMENT_FAILED_STATUS);
         return reportMap;
@@ -79,16 +79,16 @@ public class CodePushTelemetryManager {
     public WritableMap getUpdateReport(WritableMap currentPackage) {
         String currentPackageIdentifier = this.getPackageStatusReportIdentifier(currentPackage);
         String previousStatusReportIdentifier = this.getPreviousStatusReportIdentifier();
-        WritableNativeMap reportMap = null;
+        WritableMap reportMap = null;
         if (currentPackageIdentifier != null) {
             if (previousStatusReportIdentifier == null) {
                 this.clearRetryStatusReport();
-                reportMap = new WritableNativeMap();
+                reportMap = Arguments.createMap();
                 reportMap.putMap(PACKAGE_KEY, currentPackage);
                 reportMap.putString(STATUS_KEY, DEPLOYMENT_SUCCEEDED_STATUS);
             } else if (!previousStatusReportIdentifier.equals(currentPackageIdentifier)) {
                 this.clearRetryStatusReport();
-                reportMap = new WritableNativeMap();
+                reportMap = Arguments.createMap();
                 if (this.isStatusReportIdentifierCodePushLabel(previousStatusReportIdentifier)) {
                     String previousDeploymentKey = this.getDeploymentKeyFromStatusReportIdentifier(previousStatusReportIdentifier);
                     String previousLabel = this.getVersionLabelFromStatusReportIdentifier(previousStatusReportIdentifier);

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateUtils.java
@@ -2,10 +2,9 @@ package com.microsoft.codepush.react;
 
 import android.content.Context;
 
-import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.WritableMap;
-
 import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -66,14 +65,18 @@ public class CodePushUpdateUtils {
 
     public static void copyNecessaryFilesFromCurrentPackage(String diffManifestFilePath, String currentPackageFolderPath, String newPackageFolderPath) throws IOException{
         FileUtils.copyDirectoryContents(currentPackageFolderPath, newPackageFolderPath);
-        WritableMap diffManifest = CodePushUtils.getWritableMapFromFile(diffManifestFilePath);
-        ReadableArray deletedFiles = diffManifest.getArray("deletedFiles");
-        for (int i = 0; i < deletedFiles.size(); i++) {
-            String fileNameToDelete = deletedFiles.getString(i);
-            File fileToDelete = new File(newPackageFolderPath, fileNameToDelete);
-            if (fileToDelete.exists()) {
-                fileToDelete.delete();
+        JSONObject diffManifest = CodePushUtils.getJsonObjectFromFile(diffManifestFilePath);
+        try {
+            JSONArray deletedFiles = diffManifest.getJSONArray("deletedFiles");
+            for (int i = 0; i < deletedFiles.length(); i++) {
+                String fileNameToDelete = deletedFiles.getString(i);
+                File fileToDelete = new File(newPackageFolderPath, fileNameToDelete);
+                if (fileToDelete.exists()) {
+                    fileToDelete.delete();
+                }
             }
+        } catch (JSONException e) {
+            throw new CodePushUnknownException("Unable to copy files from current package during diff update", e);
         }
     }
 

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUtils.java
@@ -94,11 +94,6 @@ public class CodePushUtils {
         return map;
     }
 
-    public static WritableMap convertReadableMapToWritableMap(ReadableMap map) {
-        JSONObject mapJSON = convertReadableToJsonObject(map);
-        return convertJsonObjectToWritable(mapJSON);
-    }
-
     public static JSONArray convertReadableToJsonArray(ReadableArray arr) {
         JSONArray jsonArr = new JSONArray();
         for (int i=0; i<arr.size(); i++) {
@@ -194,11 +189,10 @@ public class CodePushUtils {
         }
     }
 
-    public static WritableMap getWritableMapFromFile(String filePath) throws IOException {
+    public static JSONObject getJsonObjectFromFile(String filePath) throws IOException {
         String content = FileUtils.readFileToString(filePath);
         try {
-            JSONObject json = new JSONObject(content);
-            return convertJsonObjectToWritable(json);
+            return new JSONObject(content);
         } catch (JSONException jsonException) {
             // Should not happen
             throw new CodePushMalformedDataException(filePath, jsonException);
@@ -213,6 +207,14 @@ public class CodePushUtils {
         log("Loading JS bundle from \"" + path + "\"");
     }
 
+    public static void setJSONValueForKey(JSONObject json, String key, Object value) {
+        try {
+            json.put(key, value);
+        } catch (JSONException e) {
+            throw new CodePushUnknownException("Unable to set value " + value + " for key " + key + " to JSONObject");
+        }
+    }
+
     public static String tryGetString(ReadableMap map, String key) {
         try {
             return map.getString(key);
@@ -221,8 +223,7 @@ public class CodePushUtils {
         }
     }
 
-    public static void writeReadableMapToFile(ReadableMap map, String filePath) throws IOException {
-        JSONObject json = CodePushUtils.convertReadableToJsonObject(map);
+    public static void writeJsonToFile(JSONObject json, String filePath) throws IOException {
         String jsonString = json.toString();
         FileUtils.writeStringToFile(jsonString, filePath);
     }

--- a/android/app/src/main/java/com/microsoft/codepush/react/SettingsManager.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/SettingsManager.java
@@ -3,8 +3,6 @@ package com.microsoft.codepush.react;
 import android.content.Context;
 import android.content.SharedPreferences;
 
-import com.facebook.react.bridge.ReadableMap;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -90,7 +88,7 @@ public class SettingsManager {
         mSettings.edit().remove(CodePushConstants.PENDING_UPDATE_KEY).commit();
     }
 
-    public void saveFailedUpdate(ReadableMap failedPackage) {
+    public void saveFailedUpdate(JSONObject failedPackage) {
         String failedUpdatesString = mSettings.getString(CodePushConstants.FAILED_UPDATES_KEY, null);
         JSONArray failedUpdates;
         if (failedUpdatesString == null) {
@@ -105,8 +103,7 @@ public class SettingsManager {
             }
         }
 
-        JSONObject failedPackageJSON = CodePushUtils.convertReadableToJsonObject(failedPackage);
-        failedUpdates.put(failedPackageJSON);
+        failedUpdates.put(failedPackage);
         mSettings.edit().putString(CodePushConstants.FAILED_UPDATES_KEY, failedUpdates.toString()).commit();
     }
 


### PR DESCRIPTION
[SoLoader](https://github.com/facebook/SoLoader) is a native code library for Android by Facebook that React Native uses. Specifically, a call to `SoLoader.init()` is needed before we can construct instances of `WritableNativeMap`, which is a data structure implemented in native C++ used by React Native libraries send JSON maps to/from JavaScript to native.

[`SoLoader.init()` is called for us](https://github.com/facebook/react-native/blob/3c4fd42749e0079b0cf54e1106bf81c993f9d29a/ReactAndroid/src/main/java/com/facebook/react/XReactInstanceManagerImpl.java#L289) by React Native when the `ReactInstanceManager` is constructed. Hence, normally React Native plugins wouldn't have to call it themselves. Our case is a little special because we require the user to override `getJSBundleFile` in their `MainApplication.java`. `CodePush.getJSBundleFile` calls `getCurrentPackage`, which returns a `WritableNativeMap`. Because in the initialization lifecycle, [the JSBundleLoader is created before the ReactInstanceManager](https://github.com/facebook/react-native/blob/3c4fd42749e0079b0cf54e1106bf81c993f9d29a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java#L392), that ends up causing an exception because we are constructing a `WritableNativeMap` before calling `SoLoader.init()`.

Calling `SoLoader.init()` ourselves works perfectly fine for us in mitigating the above issue pre RN 0.31. In RN 0.31, [SoLoader was made an external dependency](https://github.com/facebook/react-native/commit/dd06b74157efa0ebd4980eb79d92b3f0e4be35d6). That has resulted in a `java.lang.NoClassDefFoundError: com.facebook.soloader.SoLoader` reported by some customers during CodePush initialization when our plugin tries to use it directly - somehow, this transitive dependency is not accessible to us.

The fix that this PR is proposing is to remove the need to call `SoLoader.init` entirely: really, the `WritableNativeMap` is only needed to generate an argument object that we can send back to JS. Hence, during initialization, we can simply read and use the current package metadata as a normal `org.json.JSONObject`. We only need convert that to a `WritableNativeMap` when JS is calling into a native method, by which point, the `ReactInstanceManager` would already have been constructed.

In addition, `WritableNativeMap` is an internal data structure which subclasses `WritableMap` that React Native uses, they already provided us a utility [`Arguments.createMap`](https://facebook.github.io/react-native/docs/native-modules-android.html#promises) which is a documented API, so I changed our plugin to use that instead.