### PR TITLE
codePushNativeModule: launch async tasks in parallel

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -290,7 +290,7 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
             }
         };
 
-        asyncTask.execute();
+        asyncTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 
     @ReactMethod
@@ -364,7 +364,7 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
             }
         };
 
-        asyncTask.execute();
+        asyncTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 
     @ReactMethod
@@ -416,7 +416,7 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
             }
         };
 
-        asyncTask.execute();
+        asyncTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 
     @ReactMethod
@@ -485,7 +485,7 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
             }
         };
 
-        asyncTask.execute();
+        asyncTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 
     @ReactMethod


### PR DESCRIPTION
`AsyncTasks` are executed on a single thread to avoid common application errors caused by parallel execution.
So to make it possible to use tools like AsyncStorage while CodePush downloading an update we should use
`asyncTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);` code instead of `asyncTask.execute();`

Fix https://github.com/Microsoft/react-native-code-push/issues/574