### PR TITLE
Fix implicit conversion warning

### DIFF
--- a/ios/CodePush/CodePushUpdateUtils.m
+++ b/ios/CodePush/CodePushUpdateUtils.m
@@ -78,7 +78,7 @@ NSString * const ManifestFolderPrefix = @"CodePush";
 + (NSString *)computeHashForData:(NSData *)inputData
 {
     uint8_t digest[CC_SHA256_DIGEST_LENGTH];
-    CC_SHA256(inputData.bytes, inputData.length, digest);
+    CC_SHA256(inputData.bytes, (CC_LONG)inputData.length, digest);
     NSMutableString* inputHash = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH * 2];
     for (int i = 0; i < CC_SHA256_DIGEST_LENGTH; i++) {
         [inputHash appendFormat:@"%02x", digest[i]];


### PR DESCRIPTION
- Fixes a build warning about implicit conversion loss of precision.
- Fixed by adding an explicit cast to the correct type (`CC_LONG`).