### PR TITLE
fix(AppRestart): Fix update-on-app-restart for UWP

### DIFF
--- a/windows/CodePushReactPackage.cs
+++ b/windows/CodePushReactPackage.cs
@@ -39,7 +39,6 @@ namespace CodePush.ReactNative
             // TODO implement telemetryManager 
             // _codePushTelemetryManager = new CodePushTelemetryManager(this.applicationContext, CODE_PUSH_PREFERENCES);
 
-            InitializeUpdateAfterRestart();
             if (CurrentInstance != null)
             {
                 CodePushUtils.Log("More than one CodePush instance has been initialized. Please use the instance method codePush.getBundleUrlInternal() to get the correct bundleURL for a particular instance.");


### PR DESCRIPTION
The following sequence seems to be locking up the application for update-on-app-restart:
1) Start app without any updates on CodePush
2) Push a CodePush update
3) Restart the app, the update will be downloaded and installed
4) Restart the app again, the app will claim that a rollback is required and hang

The source of the issue is that CodePushReactPackage.InitializeUpdateAfterRestart() is called twice, once in the constructor of CodePushReactPackage, when it sets PendingUpdateIsLoading to true. The second time it's called is from CodePushNativeModule.Initialize, at this point the "PendingUpdateIsLoading" is read out as true, and the app thinks a pending update was not finished, so it tries to Rollback.

Everything seems to work still after having removed the constructor call.