### PR TITLE
installModes: implement new ON_NEXT_SUSPEND install mode

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -492,7 +492,9 @@ if (NativeCodePush) {
       IMMEDIATE: NativeCodePush.codePushInstallModeImmediate, // Restart the app immediately
       ON_NEXT_RESTART: NativeCodePush.codePushInstallModeOnNextRestart, // Don't artificially restart the app. Allow the update to be "picked up" on the next app restart
       ON_NEXT_RESUME: NativeCodePush.codePushInstallModeOnNextResume, // Restart the app the next time it is resumed from the background
-      ON_NEXT_SUSPEND: NativeCodePush.codePushInstallModeOnNextSuspend
+      ON_NEXT_SUSPEND: NativeCodePush.codePushInstallModeOnNextSuspend // Restart the app _while_ it is in the background,
+      // but only after it has been in the background for "minimumBackgroundDuration" seconds (0 by default),
+      // so that user context isn't lost unless the app suspension is long enough to not matter
     },
     SyncStatus: {
       UP_TO_DATE: 0, // The running app is up-to-date

--- a/CodePush.js
+++ b/CodePush.js
@@ -491,7 +491,8 @@ if (NativeCodePush) {
     InstallMode: {
       IMMEDIATE: NativeCodePush.codePushInstallModeImmediate, // Restart the app immediately
       ON_NEXT_RESTART: NativeCodePush.codePushInstallModeOnNextRestart, // Don't artificially restart the app. Allow the update to be "picked up" on the next app restart
-      ON_NEXT_RESUME: NativeCodePush.codePushInstallModeOnNextResume // Restart the app the next time it is resumed from the background
+      ON_NEXT_RESUME: NativeCodePush.codePushInstallModeOnNextResume, // Restart the app the next time it is resumed from the background
+      ON_NEXT_SUSPEND: NativeCodePush.codePushInstallModeOnNextSuspend
     },
     SyncStatus: {
       UP_TO_DATE: 0, // The running app is up-to-date

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushInstallMode.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushInstallMode.java
@@ -3,7 +3,8 @@ package com.microsoft.codepush.react;
 public enum CodePushInstallMode {
     IMMEDIATE(0),
     ON_NEXT_RESTART(1),
-    ON_NEXT_RESUME(2);
+    ON_NEXT_RESUME(2),
+    ON_NEXT_SUSPEND(3);
 
     private final int value;
     CodePushInstallMode(int value) {

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -19,7 +19,8 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
-import com.facebook.react.uimanager.ReactChoreographer;
+import com.facebook.react.modules.core.ChoreographerCompat;
+import com.facebook.react.modules.core.ReactChoreographer;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -254,7 +255,7 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
                             getReactApplicationContext().runOnUiQueueThread(new Runnable() {
                                 @Override
                                 public void run() {
-                                    ReactChoreographer.getInstance().postFrameCallback(ReactChoreographer.CallbackType.TIMERS_EVENTS, new Choreographer.FrameCallback() {
+                                    ReactChoreographer.getInstance().postFrameCallback(ReactChoreographer.CallbackType.TIMERS_EVENTS, new ChoreographerCompat.FrameCallback() {
                                         @Override
                                         public void doFrame(long frameTimeNanos) {
                                             if (!latestDownloadProgress.isCompleted()) {

--- a/ios/CodePush/CodePush.h
+++ b/ios/CodePush/CodePush.h
@@ -187,7 +187,8 @@ void CPLog(NSString *formatString, ...);
 typedef NS_ENUM(NSInteger, CodePushInstallMode) {
     CodePushInstallModeImmediate,
     CodePushInstallModeOnNextRestart,
-    CodePushInstallModeOnNextResume
+    CodePushInstallModeOnNextResume,
+    CodePushInstallModeOnNextSuspend
 };
 
 typedef NS_ENUM(NSInteger, CodePushUpdateState) {

--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -24,6 +24,8 @@
     BOOL _isFirstRunAfterUpdate;
     int _minimumBackgroundDuration;
     NSDate *_lastResignedDate;
+    CodePushInstallMode *_installMode;
+    NSTimer *_appSuspendTimer;
 
     // Used to coordinate the dispatching of download progress events to JS.
     long long _latestExpectedContentLength;
@@ -292,6 +294,7 @@ static NSString *bundleResourceSubdirectory = nil;
              @"codePushInstallModeOnNextRestart":@(CodePushInstallModeOnNextRestart),
              @"codePushInstallModeImmediate": @(CodePushInstallModeImmediate),
              @"codePushInstallModeOnNextResume": @(CodePushInstallModeOnNextResume),
+             @"codePushInstallModeOnNextSuspend": @(CodePushInstallModeOnNextSuspend),
 
              @"codePushUpdateStateRunning": @(CodePushUpdateStateRunning),
              @"codePushUpdateStatePending": @(CodePushUpdateStatePending),
@@ -559,6 +562,10 @@ static NSString *bundleResourceSubdirectory = nil;
 // a resume-based update still pending installation.
 - (void)applicationWillEnterForeground
 {
+    if (_appSuspendTimer) {
+        [_appSuspendTimer invalidate];
+        _appSuspendTimer = nil;
+    }
     // Determine how long the app was in the background and ensure
     // that it meets the minimum duration amount of time.
     int durationInBackground = 0;
@@ -576,6 +583,18 @@ static NSString *bundleResourceSubdirectory = nil;
     // Save the current time so that when the app is later
     // resumed, we can detect how long it was in the background.
     _lastResignedDate = [NSDate date];
+    
+    if (_installMode == CodePushInstallModeOnNextSuspend && [[self class] isPendingUpdate:nil]) {
+        _appSuspendTimer = [NSTimer scheduledTimerWithTimeInterval:_minimumBackgroundDuration
+                                                         target:self
+                                                       selector:@selector(loadBundleOnTick:)
+                                                       userInfo:nil
+                                                        repeats:NO];
+    }
+}
+
+-(void)loadBundleOnTick:(NSTimer *)timer {
+    [self loadBundle];
 }
 
 #pragma mark - JavaScript-exported module methods (Public)
@@ -749,7 +768,8 @@ RCT_EXPORT_METHOD(installUpdate:(NSDictionary*)updatePackage
         [self savePendingUpdate:updatePackage[PackageHashKey]
                       isLoading:NO];
 
-        if (installMode == CodePushInstallModeOnNextResume) {
+        _installMode = installMode;
+        if (_installMode == CodePushInstallModeOnNextResume || _installMode == CodePushInstallModeOnNextSuspend) {
             _minimumBackgroundDuration = minimumBackgroundDuration;
 
             if (!_hasResumeListener) {

--- a/ios/CodePush/RCTConvert+CodePushInstallMode.m
+++ b/ios/CodePush/RCTConvert+CodePushInstallMode.m
@@ -12,7 +12,8 @@
 
 RCT_ENUM_CONVERTER(CodePushInstallMode, (@{ @"codePushInstallModeImmediate": @(CodePushInstallModeImmediate),
                                             @"codePushInstallModeOnNextRestart": @(CodePushInstallModeOnNextRestart),
-                                            @"codePushInstallModeOnNextResume": @(CodePushInstallModeOnNextResume) }),
+                                            @"codePushInstallModeOnNextResume": @(CodePushInstallModeOnNextResume),
+                                            @"codePushInstallModeOnNextSuspend": @(CodePushInstallModeOnNextSuspend) }),
                    CodePushInstallModeImmediate, // Default enum value
                    integerValue)
 


### PR DESCRIPTION
Restart the app _while_ it is in the background, but only after it has been in the background for `minimumBackgroundDuration` seconds (0 by default), so that user context isn't lost unless the app suspension is long enough to not matter.

Relates to https://github.com/Microsoft/react-native-code-push/issues/366