### PR TITLE
Remove unnecessary config from AndroidManifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,9 +3,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <application
-      android:allowBackup="true"
-      android:label="@string/app_name">
+    <application>
         <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
     </application>
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">ReactNativeCodePush</string>
-</resources>


### PR DESCRIPTION
This was causing some manifest merging issues for us, however it seems
like this stuff is completely unnecessary, especially for an android
library, so I'm removing it all.