### PR TITLE
Remove ReactActivity dependency

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -126,7 +126,10 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
                 // The React Native version might be older than 0.29, or the activity does not
                 // extend ReactActivity, so we try to get the instance manager via the
                 // "mReactInstanceManager" field.
-                Field instanceManagerField = currentActivity.getClass().getDeclaredField("mReactInstanceManager");
+                Class instanceManagerHolderClass = currentActivity instanceof ReactActivity
+                        ? ReactActivity.class
+                        : currentActivity.getClass();
+                Field instanceManagerField = instanceManagerHolderClass.getDeclaredField("mReactInstanceManager");
                 instanceManagerField.setAccessible(true);
                 instanceManager = (ReactInstanceManager)instanceManagerField.get(currentActivity);
             }


### PR DESCRIPTION
Add [w=1](https://github.com/Microsoft/react-native-code-push/pull/470/files?w=1) to ignore whitespace changes.

As suggested by https://github.com/Microsoft/react-native-code-push/issues/465, sometimes the activity that hosts the React Native root view does not extend ReactActivity, especially if the app is an existing android app that was integrated with React Native as described in https://facebook.github.io/react-native/docs/integration-with-existing-apps.html (Android section).

This PR modifies our `loadBundle` logic slightly to look for the `mReactInstanceManager` field regardless of whether the Activity is a `ReactActivity`. This should improve the experience for the types of apps mentioned above, assuming that developers will be following the suggested code patches in the Facebook docs exactly down to the naming of fields. Obviously, that assumption is brittle, but at least this change exposes an option to these developers to still be able to leverage on our shiny `loadBundle` experience.

Going forward, we should discuss an API change that allows developers to either pass the `ReactInstanceManager` instance to our CodePush runtime, or perhaps create a custom interface that developers can implement in their activity that exposes a `getReactInstanceManager` method to us.