### PR TITLE
CodePush.js: fix syncStatus value mismatch

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -342,8 +342,14 @@ async function syncInternal(options = {}, syncStatusChangeCallback, downloadProg
           log("An update is available, but it is being ignored due to having been previously rolled back.");
       }
 
-      syncStatusChangeCallback(CodePush.SyncStatus.UP_TO_DATE);
-      return CodePush.SyncStatus.UP_TO_DATE;
+      const currentPackage = await CodePush.getCurrentPackage();
+      if (currentPackage.isPending) {
+        syncStatusChangeCallback(CodePush.SyncStatus.UPDATE_INSTALLED);
+        return CodePush.SyncStatus.UPDATE_INSTALLED;
+      } else {
+        syncStatusChangeCallback(CodePush.SyncStatus.UP_TO_DATE);
+        return CodePush.SyncStatus.UP_TO_DATE;
+      }
     } else if (syncOptions.updateDialog) {
       // updateDialog supports any truthy value (e.g. true, "goo", 12),
       // but we should treat a non-object value as just the default dialog


### PR DESCRIPTION
After `SyncStatus` correctly goes to `UPDATE_INSTALLED`, on the next app resume it transitions to `CHECKING_FOR_UPDATE` and then `UP_TO_DATE`, even though the update has not yet been installed. It should be equals to `UPDATE_INSTALLED` value again until next app restart.

Relates to https://github.com/Microsoft/react-native-code-push/issues/760