### PR TITLE
Fix RCTEventEmitter import for use in Swift Cocoapods projects

### DIFF
--- a/ios/CodePush/CodePush.h
+++ b/ios/CodePush/CodePush.h
@@ -1,4 +1,9 @@
+#if __has_include("RCTEventEmitter.h")
 #import "RCTEventEmitter.h"
+#else
+#import "React/RCTEventEmitter.h"   // Required when used as a Pod in a Swift project
+#endif
+
 #import <Foundation/Foundation.h>
 
 @interface CodePush : RCTEventEmitter


### PR DESCRIPTION
This should fix #583.