### PR TITLE
Exclude build artifacts and Android Studio bits from final package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -36,3 +36,10 @@ test/
 
 # Remove after this framework is published on NPM
 code-push-plugin-testing-framework/
+
+# Android build artifacts and Android Studio bits
+android/app/build
+android/local.properties
+android/.gradle
+android/**/*.iml
+android/.idea


### PR DESCRIPTION
As suggested in #519, adding android build files and some additional files to `.npmignore` - this decreases size of final package to ~233 Kb (was ~26 Mb)