### PR TITLE
Fix occasionally break in oldJsCodeLocationAssignmentStatement

### DIFF
--- a/scripts/postlink/ios/postlink.js
+++ b/scripts/postlink/ios/postlink.js
@@ -31,7 +31,7 @@ if (~appDelegateContents.indexOf(codePushHeaderImportStatement)) {
 }
 
 // 2. Modify jsCodeLocation value assignment
-var oldJsCodeLocationAssignmentStatement = appDelegateContents.match(/(jsCodeLocation = .*)\n/)[1];
+var oldJsCodeLocationAssignmentStatement = appDelegateContents.match(/(jsCodeLocation = .*)/)[1];
 var newJsCodeLocationAssignmentStatement = "jsCodeLocation = [CodePush bundleURL];";
 if (~appDelegateContents.indexOf(newJsCodeLocationAssignmentStatement)) {
     console.log(`"jsCodeLocation" already pointing to "[CodePush bundleURL]".`);


### PR DESCRIPTION
Fix issue #530.
Every so often you run the command `react-native link` an exception is thrown because the `\n` in regex does not lead to the line.