### PR TITLE
Fix the hash mismatch happening due to .DS_Store [Simulator]

### DIFF
--- a/ios/CodePush/CodePushUpdateUtils.m
+++ b/ios/CodePush/CodePushUpdateUtils.m
@@ -20,6 +20,14 @@ NSString * const ManifestFolderPrefix = @"CodePush";
     }
     
     for (NSString *fileName in folderFiles) {
+#if TARGET_IPHONE_SIMULATOR
+        // If the user is running this in a simulator, there is a chance
+        // that the .DS_Store file will mess up the calculated hash
+        // We must skip this file.
+        if ([fileName isEqualToString:@".DS_Store"]) {
+            continue;
+        }
+#endif
         NSString *fullFilePath = [folderPath stringByAppendingPathComponent:fileName];
         NSString *relativePath = [pathPrefix stringByAppendingPathComponent:fileName];
         BOOL isDir = NO;

--- a/ios/CodePush/CodePushUpdateUtils.m
+++ b/ios/CodePush/CodePushUpdateUtils.m
@@ -20,14 +20,11 @@ NSString * const ManifestFolderPrefix = @"CodePush";
     }
     
     for (NSString *fileName in folderFiles) {
-#if TARGET_IPHONE_SIMULATOR
-        // If the user is running this in a simulator, there is a chance
-        // that the .DS_Store file will mess up the calculated hash
-        // We must skip this file.
-        if ([fileName isEqualToString:@".DS_Store"]) {
+        // We must skip the macOS generated files.
+        if ([fileName isEqualToString:@".DS_Store"] || [fileName isEqualToString:@"__MACOSX"]) {
             continue;
         }
-#endif
+
         NSString *fullFilePath = [folderPath stringByAppendingPathComponent:fileName];
         NSString *relativePath = [pathPrefix stringByAppendingPathComponent:fileName];
         BOOL isDir = NO;


### PR DESCRIPTION
Mac OS creates a `.DS_Store` file in each folder. When running CodePush on the simulator, this creates a hash mismatch. We need to skip this file while calculating the hash of the downloaded bundles.

This likely resolves the issue mentioned at https://github.com/Microsoft/react-native-code-push/issues/319