### PR TITLE
Get correct apk built time

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,9 +294,11 @@ public class MainApplication extends Application implements ReactApplication {
         ...
         // 2. Override the getJSBundleFile method in order to let
         // the CodePush runtime determine where to get the JS
-        // bundle location from on each app start
+        // bundle location from on each app start. Set manually apk built time
+        // since gradle zeroes built timestamps
         @Override
         protected String getJSBundleFile() {
+            CodePush.setBuildTimestamp(BuildConfig.CODE_PUSH_APK_BUILD_TIME);
             return CodePush.getJSBundleFile();
         }
 
@@ -327,9 +329,11 @@ import com.microsoft.codepush.react.CodePush;
 public class MainActivity extends ReactActivity {
     // 2. Override the getJSBundleFile method in order to let
     // the CodePush runtime determine where to get the JS
-    // bundle location from on each app start
+    // bundle location from on each app start. Set manually apk built time
+    // since gradle zeroes built timestamps
     @Override
     protected String getJSBundleFile() {
+        CodePush.setBuildTimestamp(BuildConfig.CODE_PUSH_APK_BUILD_TIME);
         return CodePush.getJSBundleFile();
     }
 

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -32,6 +32,7 @@ public class CodePush implements ReactPackage {
     private boolean mDidUpdate = false;
 
     private String mAssetsBundleFileName;
+    private static long mBuildTimestamp;
 
     // Helper classes.
     private CodePushUpdateManager mUpdateManager;
@@ -103,7 +104,15 @@ public class CodePush implements ReactPackage {
         return mAssetsBundleFileName;
     }
 
+    public static void setBuildTimestamp(long timestamp) {
+        mBuildTimestamp = timestamp;
+    }
+
     long getBinaryResourcesModifiedTime() {
+        if (mBuildTimestamp != 0) {
+            return mBuildTimestamp;
+        }
+ 
         ZipFile applicationFile = null;
         try {
             ApplicationInfo ai = this.mContext.getPackageManager().getApplicationInfo(this.mContext.getPackageName(), 0);

--- a/android/codepush.gradle
+++ b/android/codepush.gradle
@@ -16,6 +16,9 @@ void runBefore(String dependentTaskName, Task task) {
 
 gradle.projectsEvaluated {
     def buildTypes = android.buildTypes.collect { type -> type.name }
+    android.buildTypes.each {
+        it.buildConfigField 'long', 'CODE_PUSH_APK_BUILD_TIME', System.currentTimeMillis() + "L"
+    }
     def productFlavors = android.productFlavors.collect { flavor -> flavor.name }
     if (!productFlavors) productFlavors.add('')
     def nodeModulesPath;

--- a/scripts/postlink/android/postlink.js
+++ b/scripts/postlink/android/postlink.js
@@ -11,6 +11,7 @@ var buildGradlePath = path.join("android", "app", "build.gradle");
 var getJSBundleFileOverride = `
     @Override
     protected String getJSBundleFile() {
+      CodePush.setBuildTimestamp(BuildConfig.CODE_PUSH_APK_BUILD_TIME);
       return CodePush.getJSBundleFile();
     }
 `;


### PR DESCRIPTION
We should use `buildConfigField` to get correct apk build time since gradle zeroes out built timestamp(https://github.com/Microsoft/react-native-code-push/issues/650)