### PR TITLE
Add api to specify custom NSBundle

### DIFF
--- a/Examples/CodePushDemoApp/iOS/CodePushDemoApp.xcodeproj/project.pbxproj
+++ b/Examples/CodePushDemoApp/iOS/CodePushDemoApp.xcodeproj/project.pbxproj
@@ -19,7 +19,6 @@
 		13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB11A68108700A75B9A /* LaunchScreen.xib */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		140ED2AC1D01E1AD002B40FF /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
 		146834051AC3E58100842450 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
 		549D09D81D528D0A00C95E36 /* libCodePush.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 549D09CD1D528CDB00C95E36 /* libCodePush.a */; };
 		549D09DA1D528D4D00C95E36 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 549D09D91D528D4D00C95E36 /* libz.tbd */; };
@@ -61,13 +60,6 @@
 			proxyType = 2;
 			remoteGlobalIDString = 832C81801AAF6DEF007FA2F7;
 			remoteInfo = RCTVibration;
-		};
-		00E356F41AD99517003FC87E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 83CBB9F71A601CBA00E9B192 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 13B07F861A680F5B00A75B9A;
-			remoteInfo = CodePushDemoApp;
 		};
 		139105C01AF99BAD00B5F7CC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -120,7 +112,6 @@
 		00C302BB1ABCB91800DB3ED1 /* RCTImage.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTImage.xcodeproj; path = "../node_modules/react-native/Libraries/Image/RCTImage.xcodeproj"; sourceTree = "<group>"; };
 		00C302D31ABCB9D200DB3ED1 /* RCTNetwork.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTNetwork.xcodeproj; path = "../node_modules/react-native/Libraries/Network/RCTNetwork.xcodeproj"; sourceTree = "<group>"; };
 		00C302DF1ABCB9EE00DB3ED1 /* RCTVibration.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTVibration.xcodeproj; path = "../node_modules/react-native/Libraries/Vibration/RCTVibration.xcodeproj"; sourceTree = "<group>"; };
-		00E356EE1AD99517003FC87E /* CodePushDemoAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CodePushDemoAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		139105B61AF99BAD00B5F7CC /* RCTSettings.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTSettings.xcodeproj; path = "../node_modules/react-native/Libraries/Settings/RCTSettings.xcodeproj"; sourceTree = "<group>"; };
 		139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTWebSocket.xcodeproj; path = "../node_modules/react-native/Libraries/WebSocket/RCTWebSocket.xcodeproj"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* CodePushDemoApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CodePushDemoApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -138,14 +129,6 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		00E356EB1AD99517003FC87E /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				140ED2AC1D01E1AD002B40FF /* libReact.a in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		13B07F8C1A680F5B00A75B9A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -304,7 +287,6 @@
 			isa = PBXGroup;
 			children = (
 				13B07F961A680F5B00A75B9A /* CodePushDemoApp.app */,
-				00E356EE1AD99517003FC87E /* CodePushDemoAppTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -312,24 +294,6 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		00E356ED1AD99517003FC87E /* CodePushDemoAppTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 00E357021AD99517003FC87E /* Build configuration list for PBXNativeTarget "CodePushDemoAppTests" */;
-			buildPhases = (
-				00E356EA1AD99517003FC87E /* Sources */,
-				00E356EB1AD99517003FC87E /* Frameworks */,
-				00E356EC1AD99517003FC87E /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				00E356F51AD99517003FC87E /* PBXTargetDependency */,
-			);
-			name = CodePushDemoAppTests;
-			productName = CodePushDemoAppTests;
-			productReference = 00E356EE1AD99517003FC87E /* CodePushDemoAppTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 		13B07F861A680F5B00A75B9A /* CodePushDemoApp */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "CodePushDemoApp" */;
@@ -356,12 +320,6 @@
 			attributes = {
 				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = Facebook;
-				TargetAttributes = {
-					00E356ED1AD99517003FC87E = {
-						CreatedOnToolsVersion = 6.2;
-						TestTargetID = 13B07F861A680F5B00A75B9A;
-					};
-				};
 			};
 			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "CodePushDemoApp" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -423,7 +381,6 @@
 			projectRoot = "";
 			targets = (
 				13B07F861A680F5B00A75B9A /* CodePushDemoApp */,
-				00E356ED1AD99517003FC87E /* CodePushDemoAppTests */,
 			);
 		};
 /* End PBXProject section */
@@ -509,13 +466,6 @@
 /* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
-		00E356EC1AD99517003FC87E /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		13B07F8E1A680F5B00A75B9A /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -545,13 +495,6 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		00E356EA1AD99517003FC87E /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		13B07F871A680F5B00A75B9A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -562,14 +505,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		00E356F51AD99517003FC87E /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 13B07F861A680F5B00A75B9A /* CodePushDemoApp */;
-			targetProxy = 00E356F41AD99517003FC87E /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		13B07FB11A68108700A75B9A /* LaunchScreen.xib */ = {
@@ -584,35 +519,6 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		00E356F61AD99517003FC87E /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				INFOPLIST_FILE = CodePushDemoAppTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CodePushDemoApp.app/CodePushDemoApp";
-			};
-			name = Debug;
-		};
-		00E356F71AD99517003FC87E /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				COPY_PHASE_STRIP = NO;
-				INFOPLIST_FILE = CodePushDemoAppTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CodePushDemoApp.app/CodePushDemoApp";
-			};
-			name = Release;
-		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -745,15 +651,6 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		00E357021AD99517003FC87E /* Build configuration list for PBXNativeTarget "CodePushDemoAppTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				00E356F61AD99517003FC87E /* Debug */,
-				00E356F71AD99517003FC87E /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "CodePushDemoApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/ios/CodePush/CodePush.h
+++ b/ios/CodePush/CodePush.h
@@ -25,6 +25,11 @@
                   withExtension:(NSString *)resourceExtension
                    subdirectory:(NSString *)resourceSubdirectory;
 
++ (NSURL *)bundleURLForResource:(NSString *)resourceName
+                  withExtension:(NSString *)resourceExtension
+                   subdirectory:(NSString *)resourceSubdirectory
+                         bundle:(NSBundle *)resourceBundle;
+
 + (NSString *)getApplicationSupportDirectory;
 
 + (NSString *)bundleAssetsPath;

--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -128,21 +128,21 @@ static NSString *bundleResourceSubdirectory = nil;
     bundleResourceExtension = resourceExtension;
     bundleResourceSubdirectory = resourceSubdirectory;
     bundleResourceBundle = resourceBundle;
-    
+
     [self ensureBinaryBundleExists];
-    
+
     NSString *logMessageFormat = @"Loading JS bundle from %@";
-    
+
     NSError *error;
     NSString *packageFile = [CodePushPackage getCurrentPackageBundlePath:&error];
     NSURL *binaryBundleURL = [self binaryBundleURL];
-    
+
     if (error || !packageFile) {
         CPLog(logMessageFormat, binaryBundleURL);
         isRunningBinaryVersion = YES;
         return binaryBundleURL;
     }
-    
+
     NSString *binaryAppVersion = [[CodePushConfig current] appVersion];
     NSDictionary *currentPackageMetadata = [CodePushPackage getCurrentPackage:&error];
     if (error || !currentPackageMetadata) {
@@ -150,10 +150,10 @@ static NSString *bundleResourceSubdirectory = nil;
         isRunningBinaryVersion = YES;
         return binaryBundleURL;
     }
-    
+
     NSString *packageDate = [currentPackageMetadata objectForKey:BinaryBundleDateKey];
     NSString *packageAppVersion = [currentPackageMetadata objectForKey:AppVersionKey];
-    
+
     if ([[CodePushUpdateUtils modifiedDateStringOfFileAtURL:binaryBundleURL] isEqualToString:packageDate] && ([CodePush isUsingTestConfiguration] ||[binaryAppVersion isEqualToString:packageAppVersion])) {
         // Return package file because it is newer than the app store binary's JS bundle
         NSURL *packageUrl = [[NSURL alloc] initFileURLWithPath:packageFile];
@@ -165,11 +165,11 @@ static NSString *bundleResourceSubdirectory = nil;
 #ifndef DEBUG
         isRelease = YES;
 #endif
-        
+
         if (isRelease || ![binaryAppVersion isEqualToString:packageAppVersion]) {
             [CodePush clearUpdates];
         }
-        
+
         CPLog(logMessageFormat, binaryBundleURL);
         isRunningBinaryVersion = YES;
         return binaryBundleURL;

--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -52,24 +52,31 @@ static BOOL isRunningBinaryVersion = NO;
 static BOOL needToReportRollback = NO;
 static BOOL testConfigurationFlag = NO;
 
-// These values are used to save the bundleURL, extension and subdirectory
+// These values are used to save the NS bundle, name, extension and subdirectory
 // for the JS bundle in the binary.
+static NSBundle *bundleResourceBundle = nil;
 static NSString *bundleResourceExtension = @"jsbundle";
 static NSString *bundleResourceName = @"main";
 static NSString *bundleResourceSubdirectory = nil;
+
++ (void)initialize
+{
+    // Use the mainBundle by default.
+    bundleResourceBundle = [NSBundle mainBundle];
+}
 
 #pragma mark - Public Obj-C API
 
 + (NSURL *)binaryBundleURL
 {
-    return [[NSBundle mainBundle] URLForResource:bundleResourceName
-                                   withExtension:bundleResourceExtension
-                                    subdirectory:bundleResourceSubdirectory];
+    return [bundleResourceBundle URLForResource:bundleResourceName
+                                  withExtension:bundleResourceExtension
+                                   subdirectory:bundleResourceSubdirectory];
 }
 
 + (NSString *)bundleAssetsPath
 {
-    NSString *resourcePath = [[NSBundle mainBundle] resourcePath];
+    NSString *resourcePath = [bundleResourceBundle resourcePath];
     if (bundleResourceSubdirectory) {
         resourcePath = [resourcePath stringByAppendingPathComponent:bundleResourceSubdirectory];
     }
@@ -79,15 +86,18 @@ static NSString *bundleResourceSubdirectory = nil;
 
 + (NSURL *)bundleURL
 {
-    return [self bundleURLForResource:bundleResourceName];
+    return [self bundleURLForResource:bundleResourceName
+                        withExtension:bundleResourceExtension
+                         subdirectory:bundleResourceSubdirectory
+                               bundle:bundleResourceBundle];
 }
 
 + (NSURL *)bundleURLForResource:(NSString *)resourceName
 {
-    bundleResourceName = resourceName;
     return [self bundleURLForResource:resourceName
                         withExtension:bundleResourceExtension
-                         subdirectory:bundleResourceSubdirectory];
+                         subdirectory:bundleResourceSubdirectory
+                               bundle:bundleResourceBundle];
 }
 
 + (NSURL *)bundleURLForResource:(NSString *)resourceName
@@ -95,31 +105,44 @@ static NSString *bundleResourceSubdirectory = nil;
 {
     return [self bundleURLForResource:resourceName
                         withExtension:resourceExtension
-                         subdirectory:bundleResourceSubdirectory];
+                         subdirectory:bundleResourceSubdirectory
+                               bundle:bundleResourceBundle];
 }
 
 + (NSURL *)bundleURLForResource:(NSString *)resourceName
                   withExtension:(NSString *)resourceExtension
                    subdirectory:(NSString *)resourceSubdirectory
 {
+    return [self bundleURLForResource:resourceName
+                        withExtension:resourceExtension
+                         subdirectory:resourceSubdirectory
+                               bundle:bundleResourceBundle];
+}
+
++ (NSURL *)bundleURLForResource:(NSString *)resourceName
+                  withExtension:(NSString *)resourceExtension
+                   subdirectory:(NSString *)resourceSubdirectory
+                         bundle:(NSBundle *)resourceBundle
+{
     bundleResourceName = resourceName;
     bundleResourceExtension = resourceExtension;
     bundleResourceSubdirectory = resourceSubdirectory;
-
+    bundleResourceBundle = resourceBundle;
+    
     [self ensureBinaryBundleExists];
-
+    
     NSString *logMessageFormat = @"Loading JS bundle from %@";
-
+    
     NSError *error;
     NSString *packageFile = [CodePushPackage getCurrentPackageBundlePath:&error];
     NSURL *binaryBundleURL = [self binaryBundleURL];
-
+    
     if (error || !packageFile) {
         CPLog(logMessageFormat, binaryBundleURL);
         isRunningBinaryVersion = YES;
         return binaryBundleURL;
     }
-
+    
     NSString *binaryAppVersion = [[CodePushConfig current] appVersion];
     NSDictionary *currentPackageMetadata = [CodePushPackage getCurrentPackage:&error];
     if (error || !currentPackageMetadata) {
@@ -127,10 +150,10 @@ static NSString *bundleResourceSubdirectory = nil;
         isRunningBinaryVersion = YES;
         return binaryBundleURL;
     }
-
+    
     NSString *packageDate = [currentPackageMetadata objectForKey:BinaryBundleDateKey];
     NSString *packageAppVersion = [currentPackageMetadata objectForKey:AppVersionKey];
-
+    
     if ([[CodePushUpdateUtils modifiedDateStringOfFileAtURL:binaryBundleURL] isEqualToString:packageDate] && ([CodePush isUsingTestConfiguration] ||[binaryAppVersion isEqualToString:packageAppVersion])) {
         // Return package file because it is newer than the app store binary's JS bundle
         NSURL *packageUrl = [[NSURL alloc] initFileURLWithPath:packageFile];
@@ -142,11 +165,11 @@ static NSString *bundleResourceSubdirectory = nil;
 #ifndef DEBUG
         isRelease = YES;
 #endif
-
+        
         if (isRelease || ![binaryAppVersion isEqualToString:packageAppVersion]) {
             [CodePush clearUpdates];
         }
-
+        
         CPLog(logMessageFormat, binaryBundleURL);
         isRunningBinaryVersion = YES;
         return binaryBundleURL;


### PR DESCRIPTION
Fixes https://github.com/Microsoft/react-native-code-push/issues/468, so the user can specify something like:

```objectivec
  jsCodeLocation = [CodePush bundleURLForResource:@"main"
                                    withExtension:@"jsbundle"
                                     subdirectory:nil
                                           bundle:[NSBundle bundleWithIdentifier: customBundleIdentifier]];
```

Also removed the CodePushDemoAppTests project from the pbxproj file.

@silhouettes @kenwheeler