### PR TITLE
Ignore OSX metadata when hashing updates

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateUtils.java
@@ -24,9 +24,13 @@ public class CodePushUpdateUtils {
         File folder = new File(folderPath);
         File[] folderFiles = folder.listFiles();
         for (File file : folderFiles) {
+            String fileName = file.getName();
             String fullFilePath = file.getAbsolutePath();
-            String relativePath = (pathPrefix.isEmpty() ? "" : (pathPrefix + "/")) + file.getName();
-            if (file.isDirectory()) {
+            String relativePath = (pathPrefix.isEmpty() ? "" : (pathPrefix + "/")) + fileName;
+
+            if (fileName.equals(".DS_Store") || fileName.equals("__MACOSX")) {
+                continue;
+            } else if (file.isDirectory()) {
                 addContentsOfFolderToManifest(fullFilePath, relativePath, manifest);
             } else {
                 try {


### PR DESCRIPTION
On Android, prevent hash mismatches by ensuring the hashing algorithm ignores OS X metadata (`.DS_Store` and `__MACOSX`). This addresses #472, and mirrors #471, which is the iOS side of the fix.