### PR TITLE
Fix catching IOException

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/FileUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/FileUtils.java
@@ -47,7 +47,7 @@ public class FileUtils {
                         if (fromBufferedStream != null) fromBufferedStream.close();
                         if (destStream != null) destStream.close();
                     } catch (IOException e) {
-                        throw new CodePushUnknownException("Error closing IO resources.", e);
+                        CodePushUtils.log("Error closing IO resources. " + e);
                     }
                 }
             }


### PR DESCRIPTION
Remove `throw` because we shouldn't break app in case if we can't close stream. 