### PR TITLE
Fix comparison method in setJSBundle

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -106,7 +106,7 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
 
             Method[] methods = jsBundleLoaderClass.getDeclaredMethods();
             for (Method method : methods) {
-                if (method.getName() == "createFileLoader") {
+                if (method.getName().equals("createFileLoader")) {
                     createFileLoaderMethod = method;
                     break;
                 }


### PR DESCRIPTION
Simple Fix:

The old comparison method is wrong:
`if (method.getName() == "createFileLoader")`

`==` comparison fails on Samsung S5,

Change it to:
`if (method.getName().equals("createFileLoader"))`