### PR TITLE
Update header paths to compile with RN@0.40

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,12 @@ And that's it! Isn't RNPM awesome? :)
     *Note: Alternatively, if you prefer, you can add the `-lz` flag to the `Other Linker Flags` field in the `Linking` section of the `Build Settings`.*
 
 6. Under the "Build Settings" tab of your project configuration, find the "Header Search Paths" section and edit the value.
-Add a new value, `$(SRCROOT)/../node_modules/react-native-code-push/ios` and select "recursive" in the dropdown.
+Add two new values:
+
+  - `$(SRCROOT)/../node_modules/react-native-code-push/ios`
+  - `"$(BUILT_PRODUCTS_DIR)/usr/local/include"`
+
+  and select "recursive" in the dropdowns.
 
     ![Add CodePush library reference](https://cloud.githubusercontent.com/assets/78585/20584750/bd58fd80-b230-11e6-9955-e624f12e500b.png)
 

--- a/ios/CodePush.xcodeproj/project.pbxproj
+++ b/ios/CodePush.xcodeproj/project.pbxproj
@@ -356,6 +356,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../react-native/React/**",
 					"$(SRCROOT)/../Examples/CodePushDemoApp/node_modules/react-native/React/**",
+					"$(BUILT_PRODUCTS_DIR)/usr/local/include"
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = (
@@ -375,6 +376,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../react-native/React/**",
 					"$(SRCROOT)/../Examples/CodePushDemoApp/node_modules/react-native/React/**",
+					"$(BUILT_PRODUCTS_DIR)/usr/local/include"
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = (


### PR DESCRIPTION
Since RN 0.40 headers are restructured and copied to product directory (see [facebook/react-native/e1577df)](https://github.com/facebook/react-native/commit/e1577df1fd70049ce7f288f91f6e2b18d512ff4d). To compile CodePush library which has a dependency on these headers, we need to add new location to headers search paths. Old paths still need to exist to keep compatibility w/ earlier RN versions