### PR TITLE
Restore compatibility with RN v0.46

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -305,6 +305,11 @@ public class CodePush implements ReactPackage {
     }
 
     @Override
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return new ArrayList<>();
+    }
+
+    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactApplicationContext) {
         return new ArrayList<>();
     }

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -304,7 +304,7 @@ public class CodePush implements ReactPackage {
         return nativeModules;
     }
 
-    @Override
+    // Deprecated in RN v0.47.
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return new ArrayList<>();
     }


### PR DESCRIPTION
As [discussed in #895](https://github.com/Microsoft/react-native-code-push/pull/895#issuecomment-325700522), this change is fully forward- and backwards-compatible. It can be released as a patch (e.g. `v5.0.1` or `v4.1.1`, whatever you prefer).

This would be really helpful for people who continue to use RN v0.46 but want to receive updates from react-native-code-push.