### PR TITLE
Added create-react-native-app information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ As with all other React Native plugins, the integration experience is different 
 
 If you want to see how other projects have integrated with CodePush, you can check out the excellent [example apps](#example-apps--starters) provided by the community. Additionally, if you'd like to quickly familiarize yourself with CodePush + React Native, you can check out the awesome getting started videos produced by [Bilal Budhani](https://www.youtube.com/watch?v=uN0FRWk-YW8&feature=youtu.be) and/or [Deepak Sisodiya ](https://www.youtube.com/watch?v=f6I9y7V-Ibk).
 
+*NOTE: This guide assumes you have used the `react-native init` command to initialize your React Native project. As of March 2017, the command `create-react-native-app` can also be used to initialize a React Native project. If using this command, please run `npm run eject` in your project's home directory to get a project very similar to what `react-native init` would have created.*
 
 Then continue with installing the native module
   * [iOS Setup](docs/setup-ios.md)


### PR DESCRIPTION
n March 2017, React Native introduced a new command called "create-react-native-app". This command is not compatible with the directions in this guide. The solution is to run "npm run eject" in the directory, which will allow the user's project to be compatible.