### PR TITLE
android: allow `assetsDir` and `resourcesDir` can be overridden

### DIFF
--- a/android/codepush.gradle
+++ b/android/codepush.gradle
@@ -32,12 +32,15 @@ gradle.projectsEvaluated {
                     "${productFlavorName}/${buildTypeName}" :
                     "${buildTypeName}"
 
+            def assetsDirConfigName = "assetsDir${targetName}"
+            def assetsDir = elvisFile(config."$assetsDirConfigName") ?:
+                    "$buildDir/intermediates/assets/${targetPath}"
+
             def jsBundleDirConfigName = "jsBundleDir${targetName}"
-            def assetsDir = "$buildDir/intermediates/assets/${targetPath}"
             def jsBundleDir = elvisFile(config."$jsBundleDirConfigName") ?:
                     file(assetsDir)
 
-            def resourcesDirConfigName = "jsBundleDir${targetName}"
+            def resourcesDirConfigName = "resourcesDir${targetName}"
             def resourcesDir = elvisFile(config."${resourcesDirConfigName}") ?:
                     file("$buildDir/intermediates/res/merged/${targetPath}")
             def jsBundleFile = file("$jsBundleDir/$bundleAssetName")


### PR DESCRIPTION
I'm building an android library project using react-native and code-push.
### assetsDir

When compiling an android library project the `assets` directory is located at

`${buildDir}/intermediates/bundles/${targetPath}/assets`

instead of

`${buildDir}/intermediates/assets/${targetPath}`

So I need to specify not only `jsBundleDir` but `assetsDir`, otherwise it cannot find the correct assets path in `generateBundledResourcesHash.js`
### resourcesDir

As of `resourcesDir`, it was originally overridden by `jsBunbleDir`. It would be better to be overridden by a separated variable like that in [react-native/react.gradle](https://github.com/facebook/react-native/blob/v0.36.0/react.gradle#L46)
