### PR TITLE
Verify code-push service with RN 0.42

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ We try our best to maintain backwards compatability of our plugin with previous 
 | v0.31-v0.33             | v1.14.6+ *(RN refactored native hosting code)* |
 | v0.34-v0.35             | v1.15.0+ *(RN refactored native hosting code)* |
 | v0.36-v0.39             | v1.16.0+ *(RN refactored resume handler)*      |
-| v0.40-v0.41             | v1.17.0+ *(RN refactored iOS header files)*    |
-| v0.42+                  | TBD :) We work hard to respond to new RN releases, but they do occasionally break us. We will update this chart with each RN release, so that users can check to see what our "official" support is.
+| v0.40-v0.42             | v1.17.0+ *(RN refactored iOS header files)*    |
+| v0.43+                  | TBD :) We work hard to respond to new RN releases, but they do occasionally break us. We will update this chart with each RN release, so that users can check to see what our "official" support is.
 
 ### Supported Components
 


### PR DESCRIPTION
Code push service runs well with RN 0.42

Relate https://github.com/Microsoft/react-native-code-push/issues/744