### PR TITLE
Update Android SDK to version 25

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: "com.android.library"
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
The app Gradle file currently references Android SDK 23 which is two version old. The latest SDK version is 25.

This fixes #724.
