### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ And that's it! Now when you run or build your app, your staging builds will auto
 
 *Note: If you encounter the error message `ld: library not found for ...`, please consult [this issue](https://github.com/Microsoft/react-native-code-push/issues/426) for a possible solution.*
 
-Additionally, if you want to give them seperate names and/or icons, you can modify the `Product Name` and `Asset Catalog App Icon Set Name` build settings, which will allow your staging builds to be distinguishable from release builds when installed on the same device.
+Additionally, if you want to give them seperate names and/or icons, you can modify the `Product Bundle Identifier`, `Product Name` and `Asset Catalog App Icon Set Name` build settings, which will allow your staging builds to be distinguishable from release builds when installed on the same device.
 
 ### Dynamic Deployment Assignment
 


### PR DESCRIPTION
If you want to run multiple IOS builds on same device, you also have to change Product Bundle Identifier for builds. Otherwise builds are overwritten on device. It wasn't clear in README.md