### PR TITLE
[iOS][Build] Add `Headers` and `Copy Files` build phases

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,6 @@ And that's it! Isn't RNPM awesome? :)
 
     *Note: Alternatively, if you prefer, you can add the `-lz` flag to the `Other Linker Flags` field in the `Linking` section of the `Build Settings`.*
 
-6. Under the "Build Settings" tab of your project configuration, find the "Header Search Paths" section and edit the value.
-Add a new value, `$(SRCROOT)/../node_modules/react-native-code-push/ios` and select "recursive" in the dropdown.
-
-    ![Add CodePush library reference](https://cloud.githubusercontent.com/assets/78585/20584750/bd58fd80-b230-11e6-9955-e624f12e500b.png)
 
 ### Plugin Configuration (iOS)
 
@@ -176,7 +172,7 @@ Once your Xcode project has been setup to build/link the CodePush plugin, you ne
 1. Open up the `AppDelegate.m` file, and add an import statement for the CodePush headers:
 
     ```objective-c
-    #import "CodePush.h"
+    #import <CodePush/CodePush.h>
     ```
 
 2. Find the following line of code, which loads your JS Bundle from the app binary for production releases:

--- a/ios/CodePush.xcodeproj/project.pbxproj
+++ b/ios/CodePush.xcodeproj/project.pbxproj
@@ -31,15 +31,18 @@
 		54FFEDE01BF550630061DD23 /* CodePushDownloadHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 54FFEDDF1BF550630061DD23 /* CodePushDownloadHandler.m */; };
 		810D4E6D1B96935000B397E9 /* CodePushPackage.m in Sources */ = {isa = PBXBuildFile; fileRef = 810D4E6C1B96935000B397E9 /* CodePushPackage.m */; };
 		81D51F3A1B6181C2000DA084 /* CodePushConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 81D51F391B6181C2000DA084 /* CodePushConfig.m */; };
+		8482F84C1E24C58300F793DB /* CodePush.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 13BE3DEC1AC21097009241FE /* CodePush.h */; };
+		8482F84E1E24C66300F793DB /* CodePush.h in Headers */ = {isa = PBXBuildFile; fileRef = 13BE3DEC1AC21097009241FE /* CodePush.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		58B511D91A9E6C8500147676 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
-			dstPath = "include/$(PRODUCT_NAME)";
+			dstPath = include/CodePush;
 			dstSubfolderSpec = 16;
 			files = (
+				8482F84C1E24C58300F793DB /* CodePush.h in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -190,6 +193,17 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		8482F84D1E24C65E00F793DB /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8482F84E1E24C66300F793DB /* CodePush.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
 		58B511DA1A9E6C8500147676 /* CodePush */ = {
 			isa = PBXNativeTarget;
@@ -198,6 +212,7 @@
 				58B511D71A9E6C8500147676 /* Sources */,
 				58B511D81A9E6C8500147676 /* Frameworks */,
 				58B511D91A9E6C8500147676 /* CopyFiles */,
+				8482F84D1E24C65E00F793DB /* Headers */,
 			);
 			buildRules = (
 			);

--- a/scripts/postlink/ios/postlink.js
+++ b/scripts/postlink/ios/postlink.js
@@ -21,7 +21,7 @@ var appDelegateContents = fs.readFileSync(appDelegatePath, "utf8");
 var plistContents = fs.readFileSync(plistPath, "utf8");
 
 // 1. Add the header import statement
-var codePushHeaderImportStatement = `#import "CodePush.h"`;
+var codePushHeaderImportStatement = `#import <CodePush/CodePush.h>`;
 if (~appDelegateContents.indexOf(codePushHeaderImportStatement)) {
     console.log(`"CodePush.h" header already imported.`);
 } else {


### PR DESCRIPTION
Due to changes in new release of `react-native@0.40.0` there is `CodePush.h file not found` error occures.
To fix it I've added `CodePush.h` header file in `Headers` build phase and changed
`codePushHeaderImportStatement` variable value from `#import "CodePush.h"`
to `#import <CodePush/CodePush.h>` in `postlink.js` file.
Fix https://github.com/Microsoft/react-native-code-push/issues/662