### PR TITLE
Enable CodePush for react-native-windows v0.50+

### DIFF
--- a/docs/setup-windows.md
+++ b/docs/setup-windows.md
@@ -22,14 +22,14 @@ Once you've acquired the CodePush plugin, you need to integrate it into the Visu
 
 ### Plugin Configuration (Windows)
 
-After installing the plugin, you need to configure your app to consult CodePush for the location of your JS bundle, since it will "take control" of managing the current and all future versions. To do this, update the `AppReactPage.cs` file to use CodePush via the following changes:
+After installing the plugin, you need to configure your app to consult CodePush for the location of your JS bundle, since it will "take control" of managing the current and all future versions. To do this, update the `MainReactNativeHost.cs` file to use CodePush via the following changes:
 
 ```c#
 ...
 // 1. Import the CodePush namespace
 using CodePush.ReactNative;
 ...
-class AppReactPage : ReactPage
+class MainReactNativeHost : ReactNativeHost
 {
     // 2. Declare a private instance variable for the CodePushModule instance.
     private CodePushReactPackage codePushReactPackage;
@@ -38,7 +38,7 @@ class AppReactPage : ReactPage
     // specifying the right deployment key, then use it to return the bundle URL from
     // CodePush instead of statically from the binary. If you don't already have your
     // deployment key, you can run "code-push deployment ls <appName> -k" to retrieve it.
-    public override string JavaScriptBundleFile
+    protected override string JavaScriptBundleFile
     {
         get
         {
@@ -48,7 +48,7 @@ class AppReactPage : ReactPage
     }
 
     // 4. Add the codePushReactPackage instance to the list of existing packages.
-    public override List<IReactPackage> Packages
+    protected override List<IReactPackage> Packages
     {
         get
         {

--- a/windows/.gitignore
+++ b/windows/.gitignore
@@ -1,0 +1,78 @@
+*AppPackages*
+*BundleArtifacts*
+*ReactAssets*
+
+#OS junk files
+[Tt]humbs.db
+*.DS_Store
+
+#Visual Studio files
+*.[Oo]bj
+*.user
+*.aps
+*.pch
+*.vspscc
+*.vssscc
+*_i.c
+*_p.c
+*.ncb
+*.suo
+*.tlb
+*.tlh
+*.bak
+*.[Cc]ache
+*.ilk
+*.log
+*.lib
+*.sbr
+*.sdf
+*.opensdf
+*.opendb
+*.unsuccessfulbuild
+ipch/
+[Oo]bj/
+[Bb]in
+[Dd]ebug*/
+[Rr]elease*/
+Ankh.NoLoad
+
+#MonoDevelop
+*.pidb
+*.userprefs
+
+#Tooling
+_ReSharper*/
+*.resharper
+[Tt]est[Rr]esult*
+*.sass-cache
+
+#Project files
+[Bb]uild/
+
+#Subversion files
+.svn
+
+# Office Temp Files
+~$*
+
+# vim Temp Files
+*~
+
+#NuGet
+packages/
+*.nupkg
+
+#ncrunch
+*ncrunch*
+*crunch*.local.xml
+
+# visual studio database projects
+*.dbmdl
+
+#Test files
+*.testsettings
+
+#Other files
+*.DotSettings
+.vs/
+*project.lock.json

--- a/windows/.npmignore
+++ b/windows/.npmignore
@@ -1,0 +1,8 @@
+# Make sure we don't publish build artifacts to NPM
+ARM/
+Debug/
+x64/
+x86/
+bin/
+obj/
+.vs/

--- a/windows/CodePush.Shared/CodePushNativeModule.cs
+++ b/windows/CodePush.Shared/CodePushNativeModule.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 #if WINDOWS_UWP
 using Windows.Web.Http;
@@ -312,17 +313,7 @@ namespace CodePush.ReactNative
         {
             // #1) Get the private ReactInstanceManager, which is what includes
             //     the logic to reload the current React context.
-            FieldInfo info = typeof(ReactPage)
-                .GetField("_reactInstanceManager", BindingFlags.NonPublic | BindingFlags.Instance);
-#if WINDOWS_UWP
-            var reactInstanceManager = (ReactInstanceManager)typeof(ReactPage)
-                .GetField("_reactInstanceManager", BindingFlags.NonPublic | BindingFlags.Instance)
-                .GetValue(_codePush.MainPage);
-#else
-            var reactInstanceManager = ((Lazy<IReactInstanceManager>)typeof(ReactPage)
-                .GetField("_reactInstanceManager", BindingFlags.NonPublic | BindingFlags.Instance)
-                .GetValue(_codePush.MainPage)).Value as ReactInstanceManager;
-#endif
+            var reactInstanceManager = _codePush.ReactInstanceManager;
 
             // #2) Update the locally stored JS bundle file path
             Type reactInstanceManagerType = typeof(ReactInstanceManager);
@@ -332,7 +323,7 @@ namespace CodePush.ReactNative
                 .SetValue(reactInstanceManager, latestJSBundleFile);
 
             // #3) Get the context creation method and fire it on the UI thread (which RN enforces)
-            Context.RunOnDispatcherQueueThread(reactInstanceManager.RecreateReactContextInBackground);
+            Context.RunOnDispatcherQueueThread(() => reactInstanceManager.RecreateReactContextAsync(CancellationToken.None));
         }
     }
 }


### PR DESCRIPTION
In react-native-windows v0.50+, we added ReactNativeHost, which has better support for running React Native in the background as well as embedding React Native in other controls besides XAML Pages.

Please don't merge this until https://github.com/Microsoft/react-native-windows/pull/1445 is merged and react-native-windows v0.50 is released (I'll ping back here when that is the case).
