### PR TITLE
Fix dependency issue

### DIFF
--- a/android/codepush.gradle
+++ b/android/codepush.gradle
@@ -80,6 +80,9 @@ gradle.projectsEvaluated {
                 commandLine (*nodeExecutableAndArgs, "${nodeModulesPath}/react-native-code-push/scripts/generateBundledResourcesHash.js", resourcesDir, "$jsBundleDir/$bundleAssetName", jsBundleDir, resourcesMapTempFileName)
             }
 
+            // We need to generate and record the resources map, but we use it to generate the bundle hash
+            generateBundledResourcesHash.dependsOn("recordFilesBeforeBundleCommand${targetName}")
+
             generateBundledResourcesHash.dependsOn("bundle${targetName}JsAndAssets")
             runBefore("processArmeabi-v7a${targetName}Resources", generateBundledResourcesHash)
             runBefore("processX86${targetName}Resources", generateBundledResourcesHash)


### PR DESCRIPTION
Fix this crash I see when building for android:
```
:app:generateBundledResourcesHashDebug
module.js:471
    throw err;
    ^

Error: Cannot find module '/var/folders/94/wngs1jw91_n2_jjjrfljtqrc0000gn/T/CodePushResourcesMap-1b95774b.json'
```

Looks like these two tasks (`recordFileBeforeBundleCommand` and `generateBundledResourcesHash`) run in parallel, which create problems because one depends on a file generated by the other. Not sure why others don't have this issue, though, but I suspect this is exactly the issue reported in https://github.com/Microsoft/react-native-code-push/issues/836