### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,8 @@ To set this up, perform the following steps:
         buildTypes {
             debug {
                 ...
-                // CodePush updates should not be tested in Debug mode
+                // CodePush updates should not be tested in Debug mode. Because CodePush checks for updates in all modes, we must supply a blank key. At runtime, when CodePush checks for updates it will fail and log errors, which can be ignored.
+                buildConfigField "String", "CODEPUSH_KEY", '""'
                 ...
             }
 

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ To set this up, perform the following steps:
         buildTypes {
             debug {
                 ...
-                // CodePush updates should not be tested in Debug mode. Because CodePush checks for updates in all modes, we must supply a blank key. At runtime, when CodePush checks for updates it will fail and log errors, which can be ignored.
+                // Note: CodePush updates should not be tested in Debug mode as they are overriden by the RN packager. However, because CodePush checks for updates in all modes, we must supply a key.
                 buildConfigField "String", "CODEPUSH_KEY", '""'
                 ...
             }


### PR DESCRIPTION
When I fail to supply a CODEPUSH_KEY variable for debug, the build fails. This pull fixes the example code. I also added a comment letting developers know to expect errors from CodePush in debug mode. (This behavior is surprising, but I believe is by design.)