### PR TITLE
Fix example project

### DIFF
--- a/Examples/CodePushDemoApp/App.js
+++ b/Examples/CodePushDemoApp/App.js
@@ -11,7 +11,7 @@ import {
 
 import CodePush from "react-native-code-push";
 
-export default class App extends Component<{}> {
+class App extends Component<{}> {
   constructor() {
     super();
     this.state = { restartAllowed: true };
@@ -158,3 +158,5 @@ const styles = StyleSheet.create({
 let codePushOptions = { checkFrequency: CodePush.CheckFrequency.MANUAL };
 
 App = CodePush(codePushOptions)(App);
+
+export default App;


### PR DESCRIPTION
Automatic (on_app_resume, on_app_start) sync was not working in example project because App class was exported, not the wrapped App class.