### PR TITLE
Fix podspec

### DIFF
--- a/CodePush.podspec
+++ b/CodePush.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.license        = package['license']
   s.homepage       = package['homepage']
-  s.source         = { :git => 'https://github.com/Microsoft/react-native-code-push.git', :tag => "v#{s.version}-beta"}
+  s.source         = { :git => 'https://github.com/Microsoft/react-native-code-push.git', :tag => "v#{s.version}"}
   s.ios.deployment_target = '7.0'
   s.tvos.deployment_target = '9.0'
   s.preserve_paths = '*.js'


### PR DESCRIPTION
While integrating this library with my app following [these instructions](https://docs.microsoft.com/en-us/appcenter/distribution/codepush/react-native), I bumped into the following error when running `pod install`:

```
Cloning into '/var/folders/ky/1hj50wp95js61l32lwjd8m1m0000gn/T/d20180503-72388-1y7bkdn'...
warning: Could not find remote branch v5.3.2-beta to clone.
```

Indeed, the tag `5.3.2-beta` does not exist. Updating the podspec as done in this pull request fixes the issue.