### PR TITLE
Update package.json for 1.17.3-beta and add peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-code-push",
-  "version": "1.17.2-beta",
+  "version": "1.17.3-beta",
   "description": "React Native plugin for the CodePush service",
   "main": "CodePush.js",
   "typings": "typings/react-native-code-push.d.ts",
@@ -15,6 +15,9 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/Microsoft/react-native-code-push"
+  },
+  "peerDependencies": {
+    "react-native": "0.19 - 0.42"
   },
   "dependencies": {
     "code-push": "1.8.0-beta",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,6 @@
     "type": "git",
     "url": "https://github.com/Microsoft/react-native-code-push"
   },
-  "peerDependencies": {
-    "react-native": "0.19 - 0.42"
-  },
   "dependencies": {
     "code-push": "1.8.0-beta",
     "glob": "^5.0.15",


### PR DESCRIPTION
As we are about to publish a breaking change for RN 0.43, it might be good to start indicating our peerDependencies clearly so that users don't install mismatching RN and CodePush versions. Peer dependencies are documented here: https://nodejs.org/en/blog/npm/peer-dependencies/.

Note this range won't match `-rc` releases, but I think it should be okay in this case because all of the versions in this `peerDependencies` list have non-rc versions that people should be using.

@sergey-akhalkov, @max-mironov, what do you think?