### PR TITLE
[docs] Add information about how to configure CodePush for applications using ReactInstanceManager.builder() to initialize RN

### DIFF
--- a/docs/setup-android.md
+++ b/docs/setup-android.md
@@ -66,6 +66,8 @@ After installing the plugin and syncing your Android Studio project with Gradle,
 
 **For React Native >= v0.29**
 
+If you are using React Native for the whole application please do the following:
+
 Update the `MainApplication.java` file to use CodePush via the following changes:
 
 ```java
@@ -104,6 +106,40 @@ public class MainApplication extends Application implements ReactApplication {
 @Override
 protected String getJSMainModuleName() {
     return "index";
+}
+```
+
+If you are integrating React Native into existing application please do the following:
+
+Update `MyReactActivity.java` (it could be named differently in you app) file to use CodePush via the following changes:
+
+```java
+...
+// 1. Import the plugin class.
+import com.microsoft.codepush.react.CodePush;
+
+public class MyReactActivity extends Activity {
+    private ReactRootView mReactRootView;
+    private ReactInstanceManager mReactInstanceManager;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        ...
+        mReactInstanceManager = ReactInstanceManager.builder()
+                // ...
+                // Add CodePush package
+                .addPackage(new CodePush("deployment-key-here", getApplicationContext(), BuildConfig.DEBUG))
+                // Get the JS Bundle File via Code Push
+                .setJSBundleFile(CodePush.getJSBundleFile())
+                // ...
+                
+                .build();
+        mReactRootView.startReactApplication(mReactInstanceManager, "MyReactNativeApp", null);
+
+        setContentView(mReactRootView);
+    }
+
+    ...
 }
 ```
 

--- a/docs/setup-android.md
+++ b/docs/setup-android.md
@@ -66,7 +66,7 @@ After installing the plugin and syncing your Android Studio project with Gradle,
 
 **For React Native >= v0.29**
 
-If you are using React Native for the whole application please do the following:
+If you are integrating Code Push into React Native application please do the following steps:
 
 Update the `MainApplication.java` file to use CodePush via the following changes:
 
@@ -109,9 +109,9 @@ protected String getJSMainModuleName() {
 }
 ```
 
-If you are integrating React Native into existing application please do the following:
+If you are integrating React Native into existing native application please do the following steps:
 
-Update `MyReactActivity.java` (it could be named differently in you app) file to use CodePush via the following changes:
+Update `MyReactActivity.java` (it could be named differently in your app) file to use CodePush via the following changes:
 
 ```java
 ...


### PR DESCRIPTION
RN beginners who is coming from [here](https://facebook.github.io/react-native/docs/integration-with-existing-apps.html) couldn't find information how to configure CodePush for existing android apps. This PR intends to fix this.
Also this PR relates to https://github.com/Microsoft/react-native-code-push/issues/970#issuecomment-326995052
