### PR TITLE
Fix android patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "rnpm": {
     "android": {
-      "packageInstance": "new CodePush(${androidDeploymentKey}, this, BuildConfig.DEBUG)"
+      "packageInstance": "new CodePush(${androidDeploymentKey}, (android.content.Context)(this.getClass().equals(android.app.Activity.class) ? this : MainApplication.this), BuildConfig.DEBUG)"
     },
     "ios": {
       "sharedLibraries": [

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "rnpm": {
     "android": {
-      "packageInstance": "new CodePush(${androidDeploymentKey}, (android.content.Context)(this.getClass().equals(android.app.Activity.class) ? this : MainApplication.this), BuildConfig.DEBUG)"
+      "packageInstance": "new CodePush(${androidDeploymentKey}, getApplicationContext(), BuildConfig.DEBUG)"
     },
     "ios": {
       "sharedLibraries": [


### PR DESCRIPTION
Our auto linking patch for android doesn't work Post RN 0.29, because `this` is an instance of `ReactNativeHost`, not a proper Android `Context`.

And unfortunately, this fix alone doesn't fix linking, we are currently blocked on this too: https://github.com/facebook/react-native/pull/9381