### PR TITLE
Change download to use identity Accept-Encoding

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateManager.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateManager.java
@@ -163,6 +163,7 @@ public class CodePushUpdateManager {
         try {
             URL downloadUrl = new URL(downloadUrlString);
             connection = (HttpURLConnection) (downloadUrl.openConnection());
+            connection.setRequestProperty("Accept-Encoding", "identity");
             bin = new BufferedInputStream(connection.getInputStream());
 
             long totalBytes = connection.getContentLength();


### PR DESCRIPTION
If the server returns gzip encoding, the size check will fail because getContentLength() could potentially return -1 for gzipped content.