### PR TITLE
Send the CodePush plugin version with server requests

### DIFF
--- a/request-fetch-adapter.js
+++ b/request-fetch-adapter.js
@@ -1,3 +1,5 @@
+const packageJson = require("./package.json");
+
 module.exports = {
   async request(verb, url, requestBody, callback) {
     if (typeof requestBody === "function") {
@@ -8,7 +10,9 @@ module.exports = {
     const headers = {
       "Accept": "application/json",
       "Content-Type": "application/json",
-      "X-CodePush-SDK-Version": getSDKVersion()
+      "X-CodePush-Plugin-Name": packageJson.name,
+      "X-CodePush-Plugin-Version": packageJson.version,
+      "X-CodePush-SDK-Version": packageJson.dependencies["code-push"]
     };
 
     if (requestBody && typeof requestBody === "object") {
@@ -30,10 +34,6 @@ module.exports = {
     }
   }
 };
-
-function getSDKVersion() {
-  return require("./package.json").dependencies["code-push"];
-}
 
 function getHttpMethodName(verb) {
   // Note: This should stay in sync with the enum definition in


### PR DESCRIPTION
This allows the server to maintain backward compatibility by distinguishing between different plugins (e.g. React Native/Cordova/Windows), as well as individual versions of these plugins, without needing to use the old SDK version (which refers to the acquisition SDK, which is shared between all plugins).

This will also enable us to resolve #514, by rolling out a CDN only for newer plugin versions. (On the Cordova end at the very least, some users have plugins installed that have a whitelist of acceptable endpoints).