### PR TITLE
[CocoaPods] Resolve dependencies at parent level

### DIFF
--- a/CodePush.podspec
+++ b/CodePush.podspec
@@ -3,7 +3,6 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-
   s.name           = 'CodePush'
   s.version        = package['version'].gsub(/v|-beta/, '')
   s.summary        = package['description']
@@ -15,26 +14,14 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
   s.preserve_paths = '*.js'
   s.library        = 'z'
+  s.source_files = 'ios/CodePush/*.{h,m}'
+  s.public_header_files = ['ios/CodePush/CodePush.h']
 
+  # Note: Even though there are copy/pasted versions of some of these dependencies in the repo, 
+  # we explicitly let CocoaPods pull in the versions below so all dependencies are resolved and 
+  # linked properly at a parent workspace level.
   s.dependency 'React'
-
-  s.subspec 'Core' do |ss|
-    ss.source_files = 'ios/CodePush/*.{h,m}'
-    ss.public_header_files = ['ios/CodePush/CodePush.h']
-  end
-
-  s.subspec 'SSZipArchive' do |ss|
-    ss.source_files = 'ios/CodePush/SSZipArchive/*.{h,m}', 'ios/CodePush/SSZipArchive/aes/*.{h,c}', 'ios/CodePush/SSZipArchive/minizip/*.{h,c}'
-    ss.private_header_files = 'ios/CodePush/SSZipArchive/*.h', 'ios/CodePush/SSZipArchive/aes/*.h', 'ios/CodePush/SSZipArchive/minizip/*.h'
-  end
-
-  s.subspec 'JWT' do |jwt|
-    jwt.source_files = 'ios/CodePush/JWT/**/*.{h,m}'
-    jwt.private_header_files = 'ios/CodePush/JWT/**/*.h'
-  end
-
-  s.subspec 'Base64' do |base64|
-    base64.source_files = 'ios/CodePush/Base64/**/*.{h,m}'
-    base64.private_header_files = 'ios/CodePush/Base64/**/*.h'
-  end
+  s.dependency 'SSZipArchive', '~> 2.1'
+  s.dependency 'JWT', '~> 3.0.0-beta.7'
+  s.dependency 'Base64', '~> 1.1'
 end

--- a/docs/setup-ios.md
+++ b/docs/setup-ios.md
@@ -38,21 +38,9 @@ And that's it! Isn't RNPM awesome? :)
     pod 'CodePush', :path => '../node_modules/react-native-code-push'
     ```
 
-    CodePush depends on an internal copy of the `SSZipArchive`, `JWT` and `Base64` libraries, so if your project already includes some of them (either directly or via a transitive dependency), then you can install a version of CodePush which excludes it by depending specifically on the needed subspecs:
+    *NOTE: The above path needs to be relative to your app's `Podfile`, so adjust it as necessary.*
 
-    ```ruby
-    # `SSZipArchive`, `JWT` and `Base64` already in use
-    pod 'CodePush', :path => '../node_modules/react-native-code-push', :subspecs => ['Core']
-
-    # or for example
-
-    # `SSZipArchive` and `Base64` already in use
-    pod 'CodePush', :path => '../node_modules/react-native-code-push', :subspecs => ['Core', 'JWT']
-    ```
-
-    *NOTE: The above paths needs to be relative to your app's `Podfile`, so adjust it as neccessary.*
-
-    *NOTE: `JWT` library should be of version 3.0.x*
+    *NOTE: `JWT` library should be >= version 3.0.x*
 
 2. Run `pod install`
 


### PR DESCRIPTION
## Issue

Subspecs should not be used as a means to add/remove 3rd party code that CodePush depends upon. It's meant only to add/remove features within a given library itself.

When other projects also rely upon those 3rd party libraries, subspecs break things because they don't allow you to do version resolving and dependency management like CocoaPods does by default.

## Changes

Instead of using subspecs that reference some local files in the repo, we let CocoaPods resolve dependencies based upon versions. Otherwise, you end up with very opaque linking errors trying to add/remove subspecs.

I would recommend using the same approach of using dependency resolving for all other installation methods like Carthage and leave manual installation as an "at your own risk" like it's meant to be.

## Update Instructions 

Updaters will just need to:
 - Update any of their Podfile's to remove references to the subspecs
 - Run `$ bundle exec pod update CodePush`
