### PR TITLE
Fix proguard error in Android build

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -24,3 +24,6 @@
 -keepclassmembers class com.facebook.react.XReactInstanceManagerImpl {
     void recreateReactContextInBackground();
 }
+
+# Can't find referenced class org.bouncycastle.**
+-dontwarn com.nimbusds.jose.**


### PR DESCRIPTION
Couldn't build with v5.1.1 due to the introduction of the com.nimbusds.jose library which causes a proguard error.