### PR TITLE
codepush.gradle: add support for Android Plugin for Gradle with version lower than 1.3.0

### DIFF
--- a/android/codepush.gradle
+++ b/android/codepush.gradle
@@ -40,6 +40,14 @@ gradle.projectsEvaluated {
             def resourcesDirConfigName = "jsBundleDir${targetName}"
             def resourcesDir = elvisFile(config."${resourcesDirConfigName}") ?:
                     file("$buildDir/intermediates/res/merged/${targetPath}")
+
+            // In case version of 'Android Plugin for Gradle'' is lower than 1.3.0 
+            // '$buildDir' has slightly different structure - 'merged' folder
+            // does not exists so '${targetPath}' folder contains directly in 'res' folder.
+            if (!resourcesDir.exists() && file("$buildDir/intermediates/res/${targetPath}").exists()) {
+                resourcesDir = file("$buildDir/intermediates/res/${targetPath}")
+            }
+            
             def jsBundleFile = file("$jsBundleDir/$bundleAssetName")
 
             // Make this task run right before the bundle task

--- a/scripts/recordFilesBeforeBundleCommand.js
+++ b/scripts/recordFilesBeforeBundleCommand.js
@@ -16,7 +16,15 @@ var TEMP_FILE_PATH = path.join(require("os").tmpdir(), "CodePushResourcesMap.jso
 var resourcesDir = process.argv[2];
 var resourceFiles = [];
 
-getFilesInFolder(resourcesDir, resourceFiles);
+try {
+    getFilesInFolder(resourcesDir, resourceFiles);
+} catch(error) {
+    var targetPathNotFoundExceptionMessage = "\nResources directory path does not exist.\n";
+    targetPathNotFoundExceptionMessage += "Unable to find '" + resourcesDir;
+    targetPathNotFoundExceptionMessage += "' directory. Please check version of Android Plugin for Gradle.";
+    error.message += targetPathNotFoundExceptionMessage;
+    throw error;
+}
 
 var fileToModifiedTimeMap = {};
 


### PR DESCRIPTION
In case version of `Android Plugin for Gradle` is lower than 1.3.0
`$buildDir` has slightly different structure - `merged` folder
does not exists so `${targetPath}` folder contains directly in `res` folder.

Fix issue https://github.com/Microsoft/react-native-code-push/issues/584