### PR TITLE
Fix main bundle search regression

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -1,6 +1,7 @@
 package com.microsoft.codepush.react;
 
 import android.app.Activity;
+import android.content.Context;
 import android.os.AsyncTask;
 import android.os.Handler;
 import android.os.Looper;
@@ -10,7 +11,6 @@ import android.view.Choreographer;
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.bridge.Arguments;
-import com.facebook.react.bridge.JSBundleLoader;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;

--- a/ios/CodePush/CodePushUpdateUtils.m
+++ b/ios/CodePush/CodePushUpdateUtils.m
@@ -158,10 +158,6 @@ NSString * const ManifestFolderPrefix = @"CodePush";
             NSString *mainBundlePathInFolder = [self findMainBundleInFolder:fullFilePath
                                                            expectedFileName:expectedFileName
                                                                       error:error];
-            if (!mainBundlePathInFolder) {
-                return nil;
-            }
-            
             if (mainBundlePathInFolder) {
                 return [fileName stringByAppendingPathComponent:mainBundlePathInFolder];
             }


### PR DESCRIPTION
Fixes a regression caused by https://github.com/Microsoft/react-native-code-push/pull/499. If the JS bundle is not found in a particular folder, it should continue searching the rest of the folders instead of short-circuiting.