### PR TITLE
Remove MoveIt! from example section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1383,7 +1383,6 @@ The React Native community has graciously created some awesome open source apps 
 * [Feline for Product Hunt](https://github.com/arjunkomath/Feline-for-Product-Hunt) - An Android client for Product Hunt.
 * [GeoEncoding](https://github.com/LynxITDigital/GeoEncoding) - An app by [Lynx IT Digital](https://digital.lynxit.com.au) which demonstrates how to use numerous React Native components and modules.
 * [Math Facts](https://github.com/Khan/math-facts) - An app by Khan Academy to help memorize math facts more easily.
-* [MoveIt!](https://github.com/multunus/moveit-react-native) - An app by [Multunus](http://www.multunus.com) that allows employees within a company to track their work-outs.
 
 Additionally, if you're looking to get started with React Native + CodePush, and are looking for an awesome starter kit, you should check out the following:
 


### PR DESCRIPTION
Remove Movelt! bacause it is 404 and not maintained anymore according to https://github.com/multunus/moveit-mobile.