### PR TITLE
Fix #477 - link errors with multiple AppDelegate.m

### DIFF
--- a/scripts/postlink/ios/postlink.js
+++ b/scripts/postlink/ios/postlink.js
@@ -3,20 +3,16 @@ var glob = require("glob");
 var inquirer = require('inquirer');
 var path = require("path");
 var plist = require("plist");
-
-// Fix for https://github.com/Microsoft/react-native-code-push/issues/477
-// Try to resolve package.json, assuming we are working off of the project root
-// We will use this later to fetch the correct AppDelegate and Plist file, in case there are multiple.
-var package = require(path.resolve('./package.json'));
+var package = require('../../../../../package.json');
 
 var ignoreNodeModules = { ignore: "node_modules/**" };
 var appDelegatePaths = glob.sync("**/AppDelegate.m", ignoreNodeModules);
 
-// Fix for https://github.com/Microsoft/react-native-code-push/issues/477:
+// Fix for https://github.com/Microsoft/react-native-code-push/issues/477
 // Typical location of AppDelegate.m for newer RN versions: $PROJECT_ROOT/ios/<project_name>/AppDelegate.m
-// Try to find that path by filtering the whole array for any path containing <project_name>
+// Let's try to find that path by filtering the whole array for any path containing <project_name>
 // If we can't find it there, play dumb and pray it is the first path we find.
-var appDelegatePath = findFileByAppName(appDelegatePaths, package?package.name:null) || appDelegatePaths[0];
+var appDelegatePath = findFileByAppName(appDelegatePaths, package ? package.name : null) || appDelegatePaths[0];
 
 // Glob only allows foward slashes in patterns: https://www.npmjs.com/package/glob#windows
 var plistPath = glob.sync(path.join(path.dirname(appDelegatePath), "*Info.plist").replace(/\\/g, "/"), ignoreNodeModules)[0];

--- a/scripts/postlink/ios/postlink.js
+++ b/scripts/postlink/ios/postlink.js
@@ -4,8 +4,20 @@ var inquirer = require('inquirer');
 var path = require("path");
 var plist = require("plist");
 
+// Fix for https://github.com/Microsoft/react-native-code-push/issues/477
+// Try to resolve package.json, assuming we are working off of the project root
+// We will use this later to fetch the correct AppDelegate and Plist file, in case there are multiple.
+var package = require(path.resolve('./package.json'));
+
 var ignoreNodeModules = { ignore: "node_modules/**" };
-var appDelegatePath = glob.sync("**/AppDelegate.m", ignoreNodeModules)[0];
+var appDelegatePaths = glob.sync("**/AppDelegate.m", ignoreNodeModules);
+
+// Fix for https://github.com/Microsoft/react-native-code-push/issues/477:
+// Typical location of AppDelegate.m for newer RN versions: $PROJECT_ROOT/ios/<project_name>/AppDelegate.m
+// Try to find that path by filtering the whole array for any path containing <project_name>
+// If we can't find it there, play dumb and pray it is the first path we find.
+var appDelegatePath = findFileByAppName(appDelegatePaths, package?package.name:null) || appDelegatePaths[0];
+
 // Glob only allows foward slashes in patterns: https://www.npmjs.com/package/glob#windows
 var plistPath = glob.sync(path.join(path.dirname(appDelegatePath), "*Info.plist").replace(/\\/g, "/"), ignoreNodeModules)[0];
 
@@ -59,4 +71,19 @@ if (parsedInfoPlist.CodePushDeploymentKey) {
 function writePatches() {
     fs.writeFileSync(appDelegatePath, appDelegateContents);
     fs.writeFileSync(plistPath, plistContents);
+}
+
+// Helper that filters an array with AppDelegate.m paths for a path with the app name inside it
+// Should cover nearly all cases
+function findFileByAppName(array, appName) {
+    if (array.length === 0 || !appName) return null;
+
+    for (var i = 0; i < array.length; i++) {
+        var path = array[i];
+        if (path && path.indexOf(appName) !== -1) {
+            return path;
+        }
+    }
+
+    return null;
 }


### PR DESCRIPTION
Fixes issue #477 aka `TypeError: Cannot read property '1' of null` when you try to `rnpm link` or `react-native link`.

In issue #477 there was an issue when the project has, for some reason, multiple `AppDelegate.m` files (eg project sample files) within the `ios` subdir of an RN project.

This fix will give priority to the `AppDelegate.m` found inside any path that has the application name (as defined in `package.json`) in it. If it cannot find that, it will revert to previous behavior (the first element in the path array).