### PR TITLE
Don't bind lifecycle hooks if root component instance is not ES6 declared

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -430,13 +430,19 @@ function codePushify(options = {}) {
           let rootComponentInstance = this.refs.rootComponent;
 
           let syncStatusCallback;
-          if (rootComponentInstance && rootComponentInstance.codePushStatusDidChange && rootComponentInstance instanceof React.Component) {
-            syncStatusCallback = rootComponentInstance.codePushStatusDidChange.bind(rootComponentInstance);
+          if (rootComponentInstance && rootComponentInstance.codePushStatusDidChange) {
+            syncStatusCallback = rootComponentInstance.codePushStatusDidChange;
+            if (rootComponentInstance instanceof React.Component) {
+              syncStatusCallback = syncStatusCallback.bind(rootComponentInstance);
+            }
           }
 
           let downloadProgressCallback;
-          if (rootComponentInstance && rootComponentInstance.codePushDownloadDidProgress && rootComponentInstance instanceof React.Component) {
-            downloadProgressCallback = rootComponentInstance.codePushDownloadDidProgress.bind(rootComponentInstance);
+          if (rootComponentInstance && rootComponentInstance.codePushDownloadDidProgress) {
+            downloadProgressCallback = rootComponentInstance.codePushDownloadDidProgress;
+            if (rootComponentInstance instanceof React.Component) {
+              downloadProgressCallback = downloadProgressCallback.bind(rootComponentInstance);
+            }
           }
 
           CodePush.sync(options, syncStatusCallback, downloadProgressCallback);

--- a/CodePush.js
+++ b/CodePush.js
@@ -430,12 +430,12 @@ function codePushify(options = {}) {
           let rootComponentInstance = this.refs.rootComponent;
 
           let syncStatusCallback;
-          if (rootComponentInstance && rootComponentInstance.codePushStatusDidChange) {
+          if (rootComponentInstance && rootComponentInstance.codePushStatusDidChange && rootComponentInstance instanceof React.Component) {
             syncStatusCallback = rootComponentInstance.codePushStatusDidChange.bind(rootComponentInstance);
           }
 
           let downloadProgressCallback;
-          if (rootComponentInstance && rootComponentInstance.codePushDownloadDidProgress) {
+          if (rootComponentInstance && rootComponentInstance.codePushDownloadDidProgress && rootComponentInstance instanceof React.Component) {
             downloadProgressCallback = rootComponentInstance.codePushDownloadDidProgress.bind(rootComponentInstance);
           }
 

--- a/Examples/CodePushDemoApp/demo.js
+++ b/Examples/CodePushDemoApp/demo.js
@@ -19,7 +19,6 @@ class CodePushDemoApp extends Component {
   }
 
   codePushStatusDidChange(syncStatus) {
-    console.log(this.setState);
     switch(syncStatus) {
       case CodePush.SyncStatus.CHECKING_FOR_UPDATE:
         this.setState({ syncMessage: "Checking for update." });


### PR DESCRIPTION
Fixes https://github.com/Microsoft/react-native-code-push/issues/473. The issue occurs because component functions in components declared via `React.createClass` are autobound by default, while those declared via the ES6 syntax are not.