### PR TITLE
Fix declaration of "_installMode" to remove warnings

### DIFF
--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -24,7 +24,7 @@
     BOOL _isFirstRunAfterUpdate;
     int _minimumBackgroundDuration;
     NSDate *_lastResignedDate;
-    CodePushInstallMode *_installMode;
+    CodePushInstallMode _installMode;
     NSTimer *_appSuspendTimer;
 
     // Used to coordinate the dispatching of download progress events to JS.


### PR DESCRIPTION
The `_installMode` property should not be declared as a pointer since it holds an enum value. This code causes Xcode to display the following warnings:
```
Showing All Issues
.../node_modules/react-native-code-push/ios/CodePush/CodePush.m:591:22: Comparison between pointer and integer ('CodePushInstallMode *' (aka 'enum CodePushInstallMode *') and 'NSInteger' (aka 'long'))
.../node_modules/react-native-code-push/ios/CodePush/CodePush.m:775:22: Incompatible integer to pointer conversion assigning to 'CodePushInstallMode *' (aka 'enum CodePushInstallMode *') from 'CodePushInstallMode' (aka 'enum CodePushInstallMode'); take the address with &
```