### PR TITLE
Prevent crashes during rollbacks

### DIFF
--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -455,9 +455,13 @@ static NSString *bundleResourceSubdirectory = nil;
 {
     NSError *error;
     NSDictionary *failedPackage = [CodePushPackage getCurrentPackage:&error];
-    if (error) {
-        CPLog(@"Error getting current update metadata during rollback: %@", error);
-    } else if (failedPackage) {
+    if (!failedPackage) {
+        if (error) {
+            CPLog(@"Error getting current update metadata during rollback: %@", error);
+        } else {
+            CPLog(@"Attempted to perform a rollback when there is no current update");
+        }
+    } else {
         // Write the current package's metadata to the "failed list"
         [self saveFailedUpdate:failedPackage];
     }

--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -455,9 +455,12 @@ static NSString *bundleResourceSubdirectory = nil;
 {
     NSError *error;
     NSDictionary *failedPackage = [CodePushPackage getCurrentPackage:&error];
-
-    // Write the current package's metadata to the "failed list"
-    [self saveFailedUpdate:failedPackage];
+    if (error) {
+        CPLog(@"Error getting current update metadata during rollback: %@", error);
+    } else if (failedPackage) {
+        // Write the current package's metadata to the "failed list"
+        [self saveFailedUpdate:failedPackage];
+    }
 
     // Rollback to the previous version and de-register the new update
     [CodePushPackage rollbackPackage];

--- a/ios/CodePush/CodePushPackage.m
+++ b/ios/CodePush/CodePushPackage.m
@@ -491,11 +491,13 @@ static NSString *const UnzippedFolderName = @"unzipped";
     NSError *error;
     NSMutableDictionary *info = [self getCurrentPackageInfo:&error];
     if (error) {
+        CPLog(@"Error getting current package info: %@", error);
         return;
     }
     
     NSString *currentPackageFolderPath = [self getCurrentPackageFolderPath:&error];
     if (error) {
+        CPLog(@"Error getting current package folder path: %@", error);
         return;
     }
     
@@ -515,11 +517,9 @@ static NSString *const UnzippedFolderName = @"unzipped";
 + (void)updateCurrentPackageInfo:(NSDictionary *)packageInfo
                            error:(NSError **)error
 {
-    
     NSData *packageInfoData = [NSJSONSerialization dataWithJSONObject:packageInfo
                                                               options:0
                                                                 error:error];
-    
     NSString *packageInfoString = [[NSString alloc] initWithData:packageInfoData
                                                         encoding:NSUTF8StringEncoding];
     [packageInfoString writeToFile:[self getStatusFilePath]


### PR DESCRIPTION
This PR prevents a crash caused by nil object insertion during rollbacks reported in https://github.com/Microsoft/react-native-code-push/issues/493, and also adds extra logging.