### PR TITLE
Expose clearUpdates method to RN for purging downloaded packages

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -542,6 +542,7 @@ if (NativeCodePush) {
     sync,
     disallowRestart: RestartManager.disallow,
     allowRestart: RestartManager.allow,
+    clearUpdates: NativeCodePush.clearUpdates,
     InstallMode: {
       IMMEDIATE: NativeCodePush.codePushInstallModeImmediate, // Restart the app immediately
       ON_NEXT_RESTART: NativeCodePush.codePushInstallModeOnNextRestart, // Don't artificially restart the app. Allow the update to be "picked up" on the next app restart

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -535,4 +535,9 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
             }
         }
     }
+
+    @ReactMethod
+    public void clearUpdates() {
+        mCodePush.clearUpdates();
+    }
 }

--- a/docs/api-js.md
+++ b/docs/api-js.md
@@ -28,6 +28,8 @@ When you require `react-native-code-push`, the module object provides the follow
 
 * [sync](#codepushsync): Allows checking for an update, downloading it and installing it, all with a single call. Unless you need custom UI and/or behavior, we recommend most developers to use this method when integrating CodePush into their apps
 
+* [clearUpdates](#clearupdates): Clear all downloaded CodePush updates. This is useful when switching to a different deployment which may have an older release than the current package.
+
 #### codePush
 
 ```javascript

--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -209,8 +209,6 @@ static NSString *bundleResourceSubdirectory = nil;
     [CodePushConfig current].deploymentKey = deploymentKey;
 }
 
-#pragma mark - Test-only methods
-
 /*
  * WARNING: This cleans up all downloaded and pending updates.
  */
@@ -220,6 +218,8 @@ static NSString *bundleResourceSubdirectory = nil;
     [self removePendingUpdate];
     [self removeFailedUpdates];
 }
+
+#pragma mark - Test-only methods
 
 /*
  * This returns a boolean value indicating whether CodePush has
@@ -865,6 +865,14 @@ RCT_EXPORT_METHOD(restartApp:(BOOL)onlyIfUpdateIsPending
     }
 
     resolve(@(NO));
+}
+
+/*
+ * This method clears CodePush's downloaded updates.
+ * It is needed to switch to a different deployment if the current deployment is more recent.
+ */
+RCT_EXPORT_METHOD(clearUpdates) {
+    [CodePush clearUpdates];
 }
 
 #pragma mark - JavaScript-exported module methods (Private)

--- a/typings/react-native-code-push.d.ts
+++ b/typings/react-native-code-push.d.ts
@@ -274,6 +274,12 @@ declare namespace CodePush {
     function disallowRestart(): void;
 
     /**
+     * Clear all downloaded CodePush updates.
+     * This is useful when switching to a different deployment which may have an older release than the current package.
+     */
+    function clearUpdates(): void;
+
+    /**
      * Immediately restarts the app.
      *
      * @param onlyIfUpdateIsPending Indicates whether you want the restart to no-op if there isn't currently a pending update.


### PR DESCRIPTION
This is useful when changing to a deployment with an older version than
the currently installed package.

In our case, we need our QA team to be able to toggle between Staging and Production deployments, even if it means they're switching to an older release.  This patch gives us the option to clear downloaded updates when we change deployment keys, allowing us to consistently switch to the new deployment key.  This would not be needed if the desired behavior was to always upgrade to the newest versions and never downgrade to an older version, as might be desired in a "beta channel" situation with real users.

Thanks to @newyankeecodeshop for pointing out that this is possible here: https://github.com/Microsoft/react-native-code-push/issues/1244#issuecomment-378970595