### PR TITLE
Allow node_modules path to be overridden in codepush.gradle

### DIFF
--- a/android/codepush.gradle
+++ b/android/codepush.gradle
@@ -18,6 +18,12 @@ gradle.projectsEvaluated {
     def buildTypes = android.buildTypes.collect { type -> type.name }
     def productFlavors = android.productFlavors.collect { flavor -> flavor.name }
     if (!productFlavors) productFlavors.add('')
+    def nodeModulesPath;
+    if (project.hasProperty('nodeModulesPath')) {
+        nodeModulesPath = project.nodeModulesPath
+    } else {
+        nodeModulesPath = "../../node_modules";
+    }
 
     productFlavors.each { productFlavorName ->
         buildTypes.each { buildTypeName ->
@@ -40,9 +46,9 @@ gradle.projectsEvaluated {
             def recordFilesBeforeBundleCommand = tasks.create(
                     name: "recordFilesBeforeBundleCommand${targetName}",
                     type: Exec) {
-                commandLine "node", "../../node_modules/react-native-code-push/scripts/recordFilesBeforeBundleCommand.js", resourcesDir
+                commandLine "node", "${nodeModulesPath}/react-native-code-push/scripts/recordFilesBeforeBundleCommand.js", resourcesDir
             }
-            
+
             recordFilesBeforeBundleCommand.dependsOn("merge${targetName}Resources")
             recordFilesBeforeBundleCommand.dependsOn("merge${targetName}Assets")
             runBefore("bundle${targetName}JsAndAssets", recordFilesBeforeBundleCommand)
@@ -51,7 +57,7 @@ gradle.projectsEvaluated {
             def generateBundledResourcesHash = tasks.create(
                     name: "generateBundledResourcesHash${targetName}",
                     type: Exec) {
-                commandLine "node", "../../node_modules/react-native-code-push/scripts/generateBundledResourcesHash.js", resourcesDir, "$jsBundleDir/$bundleAssetName", assetsDir
+                commandLine "node", "${nodeModulesPath}/react-native-code-push/scripts/generateBundledResourcesHash.js", resourcesDir, "$jsBundleDir/$bundleAssetName", assetsDir
             }
 
             generateBundledResourcesHash.dependsOn("bundle${targetName}JsAndAssets")


### PR DESCRIPTION
Addresses https://github.com/Microsoft/react-native-code-push/issues/501.