### PR TITLE
CodePush: changed implementation of `getBinaryResourcesModifiedTime` …

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -104,22 +104,13 @@ public class CodePush implements ReactPackage {
     }
 
     long getBinaryResourcesModifiedTime() {
-        ZipFile applicationFile = null;
         try {
-            ApplicationInfo ai = this.mContext.getPackageManager().getApplicationInfo(this.mContext.getPackageName(), 0);
-            applicationFile = new ZipFile(ai.sourceDir);
-            ZipEntry classesDexEntry = applicationFile.getEntry(CodePushConstants.RESOURCES_BUNDLE);
-            return classesDexEntry.getTime();
-        } catch (PackageManager.NameNotFoundException | IOException e) {
-            throw new CodePushUnknownException("Error in getting file information about compiled resources", e);
-        } finally {
-            if (applicationFile != null) {
-                try {
-                    applicationFile.close();
-                } catch (IOException e) {
-                    throw new CodePushUnknownException("Error in closing application file.", e);
-                }
-            }
+            String packageName = this.mContext.getPackageName();
+            int codePushApkBuildTimeId = this.mContext.getResources().getIdentifier(CodePushConstants.CODE_PUSH_APK_BUILD_TIME_KEY, "string", packageName);
+            String codePushApkBuildTime = this.mContext.getResources().getString(codePushApkBuildTimeId);
+            return Long.parseLong(codePushApkBuildTime);
+        } catch (Exception e)  {
+            throw new CodePushUnknownException("Error in getting binary resources modified time", e);
         }
     }
 

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushConstants.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushConstants.java
@@ -25,4 +25,5 @@ public class CodePushConstants {
     public static final String RESOURCES_BUNDLE = "resources.arsc";
     public static final String STATUS_FILE = "codepush.json";
     public static final String UNZIPPED_FOLDER_NAME = "unzipped";
+    public static final String CODE_PUSH_APK_BUILD_TIME_KEY = "CODE_PUSH_APK_BUILD_TIME";
 }

--- a/android/codepush.gradle
+++ b/android/codepush.gradle
@@ -16,6 +16,9 @@ void runBefore(String dependentTaskName, Task task) {
 
 gradle.projectsEvaluated {
     def buildTypes = android.buildTypes.collect { type -> type.name }
+    android.buildTypes.each {
+        it.resValue 'string', "CODE_PUSH_APK_BUILD_TIME", Long.toString(System.currentTimeMillis())
+    }
     def productFlavors = android.productFlavors.collect { flavor -> flavor.name }
     if (!productFlavors) productFlavors.add('')
     def nodeModulesPath;


### PR DESCRIPTION
…method

Due to “the last modified date on all files in an apk now have the time stamp of 'Fri, Nov 30 1979 00:00:00'”
(https://code.google.com/p/android/issues/detail?id=220039) we have to store apk build time value in
`app/src/main/res/values/strings.xml` file and use it further in `getBinaryResourcesModifiedTime` method

Fix https://github.com/Microsoft/react-native-code-push/issues/650