### PR TITLE
Fix update always available bug for newly installed android apps

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -46,7 +46,7 @@ async function checkForUpdate(deploymentKey = null) {
     queryPackage = localPackage;
   } else {
     queryPackage = { appVersion: config.appVersion };
-    if (Platform.OS === "ios" && config.packageHash) {
+    if (config.packageHash) {
       queryPackage.packageHash = config.packageHash;
     }
   }


### PR DESCRIPTION
This pull request fixed:

1. For newly installed android apps, update check always return new bundle, even if the asset bundle is already the latest, since `packageHash` is not passed to `/updateCheck`.
2. A typo in `codepush.gradle`