### PR TITLE
Fix issue where restarts did not happen for IMMEDIATE install mode

### DIFF
--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -64,6 +64,7 @@ static NSString *bundleResourceSubdirectory = nil;
 
 + (void)initialize
 {
+    [super initialize];
     if (self == [CodePush class]) {
         // Use the mainBundle by default.
         bundleResourceBundle = [NSBundle mainBundle];
@@ -231,7 +232,6 @@ static NSString *bundleResourceSubdirectory = nil;
 
 #pragma mark - Private API methods
 
-@synthesize bridge = _bridge;
 @synthesize methodQueue = _methodQueue;
 @synthesize pauseCallback = _pauseCallback;
 @synthesize paused = _paused;
@@ -255,7 +255,7 @@ static NSString *bundleResourceSubdirectory = nil;
 - (void)clearDebugUpdates
 {
     dispatch_async(dispatch_get_main_queue(), ^{
-        if ([_bridge.bundleURL.scheme hasPrefix:@"http"]) {
+        if ([super.bridge.bundleURL.scheme hasPrefix:@"http"]) {
             NSError *error;
             NSString *binaryAppVersion = [[CodePushConfig current] appVersion];
             NSDictionary *currentPackageMetadata = [CodePushPackage getCurrentPackage:&error];
@@ -434,18 +434,18 @@ static NSString *bundleResourceSubdirectory = nil;
  */
 - (void)loadBundle
 {
-    // This needs to be async dispatched because the _bridge is not set on init
+    // This needs to be async dispatched because the bridge is not set on init
     // when the app first starts, therefore rollbacks will not take effect.
     dispatch_async(dispatch_get_main_queue(), ^{
         // If the current bundle URL is using http(s), then assume the dev
         // is debugging and therefore, shouldn't be redirected to a local
         // file (since Chrome wouldn't support it). Otherwise, update
         // the current bundle URL to point at the latest update
-        if ([CodePush isUsingTestConfiguration] || ![_bridge.bundleURL.scheme hasPrefix:@"http"]) {
-            [_bridge setValue:[CodePush bundleURL] forKey:@"bundleURL"];
+        if ([CodePush isUsingTestConfiguration] || ![super.bridge.bundleURL.scheme hasPrefix:@"http"]) {
+            [super.bridge setValue:[CodePush bundleURL] forKey:@"bundleURL"];
         }
 
-        [_bridge reload];
+        [super.bridge reload];
     });
 }
 


### PR DESCRIPTION
This was introduced by #500, where the `CodePush` class was made to sub-class `RCTEventEmitter`. It seems like the [`bridge` property of `RCTEventEmitter`](https://github.com/facebook/react-native/blob/9981b8928d20416d1a3f3995b9f4d32ccf273ebd/React/Modules/RCTEventEmitter.h#L18) interferes with the synthesized [`_bridge` property of `CodePush`](https://github.com/Microsoft/react-native-code-push/blob/6d2abd11facd2950bbcda0c42753a5317a6f320a/ios/CodePush/CodePush.m#L234), with the solution being to modify `CodePush` to use `super.bridge` instead of synthesizing `_bridge`.

This bug was only present on the master branch and was never released to npm. It is possibly the issue mentioned in #521.