### PR TITLE
Handle TargetBinaryVersionMismatch

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -8,7 +8,7 @@ import log from "./logging";
 let NativeCodePush = require("react-native").NativeModules.CodePush;
 const PackageMixins = require("./package-mixins")(NativeCodePush);
 
-async function checkForUpdate(deploymentKey = null) {
+async function checkForUpdate(deploymentKey = null, handleBinaryVersionMismatch = null) {
   /*
    * Before we ask the server if an update exists, we
    * need to retrieve three pieces of information from the
@@ -76,6 +76,9 @@ async function checkForUpdate(deploymentKey = null) {
       (!localPackage || localPackage._isDebugOnly) && config.packageHash === update.packageHash) {
     if (update && update.updateAppVersion) {
       log("An update is available but it is not targeting the binary version of your app.");
+      if(handleBinaryVersionMismatch && typeof handleBinaryVersionMismatch === "function") {
+        handleBinaryVersionMismatch(update)
+      }
     }
 
     return null;
@@ -237,7 +240,7 @@ const sync = (() => {
   let syncInProgress = false;
   const setSyncCompleted = () => { syncInProgress = false; };
 
-  return (options = {}, syncStatusChangeCallback, downloadProgressCallback) => {
+  return (options = {}, syncStatusChangeCallback, downloadProgressCallback, handleBinaryVersionMismatch) => {
     if (syncInProgress) {
       typeof syncStatusChangeCallback === "function"
         ? syncStatusChangeCallback(CodePush.SyncStatus.SYNC_IN_PROGRESS)
@@ -246,7 +249,7 @@ const sync = (() => {
     }
 
     syncInProgress = true;
-    const syncPromise = syncInternal(options, syncStatusChangeCallback, downloadProgressCallback);
+    const syncPromise = syncInternal(options, syncStatusChangeCallback, downloadProgressCallback, handleBinaryVersionMismatch);
     syncPromise
       .then(setSyncCompleted)
       .catch(setSyncCompleted);
@@ -264,7 +267,7 @@ const sync = (() => {
  * releases, and displaying a standard confirmation UI to the end-user
  * when an update is available.
  */
-async function syncInternal(options = {}, syncStatusChangeCallback, downloadProgressCallback) {
+async function syncInternal(options = {}, syncStatusChangeCallback, downloadProgressCallback, handleBinaryVersionMismatch) {
   let resolvedInstallMode;
   const syncOptions = {
     deploymentKey: null,
@@ -319,7 +322,7 @@ async function syncInternal(options = {}, syncStatusChangeCallback, downloadProg
     await CodePush.notifyApplicationReady();
 
     syncStatusChangeCallback(CodePush.SyncStatus.CHECKING_FOR_UPDATE);
-    const remotePackage = await checkForUpdate(syncOptions.deploymentKey);
+    const remotePackage = await checkForUpdate(syncOptions.deploymentKey, handleBinaryVersionMismatch);
 
     const doDownloadAndInstall = async () => {
       syncStatusChangeCallback(CodePush.SyncStatus.DOWNLOADING_PACKAGE);
@@ -445,7 +448,15 @@ function codePushify(options = {}) {
             }
           }
 
-          CodePush.sync(options, syncStatusCallback, downloadProgressCallback);
+          let handleBinaryVersionMismatch;
+          if (rootComponentInstance && rootComponentInstance.codePushOnBinaryVersionMismatch) {
+            handleBinaryVersionMismatch = rootComponentInstance.codePushOnBinaryVersionMismatch;
+            if (rootComponentInstance instanceof React.Component) {
+              handleBinaryVersionMismatch = handleBinaryVersionMismatch.bind(rootComponentInstance);
+            }
+          }
+
+          CodePush.sync(options, syncStatusCallback, downloadProgressCallback, handleBinaryVersionMismatch);
           if (options.checkFrequency === CodePush.CheckFrequency.ON_APP_RESUME) {
             ReactNative.AppState.addEventListener("change", (newState) => {
               newState === "active" && CodePush.sync(options, syncStatusCallback, downloadProgressCallback);


### PR DESCRIPTION
A handler function can be added for version upgrades.
```javascript
codePushOnBinaryVersionMismatch(update) {
    console.log(VersionNumber.appVersion)
    console.log(update)
    if(update && update.updateAppVersion) {
      alert("You are running on version " + VersionNumber.appVersion + "\nApp has been updated to " + update.appVersion + " \nDownload latest APP and install")
      this.setState({codepushStatus: codePush.SyncStatus.DOWNLOADING_PACKAGE, codepushStatusMessage: "Downloading newer version of the app"})
    Linking.openURL(<Host link of app bin>)
    }
  }

It will be helpful in letting user know if there is any binary updates