### PR TITLE
[WPF] Fix application crash when storage file was deleted while app is being active.

### DIFF
--- a/Examples/CodePushDemoApp/windows/CodePushDemoApp/CodePushDemoApp.nuget.targets
+++ b/Examples/CodePushDemoApp/windows/CodePushDemoApp/CodePushDemoApp.nuget.targets
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Condition="'$(NuGetPackageRoot)' == ''">
-    <NuGetPackageRoot>$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
-  </PropertyGroup>
-  <ImportGroup>
-    <Import Project="$(NuGetPackageRoot)\Facebook.Yoga\1.0.1-pre\build\netstandard\Facebook.Yoga.targets" Condition="Exists('$(NuGetPackageRoot)\Facebook.Yoga\1.0.1-pre\build\netstandard\Facebook.Yoga.targets')" />
-  </ImportGroup>
-</Project>

--- a/windows/CodePush.Net46/Adapters/Storage/ApplicationDataContainer.cs
+++ b/windows/CodePush.Net46/Adapters/Storage/ApplicationDataContainer.cs
@@ -91,7 +91,7 @@ namespace CodePush.Net46.Adapters.Storage
         {
             await mutex.WaitAsync().ConfigureAwait(false);
             var jobject = JObject.FromObject(Values);
-            var storageFile = FileSystem.Current.LocalStorage.CreateFileAsync(storageFileName, CreationCollisionOption.OpenIfExists).Result;
+            var storageFile = await FileSystem.Current.LocalStorage.CreateFileAsync(storageFileName, CreationCollisionOption.OpenIfExists).ConfigureAwait(false);
             await storageFile.WriteAllTextAsync(JsonConvert.SerializeObject(jobject)).ConfigureAwait(false);
             mutex.Release();
         }
@@ -99,8 +99,8 @@ namespace CodePush.Net46.Adapters.Storage
         public async Task DeleteAsync()
         {
             Values.Clear();
-            var storageFile = FileSystem.Current.LocalStorage.CreateFileAsync(storageFileName, CreationCollisionOption.OpenIfExists).Result;
-            await storageFile.DeleteAsync();
+            var storageFile = await FileSystem.Current.LocalStorage.CreateFileAsync(storageFileName, CreationCollisionOption.OpenIfExists).ConfigureAwait(false);
+            await storageFile.DeleteAsync().ConfigureAwait(false);
         }
     }
 }

--- a/windows/CodePush.Net46/Adapters/Storage/ApplicationDataContainer.cs
+++ b/windows/CodePush.Net46/Adapters/Storage/ApplicationDataContainer.cs
@@ -62,11 +62,12 @@ namespace CodePush.Net46.Adapters.Storage
         private readonly SemaphoreSlim mutex = new SemaphoreSlim(1, 1);
 
         const string STORAGE_NAME = "AppStorage.data";
-        IFile storageFile = null;
+        string storageFileName = null;
 
         public ApplicationDataContainer(string name = STORAGE_NAME)
         {
-            storageFile = FileSystem.Current.LocalStorage.CreateFileAsync(name, CreationCollisionOption.OpenIfExists).Result;
+            storageFileName = name;
+            var storageFile = FileSystem.Current.LocalStorage.CreateFileAsync(storageFileName, CreationCollisionOption.OpenIfExists).Result;
             var data = CodePushUtils.GetJObjectFromFileAsync(storageFile).Result;
 
             if (data != null)
@@ -90,6 +91,7 @@ namespace CodePush.Net46.Adapters.Storage
         {
             await mutex.WaitAsync().ConfigureAwait(false);
             var jobject = JObject.FromObject(Values);
+            var storageFile = FileSystem.Current.LocalStorage.CreateFileAsync(storageFileName, CreationCollisionOption.OpenIfExists).Result;
             await storageFile.WriteAllTextAsync(JsonConvert.SerializeObject(jobject)).ConfigureAwait(false);
             mutex.Release();
         }
@@ -97,6 +99,7 @@ namespace CodePush.Net46.Adapters.Storage
         public async Task DeleteAsync()
         {
             Values.Clear();
+            var storageFile = FileSystem.Current.LocalStorage.CreateFileAsync(storageFileName, CreationCollisionOption.OpenIfExists).Result;
             await storageFile.DeleteAsync();
         }
     }


### PR DESCRIPTION
If by some reason persistent storage file was deleted while application is running, next time when CodePush tries to access it it crashes with the following exception: 
`System.IO.FileNotFoundException: Could not find file 'C:\Users\USER_NAME\AppData\Local\PATH_TO_APP\CodePush\CodePush'.` 

The fix is, if file was deleted - recreate the storage file. Of course all settings will be lost when file was deleted.