### PR TITLE
Support React Native 0.37.0

### DIFF
--- a/Examples/CodePushDemoApp/.flowconfig
+++ b/Examples/CodePushDemoApp/.flowconfig
@@ -48,11 +48,11 @@ suppress_type=$FlowIssue
 suppress_type=$FlowFixMe
 suppress_type=$FixMe
 
-suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(3[0-2]\\|[1-2][0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)
-suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(3[0-2]\\|1[0-9]\\|[1-2][0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)?:? #[0-9]+
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(3[0-3]\\|[1-2][0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)
+suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(3[0-3]\\|1[0-9]\\|[1-2][0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)?:? #[0-9]+
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 
 unsafe.enable_getters_and_setters=true
 
 [version]
-^0.32.0
+^0.33.0

--- a/Examples/CodePushDemoApp/android/app/build.gradle
+++ b/Examples/CodePushDemoApp/android/app/build.gradle
@@ -136,6 +136,6 @@ dependencies {
 // Run this once to be able to run the application with BUCK
 // puts all compile dependencies into folder libs for BUCK to use
 task copyDownloadableDepsToLibs(type: Copy) {
-  from configurations.compile
-  into 'libs'
+    from configurations.compile
+    into 'libs'
 }

--- a/Examples/CodePushDemoApp/iOS/CodePushDemoApp/Info.plist
+++ b/Examples/CodePushDemoApp/iOS/CodePushDemoApp/Info.plist
@@ -45,7 +45,7 @@
 		<dict>
 			<key>localhost</key>
 			<dict>
-				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
 			</dict>
 		</dict>

--- a/Examples/CodePushDemoApp/package.json
+++ b/Examples/CodePushDemoApp/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "babel-preset-react-native-stage-0": "1.0.1",
     "react": "15.3.1",
-    "react-native": "0.35.0",
+    "react-native": "0.37.0",
     "react-native-code-push": "file:../../"
   }
 }

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -451,17 +451,13 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
 
                             @Override
                             public void onHostResume() {
-                                if (installMode == CodePushInstallMode.IMMEDIATE.getValue()) {
-                                    loadBundle();
-                                } else {
-                                    // Determine how long the app was in the background and ensure
-                                    // that it meets the minimum duration amount of time.
-                                    long durationInBackground = 0;
-                                    if (lastPausedDate != null) {
-                                        durationInBackground = (new Date().getTime() - lastPausedDate.getTime()) / 1000;
-                                    }
-
-                                    if (durationInBackground >= CodePushNativeModule.this.mMinimumBackgroundDuration) {
+                                // As of RN 36, the resume handler fires immediately if the app is in
+                                // the foreground, so explicitly wait for it to be backgrounded first
+                                if (lastPausedDate != null) {
+                                    long durationInBackground = (new Date().getTime() - lastPausedDate.getTime()) / 1000;
+                                    if (installMode == CodePushInstallMode.IMMEDIATE.getValue()
+                                            || durationInBackground >= CodePushNativeModule.this.mMinimumBackgroundDuration) {
+                                        CodePushUtils.log("Loading bundle on resume");
                                         loadBundle();
                                     }
                                 }


### PR DESCRIPTION
As identified in #582, with RN 36 and 37, CodePush will crash on Android when the app is restarted using the `InstallMode.IMMEDIATE` and `InstallMode.ON_NEXT_RESUME` modes. The regression seems to originate from [this change](https://github.com/facebook/react-native/blob/797ca6c219b2a44f88f10c61d91e8cc21e2f306e/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java#L156), where React's `LifeCycleEventListener` will now trigger `onAppResume()` immediately if it is added while the app is in the foreground. As our code depends on this being triggered only in the act of the app being resumed from the background, `loadBundle()` will be called twice, causing issues.

The solution here is to modify our resume handler to only perform the action if the app is backgrounded AND THEN resumed. There is a limitation here - in the rare cases when the app is in the background when the listener is added, then it will need to be resumed twice to achieve the desired effect. It is unclear to me how to work around this - we could try to use the `RESUMED` and `BEFORE_RESUME` enum values provided by React Native, but then we'd lose compatibility with earlier RN versions. It's also strange that `onHostPause()` is not also triggered immediately when added if the app is in the background, but that would have also solved this problem.