### PR TITLE
Fix usage of NativeEventEmitter

### DIFF
--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -26,6 +26,9 @@ RCT_EXPORT_MODULE()
 
 #pragma mark - Private constants
 
+// These constants represent emitted events
+static NSString *const DownloadProgressEvent = @"CodePushDownloadProgress";
+
 // These constants represent valid deployment statuses
 static NSString *const DeploymentFailed = @"DeploymentFailed";
 static NSString *const DeploymentSucceeded = @"DeploymentSucceeded";
@@ -296,7 +299,7 @@ static NSString *bundleResourceSubdirectory = nil;
 
 - (void)dispatchDownloadProgressEvent {
   // Notify the script-side about the progress
-  [self sendEventWithName:@"CodePushDownloadProgress"
+  [self sendEventWithName:DownloadProgressEvent
                      body:@{
                        @"totalBytes" : [NSNumber
                            numberWithLongLong:_latestExpectedContentLength],
@@ -535,6 +538,10 @@ static NSString *bundleResourceSubdirectory = nil;
 
     [preferences setObject:pendingUpdate forKey:PendingUpdateKey];
     [preferences synchronize];
+}
+
+- (NSArray<NSString *> *)supportedEvents {
+    return @[DownloadProgressEvent];
 }
 
 #pragma mark - Application lifecycle event handlers

--- a/package-mixins.js
+++ b/package-mixins.js
@@ -1,5 +1,5 @@
 import { AcquisitionManager as Sdk } from "code-push/script/acquisition-sdk";
-import { DeviceEventEmitter } from "react-native";
+import { NativeEventEmitter } from "react-native";
 import RestartManager from "./RestartManager";
 
 // This function is used to augment remote and local
@@ -15,8 +15,9 @@ module.exports = (NativeCodePush) => {
 
         let downloadProgressSubscription;
         if (downloadProgressCallback) {
+          const codePushEventEmitter = new NativeEventEmitter(NativeCodePush);
           // Use event subscription to obtain download progress.
-          downloadProgressSubscription = DeviceEventEmitter.addListener(
+          downloadProgressSubscription = codePushEventEmitter.addListener(
             "CodePushDownloadProgress",
             downloadProgressCallback
           );


### PR DESCRIPTION
This fixes the issue reported in #516, and also ensures that the event is successfully received in JS once the `Unsupported event` crash has been avoided.

This problem was introduced in #500, but has not been released on npm yet. For those who are curious, some guidance on the `RCTEventEmitter` class can be found at https://github.com/facebook/react-native/issues/8714