### PR TITLE
Added requiresMainQueueSetup to prevent warning and future side-effects

### DIFF
--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -302,6 +302,11 @@ static NSString *bundleResourceSubdirectory = nil;
             };
 };
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 - (void)dealloc
 {
     // Ensure the global resume handler is cleared, so that
@@ -627,7 +632,7 @@ RCT_EXPORT_METHOD(downloadUpdate:(NSDictionary*)updatePackage
         _didUpdateProgress = NO;
         self.paused = NO;
     }
-    
+
     NSString * publicKey = [[CodePushConfig current] publicKey];
 
     [CodePushPackage


### PR DESCRIPTION
New versions of react will require requiresMainQueueSetup method. Here's the warning:

```
Module CodePush requires main queue setup since it overrides `constantsToExport` but doesn't implement `requiresMainQueueSetup. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.
```


<img width="2256" alt="screenshot 2017-10-06 19 08 25" src="https://user-images.githubusercontent.com/3402/31292040-c9684378-aac9-11e7-9422-4644ccf5de45.png">
