### PR TITLE
Fix WPF. Application crashes on startup

### DIFF
--- a/Examples/CodePushDemoApp/package.json
+++ b/Examples/CodePushDemoApp/package.json
@@ -10,7 +10,7 @@
 		"react": "16.0.0-alpha.12",
 		"react-native": "^0.47.1",
 		"react-native-code-push": "file:../../",
-		"react-native-windows": "^0.43.0-rc.0"
+		"react-native-windows": "^0.47.0-rc.5"
 	},
 	"devDependencies": {
 		"babel-jest": "20.0.3",

--- a/Examples/CodePushDemoApp/windows/CodePushDemoApp.Wpf/CodePushDemoApp.Wpf.csproj
+++ b/Examples/CodePushDemoApp/windows/CodePushDemoApp.Wpf/CodePushDemoApp.Wpf.csproj
@@ -102,7 +102,7 @@
   <ItemGroup>
     <Reference Include="Facebook.Yoga, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Facebook.Yoga.1.2.0-pre1\lib\net45\Facebook.Yoga.dll</HintPath>
+      <HintPath>..\packages\Facebook.Yoga.1.5.0-pre1\lib\net45\Facebook.Yoga.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -171,9 +171,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.ChakraCore.1.4.1\build\netstandard1.0\Microsoft.ChakraCore.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ChakraCore.1.4.1\build\netstandard1.0\Microsoft.ChakraCore.props'))" />
-    <Error Condition="!Exists('..\packages\Facebook.Yoga.1.2.0-pre1\build\net45\Facebook.Yoga.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Facebook.Yoga.1.2.0-pre1\build\net45\Facebook.Yoga.targets'))" />
+    <Error Condition="!Exists('..\packages\Facebook.Yoga.1.5.0-pre1\build\net45\Facebook.Yoga.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Facebook.Yoga.1.5.0-pre1\build\net45\Facebook.Yoga.targets'))" />
   </Target>
-  <Import Project="..\packages\Facebook.Yoga.1.2.0-pre1\build\net45\Facebook.Yoga.targets" Condition="Exists('..\packages\Facebook.Yoga.1.2.0-pre1\build\net45\Facebook.Yoga.targets')" />
+  <Import Project="..\packages\Facebook.Yoga.1.5.0-pre1\build\net45\Facebook.Yoga.targets" Condition="Exists('..\packages\Facebook.Yoga.1.5.0-pre1\build\net45\Facebook.Yoga.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Examples/CodePushDemoApp/windows/CodePushDemoApp.Wpf/packages.config
+++ b/Examples/CodePushDemoApp/windows/CodePushDemoApp.Wpf/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Facebook.Yoga" version="1.2.0-pre1" targetFramework="net46" />
+  <package id="Facebook.Yoga" version="1.5.0-pre1" targetFramework="net46" />
   <package id="Microsoft.ChakraCore" version="1.4.1" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/Examples/CodePushDemoApp/windows/CodePushDemoApp/project.json
+++ b/Examples/CodePushDemoApp/windows/CodePushDemoApp/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Facebook.Yoga": "1.2.0-pre1",
+    "Facebook.Yoga": "1.5.0-pre1",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2"
   },
   "frameworks": {

--- a/windows/CodePush.Net46/UpdateManager.cs
+++ b/windows/CodePush.Net46/UpdateManager.cs
@@ -266,6 +266,10 @@ namespace CodePush.ReactNative
         private async Task<IFolder> GetCurrentPackageFolderAsync()
         {
             var info = await GetCurrentPackageInfoAsync().ConfigureAwait(false);
+            if (info == null)
+            {
+                return null;
+            }
             var packageHash = (string)info[CodePushConstants.CurrentPackageKey];
             return packageHash == null ? null : await GetPackageFolderAsync(packageHash, false).ConfigureAwait(false);
         }
@@ -273,6 +277,16 @@ namespace CodePush.ReactNative
         private async Task<JObject> GetCurrentPackageInfoAsync()
         {
             var statusFile = await GetStatusFileAsync().ConfigureAwait(false);
+            var info = await CodePushUtils.GetJObjectFromFileAsync(statusFile).ConfigureAwait(false);
+
+            if (info != null)
+            {
+                return info;
+            }
+
+            // info file has been corrupted - re-create it
+            await statusFile.DeleteAsync().ConfigureAwait(false);
+            statusFile = await GetStatusFileAsync().ConfigureAwait(false);
             return await CodePushUtils.GetJObjectFromFileAsync(statusFile).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
Application crashes on startup if `codepush.json` file has been corrupted by some reason. The solution re-create file. In this case application will start with original JS bundle and the latest JS bundle will be available for download.

Windows examples were aligned with React Native v 0.47.1