### PR TITLE
Check against self class in initialize methods

### DIFF
--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -61,8 +61,10 @@ static NSString *bundleResourceSubdirectory = nil;
 
 + (void)initialize
 {
-    // Use the mainBundle by default.
-    bundleResourceBundle = [NSBundle mainBundle];
+    if (self == [CodePush class]) {
+        // Use the mainBundle by default.
+        bundleResourceBundle = [NSBundle mainBundle];
+    }
 }
 
 #pragma mark - Public Obj-C API

--- a/ios/CodePush/CodePushConfig.m
+++ b/ios/CodePush/CodePushConfig.m
@@ -20,7 +20,9 @@ static NSString * const ServerURLConfigKey = @"serverUrl";
 
 + (void)initialize
 {
-    _currentConfig = [[CodePushConfig alloc] init];
+    if (self == [CodePushConfig class]) {
+        _currentConfig = [[CodePushConfig alloc] init];
+    }
 }
 
 - (instancetype)init


### PR DESCRIPTION
- Best practice for `initialize` methods is to check against the current class, otherwise if someone subclasses, the method may be run more than once.
- See: https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSObject_Class/index.html#//apple_ref/occ/clm/NSObject/initialize