### PR TITLE
Update README for iOS Manual plugin installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ And that's it! Isn't RNPM awesome? :)
 6. Under the "Build Settings" tab of your project configuration, find the "Header Search Paths" section and edit the value.
 Add a new value, `$(SRCROOT)/../node_modules/react-native-code-push/ios` and select "recursive" in the dropdown.
 
-    ![Add CodePush library reference](https://cloud.githubusercontent.com/assets/516559/10322038/b8157962-6c30-11e5-9264-494d65fd2626.png)
+    ![Add CodePush library reference](https://cloud.githubusercontent.com/assets/78585/20584750/bd58fd80-b230-11e6-9955-e624f12e500b.png)
 
 ### Plugin Configuration (iOS)
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ And that's it! Isn't RNPM awesome? :)
     *Note: Alternatively, if you prefer, you can add the `-lz` flag to the `Other Linker Flags` field in the `Linking` section of the `Build Settings`.*
 
 6. Under the "Build Settings" tab of your project configuration, find the "Header Search Paths" section and edit the value.
-Add a new value, `$(SRCROOT)/../node_modules/react-native-code-push` and select "recursive" in the dropdown.
+Add a new value, `$(SRCROOT)/../node_modules/react-native-code-push/ios` and select "recursive" in the dropdown.
 
     ![Add CodePush library reference](https://cloud.githubusercontent.com/assets/516559/10322038/b8157962-6c30-11e5-9264-494d65fd2626.png)
 


### PR DESCRIPTION
Wrong/incomplete path to Codepush iOS library set in the `Header Search Paths` causes Xcode to fail without specifying any errors.

The path to the library should be changed from 

```
$(SRCROOT)/../node_modules/react-native-code-push

to

$(SRCROOT)/../node_modules/react-native-code-push/ios
```

<img width="817" alt="screen shot 2016-11-24 at 10 26 36 am" src="https://cloud.githubusercontent.com/assets/78585/20584750/bd58fd80-b230-11e6-9955-e624f12e500b.png">

Small detail but might cause a developer significant amount of time trying to pin down the cause of the build failure, especially when Xcode does not return any useful error.

The Xcode log when the header search path is wrong:

```
# Exit Status 65
Verify final result code for completed build operation

Build operation failed without specifying any errors. Individual build tasks may have failed for unknown reasons.
One possible cause is if there are too many (possibly zombie) processes; in this case, rebooting may fix the problem.
Some individual build task failures (up to 12) may be listed below.

```

<img width="874" alt="screen shot 2016-11-24 at 10 12 01 am" src="https://cloud.githubusercontent.com/assets/78585/20584600/34032520-b22f-11e6-8f8f-a5dc8ad42e25.png">

Cheers!