### PR TITLE
Update broken 'install RN with cocoapods' link

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ And that's it! Isn't RNPM awesome? :)
 
 2. Run `pod install`
 
-*NOTE: The CodePush `.podspec` depends on the `React` pod, and so in order to ensure that it can correctly use the version of React Native that your app is built with, please make sure to define the `React` dependency in your app's `Podfile` as explained [here](http://facebook.github.io/react-native/docs/embedded-app-ios.html#install-react-native-using-cocoapods).*
+*NOTE: The CodePush `.podspec` depends on the `React` pod, and so in order to ensure that it can correctly use the version of React Native that your app is built with, please make sure to define the `React` dependency in your app's `Podfile` as explained [here](https://facebook.github.io/react-native/docs/integration-with-existing-apps.html#podfile).*
 
 #### Plugin Installation (iOS - Manual)
 


### PR DESCRIPTION
Small docs PR, just updates the link to the React Native documentation page of instructions on specifying React as a pod, since the current one now redirects to a different page.