### PR TITLE
[Android] Let npm take care of versioning

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -21,5 +21,5 @@ android {
 }
 
 dependencies {
-    compile "com.facebook.react:react-native:0.19.+"
+    compile "com.facebook.react:react-native:+"
 }


### PR DESCRIPTION
From [build.gradle](https://github.com/Microsoft/react-native-code-push/blob/master/android/app/build.gradle#L24):

    dependencies {
        compile "com.facebook.react:react-native:0.19.+"
    }

This means that when adding the react-native-code-push module to an app and building it, Gradle will fetch React Native 0.19 from Maven, even if the app is using say RN 0.34. We stopped releasing the React Native Android artifacts to Maven - they are distributed via npm along with the JS code.  For example I installed RN 0.34 from npm, it will have the 0.34 Android artifacts in `node_modules` and [Gradle will use those to build the app](https://github.com/facebook/react-native/blob/9ee815f6b52e0c2417c04e5a05e1e31df26daed2/local-cli/generator-android/templates/src/build.gradle#L21).

Would you consider using `compile 'com.facebook.react:react-native:+'` instead, as for example [react-native-push-notification](https://github.com/zo0r/react-native-push-notification/blob/master/android/build.gradle) do [react-native-maps](https://github.com/airbnb/react-native-maps/blob/master/android/build.gradle#L56) do?

If this doesn't make sense for some reason feel free to close this pull request. Just noticed this and thought explicitly depending on a very old RN version looked wrong.
