### PR TITLE
hoist non-react static methods in decorator

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -4,6 +4,7 @@ import requestFetchAdapter from "./request-fetch-adapter";
 import { AppState, Platform } from "react-native";
 import RestartManager from "./RestartManager";
 import log from "./logging";
+import hoistStatics from 'hoist-non-react-statics';
 
 let NativeCodePush = require("react-native").NativeModules.CodePush;
 const PackageMixins = require("./package-mixins")(NativeCodePush);
@@ -451,7 +452,7 @@ function codePushify(options = {}) {
   }
 
   var decorator = (RootComponent) => {
-    return class CodePushComponent extends React.Component {
+    const extended = class CodePushComponent extends React.Component {
       componentDidMount() {
         if (options.checkFrequency === CodePush.CheckFrequency.MANUAL) {
           CodePush.notifyAppReady();
@@ -503,6 +504,8 @@ function codePushify(options = {}) {
         return <RootComponent {...props} />
       }
     }
+
+    return hoistStatics(extended, RootComponent);
   }
 
   if (typeof options === "function") {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "code-push": "1.11.2-beta",
     "glob": "^5.0.15",
+    "hoist-non-react-statics": "^2.3.1",
     "inquirer": "1.1.2",
     "plist": "1.2.0",
     "xcode": "0.9.2"


### PR DESCRIPTION
Simple fix for #882

I think that, given the decorator doesn't actually use any of these statics, this could probably be done without the library. However, the library is a tried and tested method, and is [the recommended way](https://reactjs.org/docs/higher-order-components.html#static-methods-must-be-copied-over) of doing this.