### PR TITLE
Improve post-linking process

### DIFF
--- a/scripts/postlink/android/postlink.js
+++ b/scripts/postlink/android/postlink.js
@@ -2,10 +2,31 @@ var fs = require("fs");
 var glob = require("glob");
 var path = require("path");
 
-var ignoreNodeModules = { ignore: "node_modules/**" };
-var mainApplicationPath = glob.sync("**/MainApplication.java", ignoreNodeModules)[0];
-var mainActivityPath = glob.sync("**/MainActivity.java", ignoreNodeModules)[0];
+var ignoreFolders = { ignore: ["node_modules/**", "**/build/**"] };
 var buildGradlePath = path.join("android", "app", "build.gradle");
+var manifestPath = glob.sync("**/AndroidManifest.xml", ignoreFolders)[0];
+
+function findMainApplication() {
+    if (!manifestPath) {
+        return null;
+    }
+
+    var manifest = fs.readFileSync(manifestPath, "utf8");
+
+    // Android manifest must include single 'application' element
+    var matchResult = manifest.match(/application\s+android:name\s*=\s*"(.*?)"/);
+    if (matchResult) {
+        var appName = matchResult[1];
+    } else {
+        return null;
+    }
+    
+    var nameParts = appName.split('.');
+    var searchPath = glob.sync("**/" + nameParts[nameParts.length - 1] + ".java", ignoreFolders)[0];
+    return searchPath;
+}
+
+var mainApplicationPath = findMainApplication() || glob.sync("**/MainApplication.java", ignoreFolders)[0];
 
 // 1. Add the getJSBundleFile override
 var getJSBundleFileOverride = `
@@ -30,20 +51,34 @@ if (mainApplicationPath) {
         fs.writeFileSync(mainApplicationPath, mainApplicationContents);
     }
 } else {
-    var mainActivityContents = fs.readFileSync(mainActivityPath, "utf8");
-    if (isAlreadyOverridden(mainActivityContents)) {
-        console.log(`"getJSBundleFile" is already overridden`);
+    var mainActivityPath = glob.sync("**/MainActivity.java", ignoreFolders)[0];
+    if (mainActivityPath) {
+        var mainActivityContents = fs.readFileSync(mainActivityPath, "utf8");
+        if (isAlreadyOverridden(mainActivityContents)) {
+            console.log(`"getJSBundleFile" is already overridden`);
+        } else {
+            var mainActivityClassDeclaration = "public class MainActivity extends ReactActivity {";
+            mainActivityContents = mainActivityContents.replace(mainActivityClassDeclaration,
+                `${mainActivityClassDeclaration}\n${getJSBundleFileOverride}`);
+            fs.writeFileSync(mainActivityPath, mainActivityContents);
+        }
     } else {
-        var mainActivityClassDeclaration = "public class MainActivity extends ReactActivity {";
-        mainActivityContents = mainActivityContents.replace(mainActivityClassDeclaration,
-            `${mainActivityClassDeclaration}\n${getJSBundleFileOverride}`);
-        fs.writeFileSync(mainActivityPath, mainActivityContents);
+        console.error(`Couldn't find Android application entry point. You might need to update it manually. \
+Please refer to plugin configuration section for Android at \
+https://github.com/microsoft/react-native-code-push#plugin-configuration-android for more details`);
     }
+}
+
+if (!fs.existsSync(buildGradlePath)) {
+    console.error(`Couldn't find build.gradle file. You might need to update it manually. \
+Please refer to plugin installation section for Android at \
+https://github.com/microsoft/react-native-code-push#plugin-installation-android---manual`);
+    return;
 }
 
 // 2. Add the codepush.gradle build task definitions
 var buildGradleContents = fs.readFileSync(buildGradlePath, "utf8");
-var reactGradleLink = buildGradleContents.match(/\napply from: ".*?react\.gradle"/)[0];
+var reactGradleLink = buildGradleContents.match(/\napply from: ["'].*?react\.gradle["']/)[0];
 var codePushGradleLink = `apply from: "../../node_modules/react-native-code-push/android/codepush.gradle"`;
 if (~buildGradleContents.indexOf(codePushGradleLink)) {
     console.log(`"codepush.gradle" is already linked in the build definition`);


### PR DESCRIPTION
This PR suggests the following improvements:
1) Fixed crash when any platform is missing (https://github.com/Microsoft/react-native-code-push/issues/598)
2) [android] Mitigated regex expression for importing react.gradle file (https://github.com/Microsoft/react-native-code-push/issues/598)
3) [android] First, searched main application file name in AndroidManifest.xml rather than used default `MainApplication.java`.
4) [ios] Info.plist file should be located in the root of project whereas AppDelegate file anywhere (https://github.com/Microsoft/react-native-code-push/issues/534)
5) [ios] Added supporting for files with `.mm` extension (https://github.com/Microsoft/react-native-code-push/issues/534)