### PR TITLE
podspec: remove leading 'v' letter from version string

### DIFF
--- a/CodePush.podspec
+++ b/CodePush.podspec
@@ -5,7 +5,7 @@ package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 Pod::Spec.new do |s|
 
   s.name           = 'CodePush'
-  s.version        = package['version'].sub('-beta', '')
+  s.version        = package['version'].gsub(/v|-beta/, '')
   s.summary        = package['description']
   s.author         = package['author']
   s.license        = package['license']


### PR DESCRIPTION
[`v1.2.3` is not a semantic version](https://github.com/mojombo/semver/blob/master/semver.md#is-v123-a-semantic-version). However, prefixing a semantic version with a "v" is a common way (in English) to indicate it is a version number. Abbreviating "version" as "v" is often seen with version control.

Relate https://github.com/Microsoft/react-native-code-push/issues/727#issuecomment-283333318