### PR TITLE
Adding check for null ref before accessing array index

### DIFF
--- a/scripts/postlink/ios/postlink.js
+++ b/scripts/postlink/ios/postlink.js
@@ -43,6 +43,8 @@ module.exports = () => {
     var oldJsCodeLocationAssignmentStatement;
     if (jsCodeLocations) {
         oldJsCodeLocationAssignmentStatement = jsCodeLocations[1];
+    } else {
+        console.log('Couldn\'t find jsCodeLocation setting in AppDelegate.');
     }
     var newJsCodeLocationAssignmentStatement = "jsCodeLocation = [CodePush bundleURL];";
     if (~appDelegateContents.indexOf(newJsCodeLocationAssignmentStatement)) {

--- a/scripts/postlink/ios/postlink.js
+++ b/scripts/postlink/ios/postlink.js
@@ -39,7 +39,11 @@ module.exports = () => {
     }
 
     // 2. Modify jsCodeLocation value assignment
-    var oldJsCodeLocationAssignmentStatement = appDelegateContents.match(/(jsCodeLocation = .*)/)[1];
+    var jsCodeLocations = appDelegateContents.match(/(jsCodeLocation = .*)/);
+    var oldJsCodeLocationAssignmentStatement;
+    if (jsCodeLocations) {
+        oldJsCodeLocationAssignmentStatement = jsCodeLocations[1];
+    }
     var newJsCodeLocationAssignmentStatement = "jsCodeLocation = [CodePush bundleURL];";
     if (~appDelegateContents.indexOf(newJsCodeLocationAssignmentStatement)) {
         console.log(`"jsCodeLocation" already pointing to "[CodePush bundleURL]".`);


### PR DESCRIPTION
When running `react-native link`, I ran into a null reference error. To fix this error, I had to correct this script locally. I think this patch should be included to prevent other people from having this issue.