### PR TITLE
Pass resolved install mode to status change callback

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -263,7 +263,7 @@ const sync = (() => {
 
     if (syncInProgress) {
       typeof syncStatusCallbackWithTryCatch === "function"
-        ? syncStatusCallbackWithTryCatch(CodePush.SyncStatus.SYNC_IN_PROGRESS)
+        ? syncStatusCallbackWithTryCatch(CodePush.SyncStatus.SYNC_IN_PROGRESS, null)
         : log("Sync already in progress.");
       return Promise.resolve(CodePush.SyncStatus.SYNC_IN_PROGRESS);
     }
@@ -302,18 +302,18 @@ async function syncInternal(options = {}, syncStatusChangeCallback, downloadProg
   syncStatusChangeCallback = typeof syncStatusChangeCallback === "function"
     ? syncStatusChangeCallback
     : (syncStatus) => {
-        switch(syncStatus) {
+        switch(syncStatus, resolvedInstallMode) {
           case CodePush.SyncStatus.CHECKING_FOR_UPDATE:
             log("Checking for update.");
             break;
           case CodePush.SyncStatus.AWAITING_USER_ACTION:
-            log("Awaiting user action.");
+            log("Awaiting user action. Install mode:", resolvedInstallMode);
             break;
           case CodePush.SyncStatus.DOWNLOADING_PACKAGE:
-            log("Downloading package.");
+            log("Downloading package. Install mode:", resolvedInstallMode);
             break;
           case CodePush.SyncStatus.INSTALLING_UPDATE:
-            log("Installing update.");
+            log("Installing update. Install mode:", resolvedInstallMode);
             break;
           case CodePush.SyncStatus.UP_TO_DATE:
             log("App is up to date.");
@@ -341,19 +341,19 @@ async function syncInternal(options = {}, syncStatusChangeCallback, downloadProg
   try {
     await CodePush.notifyApplicationReady();
 
-    syncStatusChangeCallback(CodePush.SyncStatus.CHECKING_FOR_UPDATE);
+    syncStatusChangeCallback(CodePush.SyncStatus.CHECKING_FOR_UPDATE, null);
     const remotePackage = await checkForUpdate(syncOptions.deploymentKey, handleBinaryVersionMismatchCallback);
 
     const doDownloadAndInstall = async () => {
-      syncStatusChangeCallback(CodePush.SyncStatus.DOWNLOADING_PACKAGE);
+      // Determine the correct install mode based on whether the update is mandatory or not.
+      resolvedInstallMode = remotePackage.isMandatory ? syncOptions.mandatoryInstallMode : syncOptions.installMode;
+
+      syncStatusChangeCallback(CodePush.SyncStatus.DOWNLOADING_PACKAGE, resolvedInstallMode);
       const localPackage = await remotePackage.download(downloadProgressCallback);
 
-      // Determine the correct install mode based on whether the update is mandatory or not.
-      resolvedInstallMode = localPackage.isMandatory ? syncOptions.mandatoryInstallMode : syncOptions.installMode;
-
-      syncStatusChangeCallback(CodePush.SyncStatus.INSTALLING_UPDATE);
+      syncStatusChangeCallback(CodePush.SyncStatus.INSTALLING_UPDATE, resolvedInstallMode);
       await localPackage.install(resolvedInstallMode, syncOptions.minimumBackgroundDuration, () => {
-        syncStatusChangeCallback(CodePush.SyncStatus.UPDATE_INSTALLED);
+        syncStatusChangeCallback(CodePush.SyncStatus.UPDATE_INSTALLED, null);
       });
 
       return CodePush.SyncStatus.UPDATE_INSTALLED;
@@ -367,10 +367,10 @@ async function syncInternal(options = {}, syncStatusChangeCallback, downloadProg
 
       const currentPackage = await CodePush.getCurrentPackage();
       if (currentPackage && currentPackage.isPending) {
-        syncStatusChangeCallback(CodePush.SyncStatus.UPDATE_INSTALLED);
+        syncStatusChangeCallback(CodePush.SyncStatus.UPDATE_INSTALLED, null);
         return CodePush.SyncStatus.UPDATE_INSTALLED;
       } else {
-        syncStatusChangeCallback(CodePush.SyncStatus.UP_TO_DATE);
+        syncStatusChangeCallback(CodePush.SyncStatus.UP_TO_DATE, null);
         return CodePush.SyncStatus.UP_TO_DATE;
       }
     } else if (syncOptions.updateDialog) {
@@ -403,7 +403,7 @@ async function syncInternal(options = {}, syncStatusChangeCallback, downloadProg
           dialogButtons.push({
             text: syncOptions.updateDialog.optionalIgnoreButtonLabel,
             onPress: () => {
-              syncStatusChangeCallback(CodePush.SyncStatus.UPDATE_IGNORED);
+              syncStatusChangeCallback(CodePush.SyncStatus.UPDATE_IGNORED, null);
               resolve(CodePush.SyncStatus.UPDATE_IGNORED);
             }
           });
@@ -415,14 +415,14 @@ async function syncInternal(options = {}, syncStatusChangeCallback, downloadProg
           message += `${syncOptions.updateDialog.descriptionPrefix} ${remotePackage.description}`;
         }
 
-        syncStatusChangeCallback(CodePush.SyncStatus.AWAITING_USER_ACTION);
+        syncStatusChangeCallback(CodePush.SyncStatus.AWAITING_USER_ACTION, null);
         Alert.alert(syncOptions.updateDialog.title, message, dialogButtons);
       });
     } else {
       return await doDownloadAndInstall();
     }
   } catch (error) {
-    syncStatusChangeCallback(CodePush.SyncStatus.UNKNOWN_ERROR);
+    syncStatusChangeCallback(CodePush.SyncStatus.UNKNOWN_ERROR, null);
     log(error.message);
     throw error;
   }


### PR DESCRIPTION
If a mandatory upgrade is being downloaded (and an app restart is thus imminent), it can be important to notify the user that this is the case. Strictly speaking, this is possible given react-native-code-push as-is, but it would require maintaining your own version of `syncInternal`, which has some fairly complex internal logic.

Here's an example higher-order component that uses this extra sync information to display an upgrade progress bar, but only if it will cause the app to restart: https://gist.github.com/RoboTeddy/64ffa4078d2f8178a7cb1555a547bc53

I haven't included docs or anything in this PR -- wanted first to check whether the maintainers are open to this feature.