### PR TITLE
build.gradle: set Android SDK Build Tools version to 23.0.1

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: "com.android.library"
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
`react-native-code-push@1.17.1-beta` release introduces Android SDK Build Tools inconsistency between React Native app and react-native-code-push Module.
It's convenient to have the same version of Android SDK Build Tools both for React Native app and react-native-code-push module, due to https://github.com/facebook/react-native/pull/11422#issuecomment-266814770

Relate https://github.com/Microsoft/react-native-code-push/issues/733