### PR TITLE
Allow setting the deploymentKey on Android

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -319,6 +319,10 @@ public class CodePush implements ReactPackage {
         return sTestConfigurationFlag;
     }
 
+    public void setDeploymentKey(String deploymentKey) {
+        mDeploymentKey = deploymentKey;
+    }
+
     public static void setUsingTestConfiguration(boolean shouldUseTestConfiguration) {
         sTestConfigurationFlag = shouldUseTestConfiguration;
     }


### PR DESCRIPTION
This adds Android support for setting the deployment key. A similar method aleady exists for iOS:
 https://github.com/Microsoft/react-native-code-push/blob/751bf02836f6af652cbd2d9f5a499444a5964a00/ios/CodePush/CodePush.m#L207-L210

Addresses #1073