### PR TITLE
Update deprecated iOS sendEvent method calls

### DIFF
--- a/ios/CodePush/CodePush.h
+++ b/ios/CodePush/CodePush.h
@@ -1,6 +1,7 @@
+#import "RCTEventEmitter.h"
 #import <Foundation/Foundation.h>
 
-@interface CodePush : NSObject
+@interface CodePush : RCTEventEmitter
 
 + (NSURL *)binaryBundleURL;
 /*

--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -269,15 +269,15 @@ static NSString *bundleResourceSubdirectory = nil;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (void)dispatchDownloadProgressEvent
-{
-    // Notify the script-side about the progress
-    [self.bridge.eventDispatcher
-     sendDeviceEventWithName:@"CodePushDownloadProgress"
-     body:@{
-            @"totalBytes":[NSNumber numberWithLongLong:_latestExpectedContentLength],
-            @"receivedBytes":[NSNumber numberWithLongLong:_latestReceivedConentLength]
-            }];
+- (void)dispatchDownloadProgressEvent {
+  // Notify the script-side about the progress
+  [self sendEventWithName:@"CodePushDownloadProgress"
+                     body:@{
+                       @"totalBytes" : [NSNumber
+                           numberWithLongLong:_latestExpectedContentLength],
+                       @"receivedBytes" : [NSNumber
+                           numberWithLongLong:_latestReceivedConentLength]
+                     }];
 }
 
 /*


### PR DESCRIPTION
Using RCTEventEmitter as base class for CodePush to use `sendEventWithName` method instead of deprecated `[self.bridge.eventDispatcher sendDeviceEventWithName:]`

Usage in JS:
```
let NativeCodePush = NativeModules.CodePush;
let NativeCodePushEvent = new NativeEventEmitter(NativeCodePush);
NativeCodePushEvent.addListener('CodePushDownloadProgress',(data) => console.log(data))
```