### PR TITLE
Remove the project name from settings.gradle

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,3 +1,1 @@
-rootProject.name = 'ReactNativeCodePush'
-
 include ':app'


### PR DESCRIPTION
As mentioned in #558, this line may override the original app's own project name.