### PR TITLE
Fix for IllegalStateException while CodePushUpdateManager.downloadPackage

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateManager.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateManager.java
@@ -163,11 +163,11 @@ public class CodePushUpdateManager {
         try {
             URL downloadUrl = new URL(downloadUrlString);
             connection = (HttpURLConnection) (downloadUrl.openConnection());
+            bin = new BufferedInputStream(connection.getInputStream());
 
             long totalBytes = connection.getContentLength();
             long receivedBytes = 0;
 
-            bin = new BufferedInputStream(connection.getInputStream());
             File downloadFolder = new File(getCodePushPath());
             downloadFolder.mkdirs();
             downloadFile = new File(downloadFolder, CodePushConstants.DOWNLOAD_FILE_NAME);


### PR DESCRIPTION
Fixes #1191

https://stackoverflow.com/questions/47919452/java-lang-illegalstateexception-cannot-access-request-header-fields-after-conne