### PR TITLE
Fix a GetFileAsync exception due to forward slash path separators

### DIFF
--- a/windows/CodePush/UpdateUtils.cs
+++ b/windows/CodePush/UpdateUtils.cs
@@ -15,7 +15,7 @@ namespace CodePush.ReactNative
             var deletedFiles = (JArray)diffManifest["deletedFiles"];
             foreach (string fileNameToDelete in deletedFiles)
             {
-                StorageFile fileToDelete = await newPackageFolder.GetFileAsync(fileNameToDelete).AsTask().ConfigureAwait(false);
+                StorageFile fileToDelete = await newPackageFolder.GetFileAsync(fileNameToDelete.Replace("/", "\\")).AsTask().ConfigureAwait(false);
                 await fileToDelete.DeleteAsync().AsTask().ConfigureAwait(false);
             }
         }


### PR DESCRIPTION
I have a React Native UWP app (thcs) with react-native-code-push 5.2.1. This is the repo [https://github.com/MrMYHuang/thcs](url) for your reference. This is a part of its package.json:
```
  "dependencies": {
    "axios": "^0.17.1",
    "babel-core": "^7.0.0-beta.3",
    "buffer": "^5.0.8",
    "cheerio-without-node-native": "^0.20.2",
    "iconv-lite": "^0.4.19",
    "react": "16.0.0",
    "react-native": "~0.51.0",
    "react-native-code-push": "^5.2.1",
    "react-native-windows": "^0.51.0-rc.0",
    "react-navigation": "^1.0.0-beta.22",
    "react-redux": "^5.0.6",
    "react-test-renderer": "16.2.0",
    "redux": "^3.7.2",
    "redux-logger": "^3.0.6",
    "redux-promise-middleware": "^5.0.0",
    "redux-thunk": "^2.2.0",
    "stream": "^0.0.2"
  },
  "devDependencies": {
    "babel-jest": "22.0.4",
    "babel-plugin-transform-decorators": "^6.24.1",
    "babel-plugin-transform-decorators-legacy": "^1.3.4",
    "babel-preset-react-native": "4.0.0",
    "jest": "22.0.4",
    "rnpm-plugin-windows": "^0.2.8",
    "tslint": "^5.8.0",
    "typescript": "^2.6.2",
    "typings": "^2.1.1"
  },
```
I met a problem that after I installed my app thcs to Windows 10, I could codepush the JS bundle to my app ***ONCE***. However, if I codepush a new JS bundle the ***SECOND TIME***, restarting the app and you would find the JS bundle is ***NOT*** updated! After I debugged the CodePush C# codes, I found a ***GetFileAsync*** in ***windows/CodePush/UpdateUtils.cs*** throws exceptions, because its argument, fileNameToDelete, contains a path with ***forward slash characters***, e.g., 
```code-push1171128-20592-ocqg7u.pwr2n/index.windows.bundle```
Acctually, these forward slash paths come from hotcodepush.json during CodePush update...

Finally, I fixed this bug:
```fileNameToDelete```
by this:
```fileNameToDelete.Replace("/", "\\")```
