### PR TITLE
check if package metadata is null

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -184,7 +184,7 @@ public class CodePush implements ReactPackage {
         JSONObject pendingUpdate = mSettingsManager.getPendingUpdate();
         if (pendingUpdate != null) {
             JSONObject packageMetadata = this.mUpdateManager.getCurrentPackage();
-            if (!isPackageBundleLatest(packageMetadata) && hasBinaryVersionChanged(packageMetadata)) {
+            if (packageMetadata == null || !isPackageBundleLatest(packageMetadata) && hasBinaryVersionChanged(packageMetadata)) {
                 CodePushUtils.log("Skipping initializeUpdateAfterRestart(), binary version is newer");
                 return;
             }


### PR DESCRIPTION
Seen this error in production:
```
Fatal Exception: java.lang.RuntimeException: Unable to start activity ComponentInfo{com.example/com.example.MainActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String org.json.JSONObject.optString(java.lang.String, java.lang.String)' on a null object reference
       at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2793)
       at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2864)
       at android.app.ActivityThread.-wrap12(ActivityThread.java)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1567)
       at android.os.Handler.dispatchMessage(Handler.java:105)
       at android.os.Looper.loop(Looper.java:156)
       at android.app.ActivityThread.main(ActivityThread.java:6523)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:941)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:831)
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String org.json.JSONObject.optString(java.lang.String, java.lang.String)' on a null object reference
       at com.microsoft.codepush.react.CodePush.isPackageBundleLatest(CodePush.java:230)
       at com.microsoft.codepush.react.CodePush.initializeUpdateAfterRestart(CodePush.java:185)
       at com.microsoft.codepush.react.CodePush.(CodePush.java)
       at com.example.MainReactNativeHost.getPackages(MainReactNativeHost.java:63)
       at com.facebook.react.ReactNativeHost.createReactInstanceManager(ReactNativeHost.java:74)
       at com.facebook.react.ReactNativeHost.getReactInstanceManager(ReactNativeHost.java:41)
       at com.facebook.react.ReactActivityDelegate.loadApp(ReactActivityDelegate.java:111)
       at com.facebook.react.ReactActivityDelegate.onCreate(ReactActivityDelegate.java:100)
       at com.facebook.react.ReactActivity.onCreate(ReactActivity.java:54)
       at android.app.Activity.performCreate(Activity.java:6910)
       at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1123)
       at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2746)
       at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2864)
       at android.app.ActivityThread.-wrap12(ActivityThread.java)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1567)
       at android.os.Handler.dispatchMessage(Handler.java:105)
       at android.os.Looper.loop(Looper.java:156)
       at android.app.ActivityThread.main(ActivityThread.java:6523)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:941)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:831)
```

Introduced in #924. 

`getJSBundleFileInternal` has a similar check for the result of `getCurrentPackageBundlePath` which would be null if the package didn't exist.