### PR TITLE
flow type checking fix: use "CodePushHash" file name instead of "Code…

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushConstants.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushConstants.java
@@ -4,7 +4,8 @@ public class CodePushConstants {
     public static final String ASSETS_BUNDLE_PREFIX = "assets://";
     public static final String BINARY_MODIFIED_TIME_KEY = "binaryModifiedTime";
     public static final String CODE_PUSH_FOLDER_PREFIX = "CodePush";
-    public static final String CODE_PUSH_HASH_FILE_NAME = "CodePushHash.json";
+    public static final String CODE_PUSH_HASH_FILE_NAME = "CodePushHash";
+    public static final String CODE_PUSH_OLD_HASH_FILE_NAME = "CodePushHash.json";
     public static final String CODE_PUSH_PREFERENCES = "CodePush";
     public static final String CURRENT_PACKAGE_KEY = "currentPackage";
     public static final String DEFAULT_JS_BUNDLE_NAME = "index.android.bundle";

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateUtils.java
@@ -109,12 +109,15 @@ public class CodePushUpdateUtils {
         try {
             return CodePushUtils.getStringFromInputStream(context.getAssets().open(CodePushConstants.CODE_PUSH_HASH_FILE_NAME));
         } catch (IOException e) {
-            if (!isDebugMode) {
-                // Only print this message in "Release" mode. In "Debug", we may not have the
-                // hash if the build skips bundling the files.
-                CodePushUtils.log("Unable to get the hash of the binary's bundled resources - \"codepush.gradle\" may have not been added to the build definition.");
+            try {
+                return CodePushUtils.getStringFromInputStream(context.getAssets().open(CodePushConstants.CODE_PUSH_OLD_HASH_FILE_NAME));
+            } catch (IOException ex) {
+                if (!isDebugMode) {
+                    // Only print this message in "Release" mode. In "Debug", we may not have the
+                    // hash if the build skips bundling the files.
+                    CodePushUtils.log("Unable to get the hash of the binary's bundled resources - \"codepush.gradle\" may have not been added to the build definition.");
+                }
             }
-
             return null;
         }
     }

--- a/scripts/generateBundledResourcesHash.js
+++ b/scripts/generateBundledResourcesHash.js
@@ -18,7 +18,8 @@ var path = require("path");
 var getFilesInFolder = require("./getFilesInFolder");
 
 var CODE_PUSH_FOLDER_PREFIX = "CodePush";
-var CODE_PUSH_HASH_FILE_NAME = "CodePushHash.json";
+var CODE_PUSH_HASH_FILE_NAME = "CodePushHash";
+var CODE_PUSH_HASH_OLD_FILE_NAME = "CodePushHash.json";
 var HASH_ALGORITHM = "sha256";
 var TEMP_FILE_PATH = path.join(require("os").tmpdir(), "CodePushResourcesMap.json");
 
@@ -72,6 +73,15 @@ function addJsBundleAndMetaToManifest() {
 
             var savedResourcesManifestPath = assetsDir + "/" + CODE_PUSH_HASH_FILE_NAME;
             fs.writeFileSync(savedResourcesManifestPath, finalHash);
+
+            // "CodePushHash.json" file name breaks flow type checking.
+            // To fix the issue we need to delete "CodePushHash.json" file and
+            // use "CodePushHash" file name instead to store the hash value.
+            // Relates to https://github.com/Microsoft/react-native-code-push/issues/577
+            var oldSavedResourcesManifestPath = assetsDir + "/" + CODE_PUSH_HASH_OLD_FILE_NAME;
+            if (fs.existsSync(oldSavedResourcesManifestPath)) {
+                fs.unlinkSync(oldSavedResourcesManifestPath);
+            }
         });
     });
 }


### PR DESCRIPTION
…PushHash.json"

`CodePushHash.json` file name breaks flow type checking.
To fix the issue we need to delete `CodePushHash.json` file and
use `CodePushHash` file name instead to store the hash value.
Relates to https://github.com/Microsoft/react-native-code-push/issues/577