### PR TITLE
Fix update crash by removing download key in mutableUpdatePackage.

### DIFF
--- a/ios/CodePush/CodePushPackage.m
+++ b/ios/CodePush/CodePushPackage.m
@@ -258,6 +258,7 @@ static NSString *const UnzippedFolderName = @"unzipped";
                                                         }
                                                     }
                                                     
+                                                    [mutableUpdatePackage removeObjectForKey:@"download"];
                                                     NSData *updateSerializedData = [NSJSONSerialization dataWithJSONObject:mutableUpdatePackage
                                                                                                                    options:0
                                                                                                                      error:&error];


### PR DESCRIPTION
`download` key is a function and isn't serializable by NSJSONSerialization.
See issue #816.