### PR TITLE
If current package folder is null don't delete

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/FileUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/FileUtils.java
@@ -55,6 +55,10 @@ public class FileUtils {
     }
 
     public static void deleteDirectoryAtPath(String directoryPath) {
+        if (directoryPath == null) {
+            CodePushUtils.log("deleteDirectoryAtPath attempted with null directoryPath");
+            return;
+        }
         File file = new File(directoryPath);
         if (file.exists()) {
             deleteFileOrFolderSilently(file);


### PR DESCRIPTION
Fixes: #795 

I've seen this in my crashlytics logs - same as the above issue.

**Issue**: `getCurrentPackageFolderPath()` can return null

**Solution**: check if path is null before deleting the directory.