### PR TITLE
fix(async): Changing all await calls to .ConfigureAwait(false)

### DIFF
--- a/windows/CodePushNativeModule.cs
+++ b/windows/CodePushNativeModule.cs
@@ -57,7 +57,7 @@ namespace CodePush.ReactNative
         {
             try
             {
-                updatePackage[CodePushConstants.BinaryModifiedTimeKey] = "" + await _codePush.GetBinaryResourcesModifiedTimeAsync();
+                updatePackage[CodePushConstants.BinaryModifiedTimeKey] = "" + await _codePush.GetBinaryResourcesModifiedTimeAsync().ConfigureAwait(false);
                 await _codePush.UpdateManager.DownloadPackageAsync(
                     updatePackage,
                     _codePush.AssetsBundleFileName,
@@ -80,9 +80,9 @@ namespace CodePush.ReactNative
                                 .emit(CodePushConstants.DownloadProgressEventName, downloadProgress);
                         }
                     )
-                );
+                ).ConfigureAwait(false);
 
-                JObject newPackage = await _codePush.UpdateManager.GetPackageAsync((string)updatePackage[CodePushConstants.PackageHashKey]);
+                JObject newPackage = await _codePush.UpdateManager.GetPackageAsync((string)updatePackage[CodePushConstants.PackageHashKey]).ConfigureAwait(false);
                 promise.Resolve(newPackage);
             }
             catch (InvalidDataException e)
@@ -121,7 +121,7 @@ namespace CodePush.ReactNative
         [ReactMethod]
         public async void getUpdateMetadata(UpdateState updateState, IPromise promise)
         {
-            JObject currentPackage = await _codePush.UpdateManager.GetCurrentPackageAsync();
+            JObject currentPackage = await _codePush.UpdateManager.GetCurrentPackageAsync().ConfigureAwait(false);
             if (currentPackage == null)
             {
                 promise.Resolve("");
@@ -146,7 +146,7 @@ namespace CodePush.ReactNative
             {
                 // The caller wants the running update, but the current
                 // one is pending, so we need to grab the previous.
-                promise.Resolve(await _codePush.UpdateManager.GetPreviousPackageAsync());
+                promise.Resolve(await _codePush.UpdateManager.GetPreviousPackageAsync().ConfigureAwait(false));
             }
             else
             {
@@ -179,7 +179,7 @@ namespace CodePush.ReactNative
         [ReactMethod]
         public async void installUpdate(JObject updatePackage, InstallMode installMode, int minimumBackgroundDuration, IPromise promise)
         {
-            await _codePush.UpdateManager.InstallPackageAsync(updatePackage, SettingsManager.IsPendingUpdate(null));
+            await _codePush.UpdateManager.InstallPackageAsync(updatePackage, SettingsManager.IsPendingUpdate(null)).ConfigureAwait(false);
             var pendingHash = (string)updatePackage[CodePushConstants.PackageHashKey];
             SettingsManager.SavePendingUpdate(pendingHash, /* isLoading */false);
             if (installMode == InstallMode.OnNextResume)
@@ -191,7 +191,7 @@ namespace CodePush.ReactNative
                     {
                         Context.RunOnNativeModulesQueueThread(async () =>
                         {
-                            await LoadBundleAsync();
+                            await LoadBundleAsync().ConfigureAwait(false);
                         });
                     };
                         
@@ -219,7 +219,7 @@ namespace CodePush.ReactNative
             bool isFirstRun = _codePush.DidUpdate
                 && packageHash != null
                 && packageHash.Length > 0
-                && packageHash.Equals(await _codePush.UpdateManager.GetCurrentPackageHashAsync());
+                && packageHash.Equals(await _codePush.UpdateManager.GetCurrentPackageHashAsync().ConfigureAwait(false));
             promise.Resolve(isFirstRun);
         }
 
@@ -237,7 +237,7 @@ namespace CodePush.ReactNative
             // is current pending update, then reload the app.
             if (!onlyIfUpdateIsPending || SettingsManager.IsPendingUpdate(null))
             {
-                await LoadBundleAsync();
+                await LoadBundleAsync().ConfigureAwait(false);
             }
         }
         
@@ -254,7 +254,7 @@ namespace CodePush.ReactNative
 
             // #2) Update the locally stored JS bundle file path
             Type reactInstanceManagerType = typeof(ReactInstanceManager);
-            string latestJSBundleFile = await _codePush.GetJavaScriptBundleFileAsync(_codePush.AssetsBundleFileName);
+            string latestJSBundleFile = await _codePush.GetJavaScriptBundleFileAsync(_codePush.AssetsBundleFileName).ConfigureAwait(false);
             reactInstanceManagerType
                 .GetField("_jsBundleFile", BindingFlags.NonPublic | BindingFlags.Instance)
                 .SetValue(reactInstanceManager, latestJSBundleFile);

--- a/windows/CodePushReactPackage.cs
+++ b/windows/CodePushReactPackage.cs
@@ -85,8 +85,8 @@ namespace CodePush.ReactNative
         {
             AssetsBundleFileName = assetsBundleFileName;
             string binaryJsBundleUrl = CodePushConstants.AssetsBundlePrefix + assetsBundleFileName;
-            var binaryResourcesModifiedTime = await GetBinaryResourcesModifiedTimeAsync();
-            var packageFile = await UpdateManager.GetCurrentPackageBundleAsync(AssetsBundleFileName);
+            var binaryResourcesModifiedTime = await GetBinaryResourcesModifiedTimeAsync().ConfigureAwait(false);
+            var packageFile = await UpdateManager.GetCurrentPackageBundleAsync(AssetsBundleFileName).ConfigureAwait(false);
             if (packageFile == null)
             {
                 // There has not been any downloaded updates.
@@ -95,7 +95,7 @@ namespace CodePush.ReactNative
                 return binaryJsBundleUrl;
             }
 
-            var packageMetadata = await UpdateManager.GetCurrentPackageAsync();
+            var packageMetadata = await UpdateManager.GetCurrentPackageAsync().ConfigureAwait(false);
             long? binaryModifiedDateDuringPackageInstall = null;
             var binaryModifiedDateDuringPackageInstallString = (string)packageMetadata[CodePushConstants.BinaryModifiedTimeKey];
             if (binaryModifiedDateDuringPackageInstallString != null)
@@ -119,7 +119,7 @@ namespace CodePush.ReactNative
                 DidUpdate = false;
                 if (!MainPage.UseDeveloperSupport || !AppVersion.Equals(packageAppVersion))
                 {
-                    await ClearUpdatesAsync();
+                    await ClearUpdatesAsync().ConfigureAwait(false);
                 }
 
                 CodePushUtils.LogBundleUrl(binaryJsBundleUrl);
@@ -134,8 +134,8 @@ namespace CodePush.ReactNative
 
         internal async Task<long> GetBinaryResourcesModifiedTimeAsync()
         {
-            var assetJSBundleFile = await StorageFile.GetFileFromApplicationUriAsync(new Uri(CodePushConstants.AssetsBundlePrefix + AssetsBundleFileName));
-            var fileProperties = await assetJSBundleFile.GetBasicPropertiesAsync();
+            var assetJSBundleFile = await StorageFile.GetFileFromApplicationUriAsync(new Uri(CodePushConstants.AssetsBundlePrefix + AssetsBundleFileName)).AsTask().ConfigureAwait(false);
+            var fileProperties = await assetJSBundleFile.GetBasicPropertiesAsync().AsTask().ConfigureAwait(false);
             return fileProperties.DateModified.ToUnixTimeMilliseconds();
         }
         
@@ -170,7 +170,7 @@ namespace CodePush.ReactNative
 
         internal async Task ClearUpdatesAsync()
         {
-            await UpdateManager.ClearUpdatesAsync();
+            await UpdateManager.ClearUpdatesAsync().ConfigureAwait(false);
             SettingsManager.RemovePendingUpdate();
             SettingsManager.RemoveFailedUpdates();
         }
@@ -181,18 +181,18 @@ namespace CodePush.ReactNative
 
         private async Task ClearReactDevBundleCacheAsync()
         {
-            var devBundleCacheFile = (StorageFile) await ApplicationData.Current.LocalFolder.TryGetItemAsync(CodePushConstants.ReactDevBundleCacheFileName);
+            var devBundleCacheFile = (StorageFile)await ApplicationData.Current.LocalFolder.TryGetItemAsync(CodePushConstants.ReactDevBundleCacheFileName).AsTask().ConfigureAwait(false);
             if (devBundleCacheFile != null)
             {
-                await devBundleCacheFile.DeleteAsync();
+                await devBundleCacheFile.DeleteAsync().AsTask().ConfigureAwait(false);
             }
         }
 
         private async Task RollbackPackageAsync()
         {
-            JObject failedPackage = await UpdateManager.GetCurrentPackageAsync();
+            JObject failedPackage = await UpdateManager.GetCurrentPackageAsync().ConfigureAwait(false);
             SettingsManager.SaveFailedUpdate(failedPackage);
-            await UpdateManager.RollbackPackageAsync();
+            await UpdateManager.RollbackPackageAsync().ConfigureAwait(false);
             SettingsManager.RemovePendingUpdate();
         }
 

--- a/windows/CodePushUtils.cs
+++ b/windows/CodePushUtils.cs
@@ -12,7 +12,7 @@ namespace CodePush.ReactNative
     {
         internal async static Task<JObject> GetJObjectFromFileAsync(StorageFile file)
         {
-            string jsonString = await FileIO.ReadTextAsync(file);
+            string jsonString = await FileIO.ReadTextAsync(file).AsTask().ConfigureAwait(false);
             if (jsonString.Length == 0)
             {
                 return new JObject();

--- a/windows/FileUtils.cs
+++ b/windows/FileUtils.cs
@@ -8,15 +8,15 @@ namespace CodePush.ReactNative
     {
         internal async static Task MergeFoldersAsync(StorageFolder source, StorageFolder target)
         {
-            foreach (StorageFile sourceFile in await source.GetFilesAsync())
+            foreach (StorageFile sourceFile in await source.GetFilesAsync().AsTask().ConfigureAwait(false))
             {
-                await sourceFile.CopyAndReplaceAsync(await target.CreateFileAsync(sourceFile.Name, CreationCollisionOption.OpenIfExists));
+                await sourceFile.CopyAndReplaceAsync(await target.CreateFileAsync(sourceFile.Name, CreationCollisionOption.OpenIfExists).AsTask().ConfigureAwait(false)).AsTask().ConfigureAwait(false);
             }
             
-            foreach (StorageFolder sourceDirectory in await source.GetFoldersAsync())
+            foreach (StorageFolder sourceDirectory in await source.GetFoldersAsync().AsTask().ConfigureAwait(false))
             {
-                StorageFolder nextTargetSubDir = await target.CreateFolderAsync(sourceDirectory.Name, CreationCollisionOption.OpenIfExists);
-                await MergeFoldersAsync(sourceDirectory, nextTargetSubDir);
+                StorageFolder nextTargetSubDir = await target.CreateFolderAsync(sourceDirectory.Name, CreationCollisionOption.OpenIfExists).AsTask().ConfigureAwait(false);
+                await MergeFoldersAsync(sourceDirectory, nextTargetSubDir).ConfigureAwait(false);
             }
         }
     }

--- a/windows/UpdateManager.cs
+++ b/windows/UpdateManager.cs
@@ -17,66 +17,66 @@ namespace CodePush.ReactNative
 
         internal async Task ClearUpdatesAsync()
         {
-            await (await GetCodePushFolderAsync()).DeleteAsync();
+            await (await GetCodePushFolderAsync().ConfigureAwait(false)).DeleteAsync().AsTask().ConfigureAwait(false);
         }
 
         internal async Task DownloadPackageAsync(JObject updatePackage, string expectedBundleFileName, Progress<HttpProgress> downloadProgress)
         {
             // Using its hash, get the folder where the new update will be saved 
-            StorageFolder codePushFolder = await GetCodePushFolderAsync();
+            StorageFolder codePushFolder = await GetCodePushFolderAsync().ConfigureAwait(false);
             var newUpdateHash = (string)updatePackage[CodePushConstants.PackageHashKey];
-            StorageFolder newUpdateFolder = await GetPackageFolderAsync(newUpdateHash, false);
+            StorageFolder newUpdateFolder = await GetPackageFolderAsync(newUpdateHash, false).ConfigureAwait(false);
             if (newUpdateFolder != null)
             {
                 // This removes any stale data in newPackageFolderPath that could have been left
                 // uncleared due to a crash or error during the download or install process.
-                await newUpdateFolder.DeleteAsync();
+                await newUpdateFolder.DeleteAsync().AsTask().ConfigureAwait(false);
             }
 
-            newUpdateFolder = await GetPackageFolderAsync(newUpdateHash, true);
-            StorageFile newUpdateMetadataFile = await newUpdateFolder.CreateFileAsync(CodePushConstants.PackageFileName);
+            newUpdateFolder = await GetPackageFolderAsync(newUpdateHash, true).ConfigureAwait(false);
+            StorageFile newUpdateMetadataFile = await newUpdateFolder.CreateFileAsync(CodePushConstants.PackageFileName).AsTask().ConfigureAwait(false);
             var downloadUrlString = (string)updatePackage[CodePushConstants.DownloadUrlKey];
-            StorageFile downloadFile = await GetDownloadFileAsync();
+            StorageFile downloadFile = await GetDownloadFileAsync().ConfigureAwait(false);
             var downloadUri = new Uri(downloadUrlString);
 
             // Download the file and send progress event asynchronously
             var request = new HttpRequestMessage(HttpMethod.Get, downloadUri);
             var client = new HttpClient();
             var cancellationTokenSource = new CancellationTokenSource();
-            using (HttpResponseMessage response = await client.SendRequestAsync(request).AsTask(cancellationTokenSource.Token, downloadProgress))
-            using (IInputStream inputStream = await response.Content.ReadAsInputStreamAsync())
-            using (IRandomAccessStream downloadFileStream = await downloadFile.OpenAsync(FileAccessMode.ReadWrite))
+            using (HttpResponseMessage response = await client.SendRequestAsync(request).AsTask(cancellationTokenSource.Token, downloadProgress).ConfigureAwait(false))
+            using (IInputStream inputStream = await response.Content.ReadAsInputStreamAsync().AsTask().ConfigureAwait(false))
+            using (IRandomAccessStream downloadFileStream = await downloadFile.OpenAsync(FileAccessMode.ReadWrite).AsTask().ConfigureAwait(false))
             {
-                await RandomAccessStream.CopyAsync(inputStream, downloadFileStream);
+                await RandomAccessStream.CopyAsync(inputStream, downloadFileStream).AsTask().ConfigureAwait(false);
             }
 
             try
             {
                 // Unzip the downloaded file and then delete the zip
-                StorageFolder unzippedFolder = await GetUnzippedFolderAsync();
+                StorageFolder unzippedFolder = await GetUnzippedFolderAsync().ConfigureAwait(false);
                 ZipFile.ExtractToDirectory(downloadFile.Path, unzippedFolder.Path);
-                await downloadFile.DeleteAsync();
+                await downloadFile.DeleteAsync().AsTask().ConfigureAwait(false);
 
                 // Merge contents with current update based on the manifest
-                StorageFile diffManifestFile = (StorageFile)await unzippedFolder.TryGetItemAsync(CodePushConstants.DiffManifestFileName);
+                StorageFile diffManifestFile = (StorageFile)await unzippedFolder.TryGetItemAsync(CodePushConstants.DiffManifestFileName).AsTask().ConfigureAwait(false);
                 if (diffManifestFile != null)
                 {
-                    StorageFolder currentPackageFolder = await GetCurrentPackageFolderAsync();
+                    StorageFolder currentPackageFolder = await GetCurrentPackageFolderAsync().ConfigureAwait(false);
                     if (currentPackageFolder == null)
                     {
                         throw new InvalidDataException("Received a diff update, but there is no current version to diff against.");
                     }
 
-                    await UpdateUtils.CopyNecessaryFilesFromCurrentPackageAsync(diffManifestFile, currentPackageFolder, newUpdateFolder);
-                    await diffManifestFile.DeleteAsync();
+                    await UpdateUtils.CopyNecessaryFilesFromCurrentPackageAsync(diffManifestFile, currentPackageFolder, newUpdateFolder).ConfigureAwait(false);
+                    await diffManifestFile.DeleteAsync().AsTask().ConfigureAwait(false);
                 }
 
-                await FileUtils.MergeFoldersAsync(unzippedFolder, newUpdateFolder);
-                await unzippedFolder.DeleteAsync();
+                await FileUtils.MergeFoldersAsync(unzippedFolder, newUpdateFolder).ConfigureAwait(false);
+                await unzippedFolder.DeleteAsync().AsTask().ConfigureAwait(false);
 
                 // For zip updates, we need to find the relative path to the jsBundle and save it in the
                 // metadata so that we can find and run it easily the next time.
-                string relativeBundlePath = await UpdateUtils.FindJSBundleInUpdateContentsAsync(newUpdateFolder, expectedBundleFileName);
+                string relativeBundlePath = await UpdateUtils.FindJSBundleInUpdateContentsAsync(newUpdateFolder, expectedBundleFileName).ConfigureAwait(false);
                 if (relativeBundlePath == null)
                 {
                     throw new InvalidDataException("Update is invalid - A JS bundle file named \"" + expectedBundleFileName + "\" could not be found within the downloaded contents. Please check that you are releasing your CodePush updates using the exact same JS bundle file name that was shipped with your app's binary.");
@@ -95,52 +95,52 @@ namespace CodePush.ReactNative
             catch (InvalidDataException)
             {
                 // Downloaded file is not a zip, assume it is a jsbundle
-                await downloadFile.RenameAsync(expectedBundleFileName);
-                await downloadFile.MoveAsync(newUpdateFolder);
+                await downloadFile.RenameAsync(expectedBundleFileName).AsTask().ConfigureAwait(false);
+                await downloadFile.MoveAsync(newUpdateFolder).AsTask().ConfigureAwait(false);
             }
 
             // Save metadata to the folder
-            await FileIO.WriteTextAsync(newUpdateMetadataFile, JsonConvert.SerializeObject(updatePackage));
+            await FileIO.WriteTextAsync(newUpdateMetadataFile, JsonConvert.SerializeObject(updatePackage)).AsTask().ConfigureAwait(false);
         }
 
         internal async Task<JObject> GetCurrentPackageAsync()
         {
-            string packageHash = await GetCurrentPackageHashAsync();
-            return packageHash == null ? null : await GetPackageAsync(packageHash);
+            string packageHash = await GetCurrentPackageHashAsync().ConfigureAwait(false);
+            return packageHash == null ? null : await GetPackageAsync(packageHash).ConfigureAwait(false);
         }
 
         internal async Task<StorageFile> GetCurrentPackageBundleAsync(string bundleFileName)
         {
-            StorageFolder packageFolder = await GetCurrentPackageFolderAsync();
+            StorageFolder packageFolder = await GetCurrentPackageFolderAsync().ConfigureAwait(false);
             if (packageFolder == null)
             {
                 return null;
             }
 
-            JObject currentPackage = await GetCurrentPackageAsync();
+            JObject currentPackage = await GetCurrentPackageAsync().ConfigureAwait(false);
             var relativeBundlePath = (string)currentPackage[CodePushConstants.RelativeBundlePathKey];
 
-            return relativeBundlePath == null 
-                ? await packageFolder.GetFileAsync(bundleFileName)
-                : await packageFolder.GetFileAsync(relativeBundlePath);
+            return relativeBundlePath == null
+                ? await packageFolder.GetFileAsync(bundleFileName).AsTask().ConfigureAwait(false)
+                : await packageFolder.GetFileAsync(relativeBundlePath).AsTask().ConfigureAwait(false);
         }
 
         internal async Task<string> GetCurrentPackageHashAsync()
         {
-            JObject info = await GetCurrentPackageInfoAsync();
+            JObject info = await GetCurrentPackageInfoAsync().ConfigureAwait(false);
             string currentPackageShortHash = (string)info[CodePushConstants.CurrentPackageKey];
             if (currentPackageShortHash == null)
             {
                 return null;
             }
 
-            JObject currentPackageMetadata = await GetPackageAsync(currentPackageShortHash);
+            JObject currentPackageMetadata = await GetPackageAsync(currentPackageShortHash).ConfigureAwait(false);
             return currentPackageMetadata == null ? null : (string)currentPackageMetadata[CodePushConstants.PackageHashKey];
         }
 
         internal async Task<JObject> GetPackageAsync(string packageHash)
         {
-            StorageFolder packageFolder = await GetPackageFolderAsync(packageHash, false);
+            StorageFolder packageFolder = await GetPackageFolderAsync(packageHash, false).ConfigureAwait(false);
             if (packageFolder == null)
             {
                 return null;
@@ -148,8 +148,8 @@ namespace CodePush.ReactNative
 
             try
             {
-                StorageFile packageFile = await packageFolder.GetFileAsync(CodePushConstants.PackageFileName);
-                return await CodePushUtils.GetJObjectFromFileAsync(packageFile);
+                StorageFile packageFile = await packageFolder.GetFileAsync(CodePushConstants.PackageFileName).AsTask().ConfigureAwait(false);
+                return await CodePushUtils.GetJObjectFromFileAsync(packageFile).ConfigureAwait(false);
             }
             catch (IOException)
             {
@@ -159,13 +159,13 @@ namespace CodePush.ReactNative
 
         internal async Task<StorageFolder> GetPackageFolderAsync(string packageHash, bool createIfNotExists)
         {
-            StorageFolder codePushFolder = await GetCodePushFolderAsync();
+            StorageFolder codePushFolder = await GetCodePushFolderAsync().ConfigureAwait(false);
             try
             {
                 packageHash = ShortenPackageHash(packageHash);
                 return createIfNotExists
-                    ? await codePushFolder.CreateFolderAsync(packageHash, CreationCollisionOption.OpenIfExists)
-                    : await codePushFolder.GetFolderAsync(packageHash);
+                    ? await codePushFolder.CreateFolderAsync(packageHash, CreationCollisionOption.OpenIfExists).AsTask().ConfigureAwait(false)
+                    : await codePushFolder.GetFolderAsync(packageHash).AsTask().ConfigureAwait(false);
             }
             catch (FileNotFoundException)
             {
@@ -175,46 +175,46 @@ namespace CodePush.ReactNative
 
         internal async Task<JObject> GetPreviousPackageAsync()
         {
-            string packageHash = await GetPreviousPackageHashAsync();
-            return packageHash == null ? null : await GetPackageAsync(packageHash);
+            string packageHash = await GetPreviousPackageHashAsync().ConfigureAwait(false);
+            return packageHash == null ? null : await GetPackageAsync(packageHash).ConfigureAwait(false);
         }
 
         internal async Task<string> GetPreviousPackageHashAsync()
         {
-            JObject info = await GetCurrentPackageInfoAsync();
+            JObject info = await GetCurrentPackageInfoAsync().ConfigureAwait(false);
             string previousPackageShortHash = (string)info[CodePushConstants.PreviousPackageKey];
             if (previousPackageShortHash == null)
             {
                 return null;
             }
 
-            JObject previousPackageMetadata = await GetPackageAsync(previousPackageShortHash);
+            JObject previousPackageMetadata = await GetPackageAsync(previousPackageShortHash).ConfigureAwait(false);
             return previousPackageMetadata == null ? null : (string)previousPackageMetadata[CodePushConstants.PackageHashKey];
         }
 
         internal async Task InstallPackageAsync(JObject updatePackage, bool currentUpdateIsPending)
         {
             var packageHash = (string)updatePackage[CodePushConstants.PackageHashKey];
-            JObject info = await GetCurrentPackageInfoAsync();
+            JObject info = await GetCurrentPackageInfoAsync().ConfigureAwait(false);
             if (currentUpdateIsPending)
             {
                 // Don't back up current update to the "previous" position because
                 // it is an unverified update which should not be rolled back to.
-                StorageFolder currentPackageFolder = await GetCurrentPackageFolderAsync();
+                StorageFolder currentPackageFolder = await GetCurrentPackageFolderAsync().ConfigureAwait(false);
                 if (currentPackageFolder != null)
                 {
-                    await currentPackageFolder.DeleteAsync();
+                    await currentPackageFolder.DeleteAsync().AsTask().ConfigureAwait(false);
                 }
             }
             else
             {
-                string previousPackageHash = await GetPreviousPackageHashAsync();
+                string previousPackageHash = await GetPreviousPackageHashAsync().ConfigureAwait(false);
                 if (previousPackageHash != null && !previousPackageHash.Equals(packageHash))
                 {
-                    StorageFolder previousPackageFolder = await GetPackageFolderAsync(previousPackageHash, false);
+                    StorageFolder previousPackageFolder = await GetPackageFolderAsync(previousPackageHash, false).ConfigureAwait(false);
                     if (previousPackageFolder != null)
                     {
-                        await previousPackageFolder.DeleteAsync();
+                        await previousPackageFolder.DeleteAsync().AsTask().ConfigureAwait(false);
                     }
                 }
 
@@ -222,21 +222,21 @@ namespace CodePush.ReactNative
             }
 
             info[CodePushConstants.CurrentPackageKey] = packageHash;
-            await UpdateCurrentPackageInfoAsync(info);
+            await UpdateCurrentPackageInfoAsync(info).ConfigureAwait(false);
         }
 
         internal async Task RollbackPackageAsync()
         {
-            JObject info = await GetCurrentPackageInfoAsync();
-            StorageFolder currentPackageFolder = await GetCurrentPackageFolderAsync();
+            JObject info = await GetCurrentPackageInfoAsync().ConfigureAwait(false);
+            StorageFolder currentPackageFolder = await GetCurrentPackageFolderAsync().ConfigureAwait(false);
             if (currentPackageFolder != null)
             {
-                await currentPackageFolder.DeleteAsync();
+                await currentPackageFolder.DeleteAsync().AsTask().ConfigureAwait(false);
             }
 
             info[CodePushConstants.CurrentPackageKey] = info[CodePushConstants.PreviousPackageKey];
             info[CodePushConstants.PreviousPackageKey] = null;
-            await UpdateCurrentPackageInfoAsync(info);
+            await UpdateCurrentPackageInfoAsync(info).ConfigureAwait(false);
         }
 
         #endregion
@@ -245,38 +245,38 @@ namespace CodePush.ReactNative
 
         private async Task<StorageFolder> GetCodePushFolderAsync()
         {
-            return await ApplicationData.Current.LocalFolder.CreateFolderAsync(CodePushConstants.CodePushFolderPrefix, CreationCollisionOption.OpenIfExists);
+            return await ApplicationData.Current.LocalFolder.CreateFolderAsync(CodePushConstants.CodePushFolderPrefix, CreationCollisionOption.OpenIfExists).AsTask().ConfigureAwait(false);
         }
 
         private async Task<StorageFolder> GetCurrentPackageFolderAsync()
         {
-            JObject info = await GetCurrentPackageInfoAsync();
+            JObject info = await GetCurrentPackageInfoAsync().ConfigureAwait(false);
             var packageHash = (string)info[CodePushConstants.CurrentPackageKey];
-            return packageHash == null ? null : await GetPackageFolderAsync(packageHash, false);
+            return packageHash == null ? null : await GetPackageFolderAsync(packageHash, false).ConfigureAwait(false);
         }
 
         private async Task<JObject> GetCurrentPackageInfoAsync()
         {
-            StorageFile statusFile = await GetStatusFileAsync();
-            return await CodePushUtils.GetJObjectFromFileAsync(statusFile);
+            StorageFile statusFile = await GetStatusFileAsync().ConfigureAwait(false);
+            return await CodePushUtils.GetJObjectFromFileAsync(statusFile).ConfigureAwait(false);
         }
 
         private async Task<StorageFile> GetDownloadFileAsync()
         {
-            var codePushFolder = await GetCodePushFolderAsync();
-            return await codePushFolder.CreateFileAsync(CodePushConstants.DownloadFileName, CreationCollisionOption.OpenIfExists);
+            var codePushFolder = await GetCodePushFolderAsync().ConfigureAwait(false);
+            return await codePushFolder.CreateFileAsync(CodePushConstants.DownloadFileName, CreationCollisionOption.OpenIfExists).AsTask().ConfigureAwait(false);
         }
 
         private async Task<StorageFile> GetStatusFileAsync()
         {
-            StorageFolder codePushFolder = await GetCodePushFolderAsync();
-            return await codePushFolder.CreateFileAsync(CodePushConstants.StatusFileName, CreationCollisionOption.OpenIfExists);
+            StorageFolder codePushFolder = await GetCodePushFolderAsync().ConfigureAwait(false);
+            return await codePushFolder.CreateFileAsync(CodePushConstants.StatusFileName, CreationCollisionOption.OpenIfExists).AsTask().ConfigureAwait(false);
         }
 
         private async Task<StorageFolder> GetUnzippedFolderAsync()
         {
-            StorageFolder codePushFolder = await GetCodePushFolderAsync();
-            return await codePushFolder.CreateFolderAsync(CodePushConstants.UnzippedFolderName, CreationCollisionOption.OpenIfExists);
+            StorageFolder codePushFolder = await GetCodePushFolderAsync().ConfigureAwait(false);
+            return await codePushFolder.CreateFolderAsync(CodePushConstants.UnzippedFolderName, CreationCollisionOption.OpenIfExists).AsTask().ConfigureAwait(false);
         }
 
         private string ShortenPackageHash(string longPackageHash)
@@ -286,7 +286,7 @@ namespace CodePush.ReactNative
 
         private async Task UpdateCurrentPackageInfoAsync(JObject packageInfo)
         {
-            await FileIO.WriteTextAsync(await GetStatusFileAsync(), JsonConvert.SerializeObject(packageInfo));
+            await FileIO.WriteTextAsync(await GetStatusFileAsync().ConfigureAwait(false), JsonConvert.SerializeObject(packageInfo)).AsTask().ConfigureAwait(false);
         }
 
         #endregion

--- a/windows/UpdateUtils.cs
+++ b/windows/UpdateUtils.cs
@@ -10,19 +10,19 @@ namespace CodePush.ReactNative
     {
         internal async static Task CopyNecessaryFilesFromCurrentPackageAsync(StorageFile diffManifestFile, StorageFolder currentPackageFolder, StorageFolder newPackageFolder)
         {
-            await FileUtils.MergeFoldersAsync(currentPackageFolder, newPackageFolder);
-            JObject diffManifest = await CodePushUtils.GetJObjectFromFileAsync(diffManifestFile);
+            await FileUtils.MergeFoldersAsync(currentPackageFolder, newPackageFolder).ConfigureAwait(false);
+            JObject diffManifest = await CodePushUtils.GetJObjectFromFileAsync(diffManifestFile).ConfigureAwait(false);
             var deletedFiles = (JArray)diffManifest["deletedFiles"];
             foreach (string fileNameToDelete in deletedFiles)
             {
-                StorageFile fileToDelete = await newPackageFolder.GetFileAsync(fileNameToDelete);
-                await fileToDelete.DeleteAsync();
+                StorageFile fileToDelete = await newPackageFolder.GetFileAsync(fileNameToDelete).AsTask().ConfigureAwait(false);
+                await fileToDelete.DeleteAsync().AsTask().ConfigureAwait(false);
             }
         }
 
         internal async static Task<string> FindJSBundleInUpdateContentsAsync(StorageFolder updateFolder, string expectedFileName)
         {
-            foreach (StorageFile file in await updateFolder.GetFilesAsync())
+            foreach (StorageFile file in await updateFolder.GetFilesAsync().AsTask().ConfigureAwait(false))
             {
                 string fileName = file.Name;
                 if (fileName.Equals(expectedFileName))
@@ -31,9 +31,9 @@ namespace CodePush.ReactNative
                 }
             }
 
-            foreach (StorageFolder folder in await updateFolder.GetFoldersAsync())
+            foreach (StorageFolder folder in await updateFolder.GetFoldersAsync().AsTask().ConfigureAwait(false))
             {
-                string mainBundlePathInSubFolder = await FindJSBundleInUpdateContentsAsync(folder, expectedFileName);
+                string mainBundlePathInSubFolder = await FindJSBundleInUpdateContentsAsync(folder, expectedFileName).ConfigureAwait(false);
                 if (mainBundlePathInSubFolder != null)
                 {
                     return Path.Combine(folder.Name, mainBundlePathInSubFolder);


### PR DESCRIPTION
The async calls in CodePush for ReactWindows can all be executed on any background thread, so adding .ConfigureAwait(false) can improve performance and reduce the likelihood of deadlock.  The blocking calls in `InitializeUpdateAfterRestart()` were hanging, but now that .ConfigureAwait(false) is used pervasively, it is no longer a problem.

Fixes #550