### PR TITLE
WPF:WINDOWS Added ability to update application installed in Program Files folder

### DIFF
--- a/Examples/CodePushDemoApp/iOS/CodePushDemoApp/AppDelegate.m
+++ b/Examples/CodePushDemoApp/iOS/CodePushDemoApp/AppDelegate.m
@@ -20,7 +20,11 @@
   NSURL *jsCodeLocation;
 
   
-jsCodeLocation = [CodePush bundleURL];
+#ifdef DEBUG
+  jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios" fallbackResource:nil];
+#else
+  jsCodeLocation = [CodePush bundleURL];
+#endif
 
   RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
                                                       moduleName:@"CodePushDemoApp"

--- a/Examples/CodePushDemoApp/package.json
+++ b/Examples/CodePushDemoApp/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "react": "16.0.0-alpha.6",
     "react-native": "^0.43.2",
-    "react-native-code-push": "file:../../"
+    "react-native-code-push": "file:../../",
+    "react-native-windows": "^0.43.0-rc.0"
   },
   "devDependencies": {
     "babel-jest": "19.0.0",

--- a/Examples/CodePushDemoApp/windows/CodePushDemoApp.Wpf/App.config
+++ b/Examples/CodePushDemoApp/windows/CodePushDemoApp.Wpf/App.config
@@ -1,6 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reactive.Core" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/Examples/CodePushDemoApp/windows/CodePushDemoApp.Wpf/App.xaml.cs
+++ b/Examples/CodePushDemoApp/windows/CodePushDemoApp.Wpf/App.xaml.cs
@@ -1,9 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Navigation;

--- a/Examples/CodePushDemoApp/windows/CodePushDemoApp.Wpf/CodePushDemoApp.Wpf.csproj
+++ b/Examples/CodePushDemoApp/windows/CodePushDemoApp.Wpf/CodePushDemoApp.Wpf.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.ChakraCore.1.4.1-preview-00010-42060\build\netstandard1.0\Microsoft.ChakraCore.props" Condition="Exists('..\packages\Microsoft.ChakraCore.1.4.1-preview-00010-42060\build\netstandard1.0\Microsoft.ChakraCore.props')" />
+  <Import Project="..\packages\Microsoft.ChakraCore.1.4.1\build\netstandard1.0\Microsoft.ChakraCore.props" Condition="Exists('..\packages\Microsoft.ChakraCore.1.4.1\build\netstandard1.0\Microsoft.ChakraCore.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -102,7 +102,7 @@
   <ItemGroup>
     <Reference Include="Facebook.Yoga, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Facebook.Yoga.1.0.1-pre\lib\netstandard\Facebook.Yoga.dll</HintPath>
+      <HintPath>..\packages\Facebook.Yoga.1.2.0-pre1\lib\net45\Facebook.Yoga.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -170,10 +170,10 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.ChakraCore.1.4.1-preview-00010-42060\build\netstandard1.0\Microsoft.ChakraCore.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ChakraCore.1.4.1-preview-00010-42060\build\netstandard1.0\Microsoft.ChakraCore.props'))" />
-    <Error Condition="!Exists('..\packages\Facebook.Yoga.1.0.1-pre\build\netstandard\Facebook.Yoga.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Facebook.Yoga.1.0.1-pre\build\netstandard\Facebook.Yoga.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.ChakraCore.1.4.1\build\netstandard1.0\Microsoft.ChakraCore.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ChakraCore.1.4.1\build\netstandard1.0\Microsoft.ChakraCore.props'))" />
+    <Error Condition="!Exists('..\packages\Facebook.Yoga.1.2.0-pre1\build\net45\Facebook.Yoga.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Facebook.Yoga.1.2.0-pre1\build\net45\Facebook.Yoga.targets'))" />
   </Target>
-  <Import Project="..\packages\Facebook.Yoga.1.0.1-pre\build\netstandard\Facebook.Yoga.targets" Condition="Exists('..\packages\Facebook.Yoga.1.0.1-pre\build\netstandard\Facebook.Yoga.targets')" />
+  <Import Project="..\packages\Facebook.Yoga.1.2.0-pre1\build\net45\Facebook.Yoga.targets" Condition="Exists('..\packages\Facebook.Yoga.1.2.0-pre1\build\net45\Facebook.Yoga.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Examples/CodePushDemoApp/windows/CodePushDemoApp.Wpf/packages.config
+++ b/Examples/CodePushDemoApp/windows/CodePushDemoApp.Wpf/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Facebook.Yoga" version="1.0.1-pre" targetFramework="net46" />
-  <package id="Microsoft.ChakraCore" version="1.4.1-preview-00010-42060" targetFramework="net46" developmentDependency="true" />
+  <package id="Facebook.Yoga" version="1.2.0-pre1" targetFramework="net46" />
+  <package id="Microsoft.ChakraCore" version="1.4.1" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/Examples/CodePushDemoApp/windows/CodePushDemoApp/project.json
+++ b/Examples/CodePushDemoApp/windows/CodePushDemoApp/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Facebook.Yoga": "1.0.1-pre",
+    "Facebook.Yoga": "1.2.0-pre1",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2"
   },
   "frameworks": {

--- a/windows/CodePush.Net46/Adapters/Storage/ApplicationDataContainer.cs
+++ b/windows/CodePush.Net46/Adapters/Storage/ApplicationDataContainer.cs
@@ -42,7 +42,7 @@ namespace CodePush.Net46.Adapters.Storage
             }
         }
 
-        public bool Remove(TKey key)
+        public new bool Remove(TKey key)
         {
             var found = base.Remove(key);
             if (found)

--- a/windows/CodePush.Net46/CodePushUtils.cs
+++ b/windows/CodePush.Net46/CodePushUtils.cs
@@ -38,7 +38,7 @@ namespace CodePush.ReactNative
             // unique for the user.
             // - Program Files folder, in this case the application is unique for the system and will be shared
             // amoung all users of the system, the bundle should be unique for the system as well.
-            // Commonly, user has no write access to Program Files folder or at least admin privelegies have to been requiested.
+            // Commonly, user has no write access to Program Files folder or at least admin privileges have to been requested.
             // In this case the bundle will be stored in ProgramData folder as it is recommended by MS.
 
             if (!string.IsNullOrEmpty(_bundlePath))

--- a/windows/CodePush.Net46/CodePushUtils.cs
+++ b/windows/CodePush.Net46/CodePushUtils.cs
@@ -1,6 +1,8 @@
 ﻿using Newtonsoft.Json.Linq;
 using PCLStorage;
 using System;
+using System.Diagnostics;
+using System.IO;
 using System.Management;
 using System.Threading.Tasks;
 
@@ -8,6 +10,52 @@ namespace CodePush.ReactNative
 {
     internal partial class CodePushUtils
     {
+        class ApplicationInfo
+        {
+            public ApplicationInfo()
+            {
+                var info = FileVersionInfo.GetVersionInfo(Environment.GetCommandLineArgs()[0]);
+                Version = $"{info.FileMajorPart}.{info.FileMinorPart}.{info.FileBuildPart}";
+                CompanyName = string.IsNullOrEmpty(info.CompanyName) ? info.ProductName : info.CompanyName;
+                ProductName = info.ProductName;
+            }
+
+            public string Version { private set; get; }
+            public string CompanyName { private set; get; }
+            public string ProductName { private set; get; }
+        }
+
+        static ApplicationInfo applicationInfo = new ApplicationInfo();
+        static string _bundlePath;
+
+        internal static string GetFileBundlePrefix()
+        {
+            // For Windows desktop application the prefix of a bundle is the full path to the folder where
+            // bundle should be installed.
+            //
+            // Desktop application can be installed at any location, the most popular are:
+            // - User local data folder, in this case the bundle can be stored in the same location and be
+            // unique for the user.
+            // - Program Files folder, in this case the application is unique for the system and will be shared
+            // amoung all users of the system, the bundle should be unique for the system as well.
+            // Commonly, user has no write access to Program Files folder or at least admin privelegies have to been requiested.
+            // In this case the bundle will be stored in ProgramData folder as it is recommended by MS.
+
+            if (!string.IsNullOrEmpty(_bundlePath))
+            {
+                return _bundlePath;
+            }
+
+            _bundlePath = GetAppFolder();
+
+            if (!HasWriteAccessToFolder(_bundlePath))
+            {
+                _bundlePath = $"{Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), applicationInfo.CompanyName, applicationInfo.ProductName, applicationInfo.Version)}\\";
+            }
+
+            return _bundlePath;
+        }
+
         internal async static Task<JObject> GetJObjectFromFileAsync(IFile file)
         {
             string jsonString = await file.ReadAllTextAsync().ConfigureAwait(false);
@@ -92,6 +140,19 @@ namespace CodePush.ReactNative
             }
 
             return mac;
+        }
+
+        static bool HasWriteAccessToFolder(string path)
+        {
+            try
+            {
+                File.Open(Path.Combine(path, ".security-check"), FileMode.OpenOrCreate).Close();
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
         }
     }
 }

--- a/windows/CodePush.Net46/UpdateUtils.cs
+++ b/windows/CodePush.Net46/UpdateUtils.cs
@@ -63,7 +63,7 @@ namespace CodePush.ReactNative
 
         internal static async Task<IFolder> GetCodePushFolderAsync()
         {
-            var pathToCodePush = Path.Combine(CodePushUtils.GetAppFolder(), CodePushConstants.CodePushFolderPrefix);
+            var pathToCodePush = Path.Combine(CodePushUtils.GetFileBundlePrefix(), CodePushConstants.CodePushFolderPrefix);
             return await FileSystem.Current.LocalStorage.CreateFolderAsync(pathToCodePush, CreationCollisionOption.OpenIfExists).ConfigureAwait(false);
         }
     }

--- a/windows/CodePush.Shared/CodePushConstants.cs
+++ b/windows/CodePush.Shared/CodePushConstants.cs
@@ -27,7 +27,7 @@
         internal const string UnzippedFolderName = "unzipped";
 #if WINDOWS_UWP
         internal const string AssetsBundlePrefix = "ms-appx:///ReactAssets/";
-        internal const string FileBundlePrefix = "ms-appdata:///local";
+        internal const string FileBundlePrefix = "ms-appdata:///local/";
 #else
         internal const string AssetsBundlePrefix = "ReactAssets/";
 #endif

--- a/windows/CodePush.Shared/CodePushReactPackage.cs
+++ b/windows/CodePush.Shared/CodePushReactPackage.cs
@@ -105,7 +105,8 @@ namespace CodePush.ReactNative
             {
                 CodePushUtils.LogBundleUrl(packageFile.Path);
                 IsRunningBinaryVersion = false;
-                return CodePushUtils.GetFileBundlePrefix() + packageFile.Path.Replace(CodePushUtils.GetAppFolder(), "").Replace("\\", "/");
+
+                return CodePushUtils.GetFileBundlePrefix() + CodePushUtils.ExtractSubFolder(packageFile.Path);
             }
             else
             {

--- a/windows/CodePush.Shared/CodePushUtils.cs
+++ b/windows/CodePush.Shared/CodePushUtils.cs
@@ -38,8 +38,7 @@ namespace CodePush.ReactNative
 #if WINDOWS_UWP
             return Package.Current.Id.Version.Major + "." + Package.Current.Id.Version.Minor + "." + Package.Current.Id.Version.Build;
 #else
-            var version = FileVersionInfo.GetVersionInfo(Environment.GetCommandLineArgs()[0]);
-            return $"{version.FileMajorPart}.{version.FileMinorPart}.{version.FileBuildPart}";
+            return applicationInfo.Version;
 #endif
         }
 
@@ -58,15 +57,6 @@ namespace CodePush.ReactNative
             return CodePushConstants.AssetsBundlePrefix;
 #else
             return Path.Combine(GetAppFolder(), CodePushConstants.AssetsBundlePrefix);
-#endif
-        }
-
-        internal static string GetFileBundlePrefix()
-        {
-#if WINDOWS_UWP
-            return CodePushConstants.FileBundlePrefix;
-#else
-            return "C:\\ProgramData\\BlueJeans\\"; //TODO: make it smarter can be GetAppFolder for localUser
 #endif
         }
 

--- a/windows/CodePush.Shared/CodePushUtils.cs
+++ b/windows/CodePush.Shared/CodePushUtils.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Linq;
+using System.IO;
 #if WINDOWS_UWP
 using Windows.ApplicationModel;
 using Windows.Storage;
-#else
-using System.IO;
 #endif
 
 namespace CodePush.ReactNative
@@ -66,8 +66,14 @@ namespace CodePush.ReactNative
 #if WINDOWS_UWP
             return CodePushConstants.FileBundlePrefix;
 #else
-            return GetAppFolder();
+            return "C:\\ProgramData\\BlueJeans\\"; //TODO: make it smarter can be GetAppFolder for localUser
 #endif
+        }
+
+        internal static string ExtractSubFolder(string fullPath)
+        {
+            var codePushSubPathArray = fullPath.Split(Path.DirectorySeparatorChar);
+            return String.Join("/", codePushSubPathArray.SkipWhile((value, index) => codePushSubPathArray.Length - index > 4).ToArray());
         }
 
     }

--- a/windows/CodePush/CodePushUtils.cs
+++ b/windows/CodePush/CodePushUtils.cs
@@ -9,6 +9,11 @@ namespace CodePush.ReactNative
 {
     internal partial class CodePushUtils
     {
+        internal static string GetFileBundlePrefix()
+        {
+            return CodePushConstants.FileBundlePrefix;
+        }
+
         internal async static Task<JObject> GetJObjectFromFileAsync(StorageFile file)
         {
             string jsonString = await FileIO.ReadTextAsync(file).AsTask().ConfigureAwait(false);


### PR DESCRIPTION
1) Desktop application can be installed at any location, the most popular are: 
 - _User local data folder_, in this case the bundle can be stored in the same location and be  unique for the user. 
 - _Program Files folder_, in this case the application is unique for the system and will be shared  among all users of the system, the bundle should be unique for the system as well. 

Usually, user has no write access to Program Files folder or at least admin privileges have to been requested.  In this case the bundle will be stored in ProgramData folder as it is recommended.

2) Small refactoring to share more code between UWP and WPF projects.

3) Windows examples were updated to `react-native-windows 0.43.0-rc.0`