### PR TITLE
Improved logic for searching plist file path for iOS postlink.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "code-push": "1.8.0-beta",
     "glob": "^5.0.15",
     "inquirer": "1.1.2",
-    "plist": "1.2.0"
+    "plist": "1.2.0",
+    "xcode": "0.9.1"
   },
   "devDependencies": {
     "archiver": "latest",

--- a/scripts/postlink/ios/postlink.js
+++ b/scripts/postlink/ios/postlink.js
@@ -110,7 +110,7 @@ function getDefaultPlistPath() {
 // So we suppose that proj name should be the same as package name, otherwise fallback to default plist path searching logic
 function getBuildSettingsPropertyMatchingTargetProductName(parsedXCodeProj, prop, targetProductName, build){
     var target;
-    var COMMENT_KEY = /_comment$/
+    var COMMENT_KEY = /_comment$/;
     var PRODUCT_NAME_PROJECT_KEY = 'PRODUCT_NAME';
 
     if (!targetProductName){
@@ -156,9 +156,14 @@ function getPlistPath(){
     }
 
     var INFO_PLIST_PROJECT_KEY = 'INFOPLIST_FILE';
+    var RELEASE_BUILD_PROPERTY_NAME = "Release";
     var targetProductName = package ? package.name : null;
 
-    var plistPathValue = getBuildSettingsPropertyMatchingTargetProductName(parsedXCodeProj, INFO_PLIST_PROJECT_KEY, targetProductName);
+    //Try to get 'Release' build of ProductName matching the package name first and if it doesn't exist then try to get any other if existing
+    var plistPathValue = getBuildSettingsPropertyMatchingTargetProductName(parsedXCodeProj, INFO_PLIST_PROJECT_KEY, targetProductName, RELEASE_BUILD_PROPERTY_NAME) || 
+        getBuildSettingsPropertyMatchingTargetProductName(parsedXCodeProj, INFO_PLIST_PROJECT_KEY, targetProductName) ||
+         parsedXCodeProj.getBuildProperty(INFO_PLIST_PROJECT_KEY, RELEASE_BUILD_PROPERTY_NAME) || 
+         parsedXCodeProj.getBuildProperty(INFO_PLIST_PROJECT_KEY);
 
     if (!plistPathValue){
         return getDefaultPlistPath();


### PR DESCRIPTION
Added Xcode package for parsing xcodeproj file and retrieving correct plist file related to the project. This should also fix issue described here: https://github.com/Microsoft/react-native-code-push/issues/661