### PR TITLE
Fixed iOS codesigning

### DIFF
--- a/ios/CodePush/CodePushUpdateUtils.m
+++ b/ios/CodePush/CodePushUpdateUtils.m
@@ -303,7 +303,15 @@ NSString * const IgnoreCodePushMetadata = @".codepushrelease";
 
 + (NSString *)getSignatureFilePath:(NSString *)updateFolderPath
 {
-    return [NSString stringWithFormat:@"%@/%@/%@", updateFolderPath, ManifestFolderPrefix, BundleJWTFile];
+    NSString* signatureFilePath = [NSString stringWithFormat:@"%@/%@/%@", updateFolderPath, ManifestFolderPrefix, BundleJWTFile];
+  
+    if ([[NSFileManager defaultManager] fileExistsAtPath:signatureFilePath]) {
+      return signatureFilePath;
+    } else {
+      return [NSString stringWithFormat:@"%@/%@", updateFolderPath, [CodePushUpdateUtils findMainBundleInFolder:updateFolderPath
+                                                                                               expectedFileName:BundleJWTFile
+                                                                                                          error:nil]];
+    }
 }
 
 + (NSString *)getSignatureFor:(NSString *)folderPath


### PR DESCRIPTION
`getSignatureFilePath` wasn't able to find `.codepushrelease` file on iPad 4 with iOS 10.3.3 after downloading a bundle from appcenter.