### PR TITLE
Support React Native 0.35.0

### DIFF
--- a/Examples/CodePushDemoApp/package.json
+++ b/Examples/CodePushDemoApp/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "babel-preset-react-native-stage-0": "1.0.1",
     "react": "15.3.1",
-    "react-native": "0.34.1",
+    "react-native": "0.35.0",
     "react-native-code-push": "file:../../"
   }
 }

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ We try our best to maintain backwards compatability of our plugin with previous 
 | v0.19-v0.28             | v1.7.0+ *(introduced Android asset support)*   |
 | v0.29-v0.30             | v1.13.0+ *(RN refactored native hosting code)* |
 | v0.31-v0.33             | v1.14.6+ *(RN refactored native hosting code)* |
-| v0.34                   | v1.15.0+ *(RN refactored native hosting code)* |
-| v0.35+                  | TBD :) We work hard to respond to new RN releases, but they do occasionally break us. We will update this chart with each RN release, so that users can check to see what our "official" support is.
+| v0.34-v0.35             | v1.15.0+ *(RN refactored native hosting code)* |
+| v0.36+                  | TBD :) We work hard to respond to new RN releases, but they do occasionally break us. We will update this chart with each RN release, so that users can check to see what our "official" support is.
 
 ## Supported Components
 

--- a/package-mixins.js
+++ b/package-mixins.js
@@ -41,7 +41,8 @@ module.exports = (NativeCodePush) => {
   const local = {
     async install(installMode = NativeCodePush.codePushInstallModeOnNextRestart, minimumBackgroundDuration = 0, updateInstalledCallback) {
       const localPackage = this;
-      await NativeCodePush.installUpdate(this, installMode, minimumBackgroundDuration);
+      const localPackageCopy = Object.assign({}, localPackage); // In dev mode, React Native deep freezes any object queued over the bridge
+      await NativeCodePush.installUpdate(localPackageCopy, installMode, minimumBackgroundDuration);
       updateInstalledCallback && updateInstalledCallback();
       if (installMode == NativeCodePush.codePushInstallModeImmediate) {
         RestartManager.restartApp(false);


### PR DESCRIPTION
This line was added in React Native 0.35.0: https://github.com/facebook/react-native/blob/v0.35.0/Libraries/Utilities/MessageQueue.js#L194 (https://github.com/facebook/react-native/commit/145109fc6d7310d844f6c15b74aad29ddb495e79). It essentially deep freezes (or makes immutable) any object sent from JS to Native over the bridge. This object is already pass-by-value to begin with, so I assume the purpose of this is to avoid any ambiguity or confusion that might occur if the object is modified while it is sitting in the message queue.

We do send a `localPackage` object over the bridge, which we modify afterwards. Because we only care about the value of this object at the moment that it is queued, the fix is to make a copy of it before sending it over the bridge.

This is relevant to issue #536 (RN version support).