### PR TITLE
Add double hash checking support for code signing

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateManager.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateManager.java
@@ -257,7 +257,8 @@ public class CodePushUpdateManager {
 
                 if (isSignatureVerificationEnabled) {
                     if (isSignatureAppearedInBundle) {
-                        CodePushUpdateUtils.verifySignature(newUpdateFolderPath, stringPublicKey);
+                        CodePushUpdateUtils.verifyFolderHash(newUpdateFolderPath, newUpdateHash);
+                        CodePushUpdateUtils.verifyUpdateSignature(newUpdateFolderPath, newUpdateHash, stringPublicKey);
                     } else {
                         throw new CodePushInvalidUpdateException(
                                 "Error! Public key was provided but there is no JWT signature within app bundle to verify. " +

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateUtils.java
@@ -172,13 +172,15 @@ public class CodePushUpdateUtils {
         if (!expectedHash.equals(updateContentsManifestHash)) {
             throw new CodePushInvalidUpdateException("The update contents failed the data integrity check.");
         }
+
+        CodePushUtils.log("The update contents succeeded the data integrity check.");
     }
 
     public static Map<String, Object> verifyAndDecodeJWT(String jwt, PublicKey publicKey) {
         try {
             final JWTVerifier verifier = new JWTVerifier(publicKey);
             final Map<String, Object> claims = verifier.verify(jwt);
-            CodePushUtils.log("JWT verification succeeded:\n" + claims.toString());
+            CodePushUtils.log("JWT signature verification succeeded, payload content: " + claims.toString());
             return claims;
         } catch (Exception e) {
             return null;
@@ -223,7 +225,7 @@ public class CodePushUpdateUtils {
         }
     }
 
-    public static void verifySignature(String folderPath, String stringPublicKey) throws CodePushInvalidUpdateException {
+    public static void verifyUpdateSignature(String folderPath, String packageHash, String stringPublicKey) throws CodePushInvalidUpdateException {
         CodePushUtils.log("Verifying signature for folder path: " + folderPath);
 
         final PublicKey publicKey = parsePublicKey(stringPublicKey);
@@ -246,7 +248,11 @@ public class CodePushUpdateUtils {
             throw new CodePushInvalidUpdateException("The update could not be verified because the signature did not specify a content hash.");
         }
 
-        CodePushUpdateUtils.verifyFolderHash(folderPath, contentHash);
+        if (!contentHash.equals(packageHash)) {
+            throw new CodePushInvalidUpdateException("The update contents failed the code signing check.");
+        }
+
+        CodePushUtils.log("The update contents succeeded the code signing check.");
     }
 
 }

--- a/ios/CodePush/CodePush.h
+++ b/ios/CodePush/CodePush.h
@@ -193,9 +193,10 @@ failCallback:(void (^)(NSError *err))failCallback;
                withPublicKey:(NSString *)publicKey
                        error:(NSError **)error;
 
-+ (BOOL)verifySignatureFor:(NSString *)updateFolderPath
-             withPublicKey:(NSString *)publicKey
-                  error:(NSError **)error;
++ (BOOL)verifyUpdateSignatureFor:(NSString *)updateFolderPath
+                    expectedHash:(NSString *)newUpdateHash
+                   withPublicKey:(NSString *)publicKeyString
+                           error:(NSError **)error;
 
 @end
 

--- a/ios/CodePush/CodePushPackage.m
+++ b/ios/CodePush/CodePushPackage.m
@@ -241,18 +241,32 @@ static NSString *const UnzippedFolderName = @"unzipped";
                                                         
                                                         if (isSignatureVerificationEnabled) {
                                                             if (isSignatureAppearedInBundle) {
-                                                                BOOL isSignatureValid = [CodePushUpdateUtils verifySignatureFor:newUpdateFolderPath
-                                                                                                                  withPublicKey:publicKey
-                                                                                                                          error:&error];
-                                                                if (!isSignatureValid) {
-                                                                    CPLog(@"Code signing integrity check error.");
+                                                                if (![CodePushUpdateUtils verifyFolderHash:newUpdateFolderPath
+                                                                                              expectedHash:newUpdateHash
+                                                                                                     error:&error]) {
+                                                                    CPLog(@"The update contents failed the data integrity check.");
                                                                     if (!error) {
-                                                                        error = [CodePushErrorUtils errorWithMessage:@"Code signing integrity check error."];
+                                                                        error = [CodePushErrorUtils errorWithMessage:@"The update contents failed the data integrity check."];
+                                                                    }
+                                                                    
+                                                                    failCallback(error);
+                                                                    return;
+                                                                } else {
+                                                                    CPLog(@"The update contents succeeded the data integrity check.");
+                                                                }
+                                                                BOOL isSignatureValid = [CodePushUpdateUtils verifyUpdateSignatureFor:newUpdateFolderPath
+                                                                                                                         expectedHash:newUpdateHash
+                                                                                                                        withPublicKey:publicKey
+                                                                                                                                error:&error];
+                                                                if (!isSignatureValid) {
+                                                                    CPLog(@"The update contents failed code signing check.");
+                                                                    if (!error) {
+                                                                        error = [CodePushErrorUtils errorWithMessage:@"The update contents failed code signing check."];
                                                                     }
                                                                     failCallback(error);
                                                                     return;
                                                                 } else {
-                                                                    CPLog(@"The update contents succeeded the code signing integrity check.");
+                                                                    CPLog(@"The update contents succeeded the code signing check.");
                                                                 }
                                                             } else {
                                                                 error = [CodePushErrorUtils errorWithMessage:

--- a/ios/CodePush/CodePushUpdateUtils.m
+++ b/ios/CodePush/CodePushUpdateUtils.m
@@ -335,9 +335,10 @@ NSString * const IgnoreCodePushMetadata = @".codepushrelease";
     }
 }
 
-+ (BOOL)verifySignatureFor:(NSString *)folderPath
-             withPublicKey:(NSString *)publicKeyString
-                     error:(NSError **)error
++ (BOOL)verifyUpdateSignatureFor:(NSString *)folderPath
+                    expectedHash:(NSString *)newUpdateHash
+                   withPublicKey:(NSString *)publicKeyString
+                           error:(NSError **)error
 {
     NSLog(@"Verifying signature for folder path: %@", folderPath);
     
@@ -360,6 +361,8 @@ NSString * const IgnoreCodePushMetadata = @".codepushrelease";
         return false;
     }
     
+    CPLog(@"JWT signature verification succeeded, payload content:  %@", envelopedPayload);
+    
     if(![envelopedPayload objectForKey:@"contentHash"]){
         CPLog(@"The update could not be verified because the signature did not specify a content hash.");
         return false;
@@ -367,9 +370,7 @@ NSString * const IgnoreCodePushMetadata = @".codepushrelease";
     
     NSString *contentHash = envelopedPayload[@"contentHash"];
     
-    return [self verifyFolderHash:folderPath
-                     expectedHash:contentHash
-                            error:error];
+    return [contentHash isEqualToString:newUpdateHash];
 }
 
 @end


### PR DESCRIPTION
This PR improves code signing verification providing transitive verification between package hash, computed update folder hash and content hash from jwt payload on SDK side.