### PR TITLE
add support for RN 0.45.x

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -9,6 +9,7 @@ import android.provider.Settings;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.JSBundleLoader;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -97,37 +98,14 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
     // to approach this.
     private void setJSBundle(ReactInstanceManager instanceManager, String latestJSBundleFile) throws IllegalAccessException {
         try {
-            Field bundleLoaderField = instanceManager.getClass().getDeclaredField("mBundleLoader");
-            Class<?> jsBundleLoaderClass = Class.forName("com.facebook.react.cxxbridge.JSBundleLoader");
-            Method createFileLoaderMethod = null;
-            String createFileLoaderMethodName = latestJSBundleFile.toLowerCase().startsWith("assets://")
-                        ? "createAssetLoader" : "createFileLoader";
-
-            Method[] methods = jsBundleLoaderClass.getDeclaredMethods();
-            for (Method method : methods) {
-                if (method.getName().equals(createFileLoaderMethodName)) {
-                    createFileLoaderMethod = method;
-                    break;
-                }
-            }
-
-            if (createFileLoaderMethod == null) {
-                throw new NoSuchMethodException("Could not find a recognized 'createFileLoader' method");
-            }
-
-            int numParameters = createFileLoaderMethod.getGenericParameterTypes().length;
-            Object latestJSBundleLoader;
-
-            if (numParameters == 1) {
-                // RN >= v0.34
-                latestJSBundleLoader = createFileLoaderMethod.invoke(jsBundleLoaderClass, latestJSBundleFile);
-            } else if (numParameters == 2) {
-                // AssetLoader instance
-                latestJSBundleLoader = createFileLoaderMethod.invoke(jsBundleLoaderClass, getReactApplicationContext(), latestJSBundleFile);
+            JSBundleLoader latestJSBundleLoader;
+            if (latestJSBundleFile.toLowerCase().startsWith("assets://")) {
+                latestJSBundleLoader = JSBundleLoader.createAssetLoader(getReactApplicationContext(), latestJSBundleFile, false);
             } else {
-                throw new NoSuchMethodException("Could not find a recognized 'createFileLoader' method");
+                latestJSBundleLoader = JSBundleLoader.createFileLoader(latestJSBundleFile);
             }
 
+            Field bundleLoaderField = instanceManager.getClass().getDeclaredField("mBundleLoader");
             bundleLoaderField.setAccessible(true);
             bundleLoaderField.set(instanceManager, latestJSBundleLoader);
         } catch (Exception e) {
@@ -157,6 +135,14 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
                 @Override
                 public void run() {
                     try {
+                        // This workaround has been implemented in order to fix https://github.com/facebook/react-native/issues/14533
+                        // resetReactRootViews allows to call recreateReactContextInBackground without any exceptions
+                        // This fix also relates to https://github.com/Microsoft/react-native-code-push/issues/878
+                        resetReactRootViews(instanceManager);
+
+                        instanceManager.recreateReactContextInBackground();
+                        mCodePush.initializeUpdateAfterRestart();
+
                         instanceManager.recreateReactContextInBackground();
                         mCodePush.initializeUpdateAfterRestart();
                     } catch (Exception e) {
@@ -172,6 +158,17 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
             // so fall back to restarting the Activity (if it exists)
             loadBundleLegacy();
         }
+    }
+
+    private void resetReactRootViews(ReactInstanceManager instanceManager) throws NoSuchFieldException, IllegalAccessException {
+        Field mAttachedRootViewsField = instanceManager.getClass().getDeclaredField("mAttachedRootViews");
+        mAttachedRootViewsField.setAccessible(true);
+        List<ReactRootView> mAttachedRootViews = (List<ReactRootView>)mAttachedRootViewsField.get(instanceManager);
+        for (ReactRootView reactRootView : mAttachedRootViews) {
+            reactRootView.removeAllViews();
+            reactRootView.setId(View.NO_ID);
+        }
+        mAttachedRootViewsField.set(instanceManager, mAttachedRootViews);
     }
 
     private void clearLifecycleEventListener() {

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -11,7 +11,6 @@ import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactRootView;
 import com.facebook.react.bridge.Arguments;
-import com.facebook.react.bridge.JSBundleLoader;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -29,6 +28,7 @@ import org.json.JSONObject;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -100,14 +100,37 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
     // to approach this.
     private void setJSBundle(ReactInstanceManager instanceManager, String latestJSBundleFile) throws IllegalAccessException {
         try {
-            JSBundleLoader latestJSBundleLoader;
-            if (latestJSBundleFile.toLowerCase().startsWith("assets://")) {
-                latestJSBundleLoader = JSBundleLoader.createAssetLoader(getReactApplicationContext(), latestJSBundleFile, false);
-            } else {
-                latestJSBundleLoader = JSBundleLoader.createFileLoader(latestJSBundleFile);
+            Field bundleLoaderField = instanceManager.getClass().getDeclaredField("mBundleLoader");
+            Class<?> jsBundleLoaderClass = Class.forName("com.facebook.react.cxxbridge.JSBundleLoader");
+            Method createFileLoaderMethod = null;
+            String createFileLoaderMethodName = latestJSBundleFile.toLowerCase().startsWith("assets://")
+                    ? "createAssetLoader" : "createFileLoader";
+
+            Method[] methods = jsBundleLoaderClass.getDeclaredMethods();
+            for (Method method : methods) {
+                if (method.getName().equals(createFileLoaderMethodName)) {
+                    createFileLoaderMethod = method;
+                    break;
+                }
             }
 
-            Field bundleLoaderField = instanceManager.getClass().getDeclaredField("mBundleLoader");
+            if (createFileLoaderMethod == null) {
+                throw new NoSuchMethodException("Could not find a recognized 'createFileLoader' method");
+            }
+
+            int numParameters = createFileLoaderMethod.getGenericParameterTypes().length;
+            Object latestJSBundleLoader;
+
+            if (numParameters == 1) {
+                // RN >= v0.34
+                latestJSBundleLoader = createFileLoaderMethod.invoke(jsBundleLoaderClass, latestJSBundleFile);
+            } else if (numParameters == 2) {
+                // AssetLoader instance
+                latestJSBundleLoader = createFileLoaderMethod.invoke(jsBundleLoaderClass, getReactApplicationContext(), latestJSBundleFile);
+            } else {
+                throw new NoSuchMethodException("Could not find a recognized 'createFileLoader' method");
+            }
+
             bundleLoaderField.setAccessible(true);
             bundleLoaderField.set(instanceManager, latestJSBundleLoader);
         } catch (Exception e) {

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -5,9 +5,11 @@ import android.os.AsyncTask;
 import android.os.Handler;
 import android.os.Looper;
 import android.provider.Settings;
+import android.view.View;
 
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.ReactRootView;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.JSBundleLoader;
 import com.facebook.react.bridge.LifecycleEventListener;
@@ -27,9 +29,9 @@ import org.json.JSONObject;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class CodePushNativeModule extends ReactContextBaseJavaModule {

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -144,9 +144,6 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
 
                         instanceManager.recreateReactContextInBackground();
                         mCodePush.initializeUpdateAfterRestart();
-
-                        instanceManager.recreateReactContextInBackground();
-                        mCodePush.initializeUpdateAfterRestart();
                     } catch (Exception e) {
                         // The recreation method threw an unknown exception
                         // so just simply fallback to restarting the Activity (if it exists)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-code-push",
-  "version": "2.1.0-beta",
+  "version": "1000.0.0-beta",
   "description": "React Native plugin for the CodePush service",
   "main": "CodePush.js",
   "typings": "typings/react-native-code-push.d.ts",


### PR DESCRIPTION
This workaround has been implemented in order to fix https://github.com/facebook/react-native/issues/14533
`resetReactRootViews` allows to call `recreateReactContextInBackground` without any exceptions
This fix also relates to https://github.com/Microsoft/react-native-code-push/issues/878