### PR TITLE
Fix TypeScript types: Describe function more so it works with Ramda too

### DIFF
--- a/typings/react-native-code-push.d.ts
+++ b/typings/react-native-code-push.d.ts
@@ -233,7 +233,7 @@ export interface StatusReport {
  *
  * @param options Options used to configure the end-user sync and update experience (e.g. when to check for updates?, show an prompt?, install the update immediately?).
  */
-declare function CodePush(options?: CodePushOptions): Function;
+declare function CodePush(options?: CodePushOptions): (x: any) => any;
 
 declare namespace CodePush {
     /**


### PR DESCRIPTION
I faced a problem when I was composing functions with [Ramda](http://ramdajs.com/)
I used `R.pipe` but same applies for `R.compose`. Imagine simple React component called `MyComponent`

I want to export my component but I want to enhance it with code push like [docs say](https://github.com/Microsoft/react-native-code-push#plugin-usage) like this:
`export default codePush({})(MyComponent)`. This works and like is good ✅ 

But when I have multiple enhance function for example `react-redux`'s `connect` function I would like then compose enhance functions with Ramda's `pipe`. So then my code would look like this
```js
export default R.pipe(
  codePush({}),
  connect(),
)(Main);
```
This does not work because of the wrong type I just fixed. I get error from Ramda's types: 🛑 
```
Argument of type 'Function' is not assignable to parameter of type '(x0: {}, x1: {}, x2: {}) => {}'.
  Type 'Function' provides no match for the signature '(x0: {}, x1: {}, x2: {}): {}'.
```


With my PR both ways work without a problem with TypeScript