### PR TITLE
Proguard rules

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -14,6 +14,10 @@ android {
     lintOptions {
         abortOnError false
     }
+
+    defaultConfig {
+        consumerProguardFiles 'proguard-rules.pro'
+    }
 }
 
 dependencies {

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -15,3 +15,8 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+# Invoked via reflection, when forcing javascript restarts.
+-keepclassmembers class com.facebook.react.ReactInstanceManagerImpl {
+    void recreateReactContextInBackground();
+}


### PR DESCRIPTION
For us, without this rule, `restartApp` always fell back to using the `currentActivity` (the reflection technique always failed @ https://github.com/Microsoft/react-native-code-push/blob/235450604feca12c902746decfcbb2e715f4a071/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java#L145 )

This change was necessary to get codepush working in an app that ran without an activity (ref https://github.com/Microsoft/react-native-code-push/pull/491)