### PR TITLE
Fix 0.32 compat

### DIFF
--- a/Examples/CodePushDemoApp/.flowconfig
+++ b/Examples/CodePushDemoApp/.flowconfig
@@ -1,13 +1,28 @@
 [ignore]
 
 # We fork some components by platform.
-.*/*.android.js
+.*/*[.]android.js
 
 # Ignore templates with `@flow` in header
 .*/local-cli/generator.*
 
 # Ignore malformed json
 .*/node_modules/y18n/test/.*\.json
+
+# Ignore the website subdir
+<PROJECT_ROOT>/website/.*
+
+# Ignore BUCK generated dirs
+<PROJECT_ROOT>/\.buckd/
+
+# Ignore unexpected extra @providesModule
+.*/node_modules/commoner/test/source/widget/share.js
+
+# Ignore duplicate module providers
+# For RN Apps installed via npm, "Libraries" folder is inside node_modules/react-native but in the source repo it is in the root
+.*/Libraries/react-native/React.js
+.*/Libraries/react-native/ReactNative.js
+.*/node_modules/jest-runtime/build/__tests__/.*
 
 [include]
 
@@ -33,9 +48,11 @@ suppress_type=$FlowIssue
 suppress_type=$FlowFixMe
 suppress_type=$FixMe
 
-suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(2[0-7]\\|1[0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)
-suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(2[0-7]\\|1[0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)?:? #[0-9]+
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(30\\|[1-2][0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)
+suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(30\\|1[0-9]\\|[1-2][0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)?:? #[0-9]+
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 
+unsafe.enable_getters_and_setters=true
+
 [version]
-^0.27.0
+^0.30.0

--- a/Examples/CodePushDemoApp/iOS/CodePushDemoApp/AppDelegate.m
+++ b/Examples/CodePushDemoApp/iOS/CodePushDemoApp/AppDelegate.m
@@ -11,7 +11,7 @@
 
   // Use React Native's RCTBundleURLProvider to resolve your JS bundle location, so that your app will load the JS bundle from the packager server during development.
   //jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
-  
+
   // Use CodePush to resolve your JS bundle location, so that your app will run the version of the code distributed via CodePush
   jsCodeLocation = [CodePush bundleURL];
 

--- a/Examples/CodePushDemoApp/package.json
+++ b/Examples/CodePushDemoApp/package.json
@@ -7,8 +7,8 @@
   },
   "dependencies": {
     "babel-preset-react-native-stage-0": "1.0.1",
-    "react": "15.2.1",
-    "react-native": "0.30.0",
+    "react": "^15.3.1",
+    "react-native": "^0.32.0",
     "react-native-code-push": "file:../../"
   }
 }

--- a/Examples/CodePushDemoApp/package.json
+++ b/Examples/CodePushDemoApp/package.json
@@ -7,8 +7,8 @@
   },
   "dependencies": {
     "babel-preset-react-native-stage-0": "1.0.1",
-    "react": "^15.3.1",
-    "react-native": "^0.32.0",
+    "react": "15.3.1",
+    "react-native": "0.32.0",
     "react-native-code-push": "file:../../"
   }
 }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -20,3 +20,7 @@
 -keepclassmembers class com.facebook.react.ReactInstanceManagerImpl {
     void recreateReactContextInBackground();
 }
+
+-keepclassmembers class com.facebook.react.XReactInstanceManagerImpl {
+    void recreateReactContextInBackground();
+}

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -147,7 +147,6 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
                 bundleLoaderField.setAccessible(true);
                 bundleLoaderField.set(instanceManager, latestJSBundleLoader);
             } catch (Exception e) {
-                e.printStackTrace();
                 // RN <= v0.30
                 Field jsBundleField = instanceManager.getClass().getDeclaredField("mJSBundleFile");
                 jsBundleField.setAccessible(true);


### PR DESCRIPTION
Fixes https://github.com/Microsoft/react-native-code-push/issues/495 as well.

Our reflection based loadBundle is getting far too brittle and sensitive to changes in React Native's android interface. I will try to work with them to get a more stable solution going forward.