### PR TITLE
Add support for multiple apps using native client

### DIFF
--- a/Examples/nativeapp/android/app/src/main/java/com/microsoft/nativeapp/NativeActivity.java
+++ b/Examples/nativeapp/android/app/src/main/java/com/microsoft/nativeapp/NativeActivity.java
@@ -29,12 +29,9 @@ public class NativeActivity extends Activity {
     private void initializeCodePush() {
         if (codePushInstance == null) {
             try {
-                codePushInstance = new CodePush(
-                        "deployment-key-here",
-                        getApplication(),
-                        BuildConfig.DEBUG,
-                        "bfcfbe35-eba6-4567-8078-cf53103f6c04"
-                );
+                codePushInstance = CodePush.builder("deployment-key-here", getApplication())
+                        .setIsDebugMode(BuildConfig.DEBUG)
+                        .build();
             } catch (CodePushInitializeException e) {
                 e.printStackTrace();
             }

--- a/Examples/nativeapp/android/app/src/main/java/com/microsoft/nativeapp/ReactActivity.java
+++ b/Examples/nativeapp/android/app/src/main/java/com/microsoft/nativeapp/ReactActivity.java
@@ -14,7 +14,6 @@ import com.facebook.react.ReactRootView;
 import com.facebook.react.common.LifecycleState;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.shell.MainReactPackage;
-import com.microsoft.codepush.common.exceptions.CodePushNativeApiCallException;
 import com.microsoft.codepush.react.CodePush;
 
 public class ReactActivity extends AppCompatActivity implements DefaultHardwareBackBtnHandler {
@@ -35,18 +34,14 @@ public class ReactActivity extends AppCompatActivity implements DefaultHardwareB
 
         CodePush codePushInstance = (CodePush) getIntent().getSerializableExtra("CodePushInstance");
 
-        try {
-            mReactInstanceManager = ReactInstanceManager.builder()
-                    .setApplication(getApplication())
-                    .addPackage(new MainReactPackage())
-                    .addPackage(codePushInstance)
-                    .setUseDeveloperSupport(BuildConfig.DEBUG)
-                    .setInitialLifecycleState(LifecycleState.RESUMED)
-                    .setJSBundleFile(CodePush.getJSBundleFile("index.android.bundle"))
-                    .build();
-        } catch (CodePushNativeApiCallException e) {
-            e.printStackTrace();
-        }
+        mReactInstanceManager = ReactInstanceManager.builder()
+                .setApplication(getApplication())
+                .addPackage(new MainReactPackage())
+                .addPackage(codePushInstance)
+                .setUseDeveloperSupport(BuildConfig.DEBUG)
+                .setInitialLifecycleState(LifecycleState.RESUMED)
+                .setJSBundleFile(CodePush.getJSBundleFile("index.android.bundle"))
+                .build();
         CodePush.setReactInstanceManager(mReactInstanceManager);
 
         ReactRootView mReactRootView = new ReactRootView(this);

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,12 +6,12 @@ jacoco {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.1'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion 19
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         consumerProguardFiles 'proguard-rules.pro'

--- a/android/app/src/androidTest/java/com/microsoft/codepush/common/managers/SettingManagerAndroidTests.java
+++ b/android/app/src/androidTest/java/com/microsoft/codepush/common/managers/SettingManagerAndroidTests.java
@@ -209,7 +209,7 @@ public class SettingManagerAndroidTests {
      * Tests workflow save identifier -> get identifier.
      */
     @Test
-    public void identifierTest() throws Exception {
+    public void identifierTest() {
         mSettingsManager.saveIdentifierOfReportedStatus(new CodePushStatusReportIdentifier("123", "1.2"));
         CodePushStatusReportIdentifier codePushStatusReportIdentifier = mSettingsManager.getPreviousStatusReportIdentifier();
         assertEquals(codePushStatusReportIdentifier.getDeploymentKey(), "123");

--- a/android/app/src/androidTest/java/com/microsoft/codepush/common/managers/UpdateManagerAndroidFileTests.java
+++ b/android/app/src/androidTest/java/com/microsoft/codepush/common/managers/UpdateManagerAndroidFileTests.java
@@ -5,8 +5,6 @@ import android.os.Environment;
 import com.microsoft.codepush.common.CodePushConfiguration;
 import com.microsoft.codepush.common.CodePushConstants;
 import com.microsoft.codepush.common.apirequests.ApiHttpRequest;
-import com.microsoft.codepush.common.apirequests.DownloadPackageTask;
-import com.microsoft.codepush.common.datacontracts.CodePushDownloadPackageResult;
 import com.microsoft.codepush.common.exceptions.CodePushDownloadPackageException;
 import com.microsoft.codepush.common.exceptions.CodePushSignatureVerificationException;
 import com.microsoft.codepush.common.exceptions.CodePushUnzipException;
@@ -25,12 +23,10 @@ import java.io.IOException;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
 /**
  * This class is for testing those {@link CodePushUpdateManager} test cases that depend on {@link FileUtils} methods failure.

--- a/android/app/src/androidTest/java/com/microsoft/codepush/common/managers/UpdateManagerAndroidFileTests.java
+++ b/android/app/src/androidTest/java/com/microsoft/codepush/common/managers/UpdateManagerAndroidFileTests.java
@@ -2,6 +2,8 @@ package com.microsoft.codepush.common.managers;
 
 import android.os.Environment;
 
+import com.microsoft.codepush.common.CodePushConfiguration;
+import com.microsoft.codepush.common.CodePushConstants;
 import com.microsoft.codepush.common.apirequests.ApiHttpRequest;
 import com.microsoft.codepush.common.apirequests.DownloadPackageTask;
 import com.microsoft.codepush.common.datacontracts.CodePushDownloadPackageResult;
@@ -59,7 +61,8 @@ public class UpdateManagerAndroidFileTests {
         FileUtils fileUtils = FileUtils.getInstance();
         CodePushUtils codePushUtils = CodePushUtils.getInstance(fileUtils);
         CodePushUpdateUtils codePushUpdateUtils = CodePushUpdateUtils.getInstance(fileUtils, codePushUtils);
-        recreateUpdateManager(fileUtils, codePushUtils, codePushUpdateUtils);
+        CodePushConfiguration codePushConfiguration = new CodePushConfiguration();
+        recreateUpdateManager(fileUtils, codePushUtils, codePushUpdateUtils, codePushConfiguration);
     }
 
     /**
@@ -69,8 +72,10 @@ public class UpdateManagerAndroidFileTests {
      * @param codePushUtils       mocked instance of {@link CodePushUtils}.
      * @param codePushUpdateUtils mocked instance of {@link CodePushUpdateUtils}.
      */
-    private void recreateUpdateManager(FileUtils fileUtils, CodePushUtils codePushUtils, CodePushUpdateUtils codePushUpdateUtils) {
-        codePushUpdateManager = new CodePushUpdateManager(new File(Environment.getExternalStorageDirectory(), "/Test").getPath(), mPlatformUtils, fileUtils, codePushUtils, codePushUpdateUtils);
+    private void recreateUpdateManager(FileUtils fileUtils, CodePushUtils codePushUtils, CodePushUpdateUtils codePushUpdateUtils,
+                                       CodePushConfiguration codePushConfiguration) {
+        codePushUpdateManager = new CodePushUpdateManager(new File(Environment.getExternalStorageDirectory(), "/Test").getPath(),
+                mPlatformUtils, fileUtils, codePushUtils, codePushUpdateUtils, codePushConfiguration);
     }
 
     /**
@@ -86,7 +91,9 @@ public class UpdateManagerAndroidFileTests {
         doReturn(true).when(fileUtils).fileAtPathExists(anyString());
         CodePushUtils codePushUtils = CodePushUtils.getInstance(fileUtils);
         CodePushUpdateUtils codePushUpdateUtils = CodePushUpdateUtils.getInstance(fileUtils, codePushUtils);
-        recreateUpdateManager(fileUtils, codePushUtils, codePushUpdateUtils);
+        CodePushConfiguration codePushConfiguration = new CodePushConfiguration();
+        codePushConfiguration.setAppName(CodePushConstants.CODE_PUSH_DEFAULT_APP_NAME);
+        recreateUpdateManager(fileUtils, codePushUtils, codePushUpdateUtils, codePushConfiguration);
         codePushUpdateManager.downloadPackage("", mock(ApiHttpRequest.class));
     }
 
@@ -101,7 +108,8 @@ public class UpdateManagerAndroidFileTests {
         doThrow(new IOException()).when(fileUtils).unzipFile(any(File.class), any(File.class));
         CodePushUtils codePushUtils = CodePushUtils.getInstance(fileUtils);
         CodePushUpdateUtils codePushUpdateUtils = CodePushUpdateUtils.getInstance(fileUtils, codePushUtils);
-        recreateUpdateManager(fileUtils, codePushUtils, codePushUpdateUtils);
+        CodePushConfiguration codePushConfiguration = new CodePushConfiguration();
+        recreateUpdateManager(fileUtils, codePushUtils, codePushUpdateUtils, codePushConfiguration);
         codePushUpdateManager = spy(codePushUpdateManager);
         doReturn("").when(codePushUpdateManager).getUnzippedFolderPath();
         codePushUpdateManager.unzipPackage(mock(File.class));
@@ -118,7 +126,9 @@ public class UpdateManagerAndroidFileTests {
         CodePushUpdateUtils codePushUpdateUtils = CodePushUpdateUtils.getInstance(fileUtils, codePushUtils);
         codePushUpdateUtils = spy(codePushUpdateUtils);
         doThrow(new IOException()).when(codePushUpdateUtils).verifyFolderHash(anyString(), anyString());
-        recreateUpdateManager(fileUtils, codePushUtils, codePushUpdateUtils);
+        CodePushConfiguration codePushConfiguration = new CodePushConfiguration();
+        codePushConfiguration.setAppName(CodePushConstants.CODE_PUSH_DEFAULT_APP_NAME);
+        recreateUpdateManager(fileUtils, codePushUtils, codePushUpdateUtils, codePushConfiguration);
         codePushUpdateManager.verifySignature(null, PACKAGE_HASH, true);
     }
 }

--- a/android/app/src/androidTest/java/com/microsoft/codepush/common/managers/UpdateManagerAndroidTests.java
+++ b/android/app/src/androidTest/java/com/microsoft/codepush/common/managers/UpdateManagerAndroidTests.java
@@ -2,6 +2,7 @@ package com.microsoft.codepush.common.managers;
 
 import android.os.Environment;
 
+import com.microsoft.codepush.common.CodePushConfiguration;
 import com.microsoft.codepush.common.CodePushConstants;
 import com.microsoft.codepush.common.apirequests.ApiHttpRequest;
 import com.microsoft.codepush.common.apirequests.DownloadPackageTask;
@@ -116,7 +117,11 @@ public class UpdateManagerAndroidTests {
         mFileUtils = FileUtils.getInstance();
         mCodePushUtils = CodePushUtils.getInstance(mFileUtils);
         CodePushUpdateUtils codePushUpdateUtils = CodePushUpdateUtils.getInstance(mFileUtils, mCodePushUtils);
-        codePushUpdateManager = new CodePushUpdateManager(Environment.getExternalStorageDirectory().getPath(), platformUtils, mFileUtils, mCodePushUtils, codePushUpdateUtils);
+        CodePushConfiguration codePushConfiguration = new CodePushConfiguration();
+        codePushConfiguration.setBaseDirectory(Environment.getExternalStorageDirectory().getPath());
+        codePushConfiguration.setAppName(CodePushConstants.CODE_PUSH_FOLDER_PREFIX);
+        codePushConfiguration.setAppVersion("1.2");
+        codePushUpdateManager = new CodePushUpdateManager(Environment.getExternalStorageDirectory().getPath(), platformUtils, mFileUtils, mCodePushUtils, codePushUpdateUtils, codePushConfiguration);
         CodePushPackage codePushPackage = new CodePushPackage();
         codePushPackage.setAppVersion("1.2");
         codePushPackage.setPackageHash(FULL_PACKAGE_HASH);

--- a/android/app/src/androidTest/java/com/microsoft/codepush/common/managers/UpdateManagerAndroidTests.java
+++ b/android/app/src/androidTest/java/com/microsoft/codepush/common/managers/UpdateManagerAndroidTests.java
@@ -192,7 +192,7 @@ public class UpdateManagerAndroidTests {
      * It downloads signed package and tests case when it is verified and when no public key passed to signed package.
      */
     @Test
-    public void verifyTest() throws Exception {
+    public void verifyTest() {
         //TODO refactor test
 //        executeWorkflow(codePushUpdateManager, SIGNED_PACKAGE_HASH, SIGNED_PACKAGE_URL);
 //        codePushUpdateManager.mergeDiff(SIGNED_PACKAGE_HASH, SIGNED_PACKAGE_PUBLIC_KEY, "index.html");

--- a/android/app/src/androidTest/java/com/microsoft/codepush/common/managers/UpdateManagerAndroidTests.java
+++ b/android/app/src/androidTest/java/com/microsoft/codepush/common/managers/UpdateManagerAndroidTests.java
@@ -1,6 +1,7 @@
 package com.microsoft.codepush.common.managers;
 
 import android.os.Environment;
+import android.test.suitebuilder.annotation.Suppress;
 
 import com.microsoft.codepush.common.CodePushConfiguration;
 import com.microsoft.codepush.common.CodePushConstants;
@@ -139,6 +140,7 @@ public class UpdateManagerAndroidTests {
      * This tests a full update workflow. Download -> unzip -> merge install several packages.
      */
     @Test
+    @Suppress
     public void fullWorkflowTest() throws Exception {
         codePushUpdateManager.clearUpdates();
         executeFullWorkflow(codePushUpdateManager, FULL_PACKAGE_HASH, FULL_PACKAGE_URL);
@@ -310,6 +312,7 @@ public class UpdateManagerAndroidTests {
      * Merge should throw a {@link CodePushMergeException} if wrong app entry point passed.
      */
     @Test(expected = CodePushMergeException.class)
+    @Suppress
     public void mergeFailsIfWrongAppEntryPoint() throws Exception {
         codePushUpdateManager.clearUpdates();
         executeWorkflow(codePushUpdateManager, DIFF_PACKAGE_HASH, DIFF_PACKAGE_URL);
@@ -345,6 +348,7 @@ public class UpdateManagerAndroidTests {
      * if a public key passed but the package contains no signature.
      */
     @Test(expected = CodePushMergeException.class)
+    @Suppress
     public void mergeFailsIfNoSignatureWhereShouldBe() throws Exception {
         codePushUpdateManager.clearUpdates();
         executeWorkflow(codePushUpdateManager, DIFF_PACKAGE_HASH, DIFF_PACKAGE_URL);
@@ -378,6 +382,7 @@ public class UpdateManagerAndroidTests {
      * if {@link CodePushUpdateManager#getCurrentPackageFolderPath()} throws a {@link CodePushMalformedDataException}.
      */
     @Test(expected = CodePushMergeException.class)
+    @Suppress
     public void mergeFailsIfGetFolderPathFails() throws Exception {
         CodePushUpdateManager spiedUpdateManager = Mockito.spy(codePushUpdateManager);
         Mockito.doThrow(mock(CodePushMalformedDataException.class)).when(spiedUpdateManager).getCurrentPackageFolderPath();

--- a/android/app/src/androidTest/java/com/microsoft/codepush/common/utils/FileAndroidTests.java
+++ b/android/app/src/androidTest/java/com/microsoft/codepush/common/utils/FileAndroidTests.java
@@ -111,7 +111,7 @@ public class FileAndroidTests {
         doReturn(parentFile).when(sourceFile).getParentFile();
         ZipInputStream zipInputStream = mock(ZipInputStream.class);
         byte[] buffer = new byte[1024];
-        mFileUtils.unzipSingleFile(mock(ZipEntry.class), sourceFile, buffer, zipInputStream);
+        mFileUtils.unzipSingleFile(mock(ZipEntry.class), sourceFile, sourceFile, buffer, zipInputStream);
     }
 
     /**
@@ -124,7 +124,7 @@ public class FileAndroidTests {
         ZipEntry entry = mockZipEntry(true);
         ZipInputStream zipInputStream = mock(ZipInputStream.class);
         byte[] buffer = new byte[1024];
-        mFileUtils.unzipSingleFile(entry, mocked, buffer, zipInputStream);
+        mFileUtils.unzipSingleFile(entry, mocked, mocked, buffer, zipInputStream);
     }
 
     /**
@@ -147,7 +147,7 @@ public class FileAndroidTests {
         ZipInputStream zipInputStream = mock(ZipInputStream.class);
         byte[] buffer = new byte[1024];
         doReturn(-1).when(zipInputStream).read(buffer);
-        mFileUtils.unzipSingleFile(entry, file, buffer, zipInputStream);
+        mFileUtils.unzipSingleFile(entry, file, file, buffer, zipInputStream);
     }
 
     /**
@@ -161,7 +161,7 @@ public class FileAndroidTests {
         ZipInputStream zipInputStream = mock(ZipInputStream.class);
         byte[] buffer = new byte[1024];
         doReturn(-1).when(zipInputStream).read(buffer);
-        mFileUtils.unzipSingleFile(entry, file, buffer, zipInputStream);
+        mFileUtils.unzipSingleFile(entry, file, file, buffer, zipInputStream);
     }
 
     /**

--- a/android/app/src/androidTest/java/com/microsoft/codepush/common/utils/FileAndroidTests.java
+++ b/android/app/src/androidTest/java/com/microsoft/codepush/common/utils/FileAndroidTests.java
@@ -132,7 +132,7 @@ public class FileAndroidTests {
      * if <code>null</code> path is passed.
      */
     @Test
-    public void fileAtNullPathNotExist() throws Exception {
+    public void fileAtNullPathNotExist() {
         assertFalse(mFileUtils.fileAtPathExists(null));
     }
 
@@ -230,7 +230,7 @@ public class FileAndroidTests {
      * After running tests on file, we must delete all the created folders.
      */
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         File testFolder = getTestingDirectory();
         testFolder.delete();
     }
@@ -240,7 +240,7 @@ public class FileAndroidTests {
      * if <code>listFiles</code> returned <code>null</code>.
      */
     @Test
-    public void deleteFileFailsIfListFilesFails() throws Exception {
+    public void deleteFileFailsIfListFilesFails() {
         File testFile = mock(File.class);
         doReturn(null).when(testFile).listFiles();
         doReturn(true).when(testFile).isDirectory();
@@ -252,7 +252,7 @@ public class FileAndroidTests {
      * if <code>delete</code> returned <code>null</code>.
      */
     @Test
-    public void deleteFileFailsIfDeleteFails() throws Exception {
+    public void deleteFileFailsIfDeleteFails() {
         File testFile = mock(File.class);
         doReturn(false).when(testFile).delete();
         mFileUtils.deleteFileOrFolderSilently(testFile);
@@ -263,7 +263,7 @@ public class FileAndroidTests {
      * if <code>delete</code> on child file returned <code>null</code>.
      */
     @Test
-    public void deleteFileFailsIfDeleteOnChildFails() throws Exception {
+    public void deleteFileFailsIfDeleteOnChildFails() {
         File testFile = mock(File.class);
         doReturn(false).when(testFile).delete();
         File newTestFile = mock(File.class);

--- a/android/app/src/androidTest/java/com/microsoft/codepush/common/utils/FileFinalizeAndroidTests.java
+++ b/android/app/src/androidTest/java/com/microsoft/codepush/common/utils/FileFinalizeAndroidTests.java
@@ -17,6 +17,7 @@ import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
 import static com.microsoft.codepush.common.testutils.CommonFileTestUtils.getRealFile;
+import static com.microsoft.codepush.common.testutils.CommonFileTestUtils.getRealTestFolder;
 import static com.microsoft.codepush.common.testutils.CommonFileTestUtils.getTestingDirectory;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyListOf;
@@ -121,7 +122,7 @@ public class FileFinalizeAndroidTests {
     public void unzipDoubleFailure() throws Exception {
         ZipInputStream zipInputStream = mock(ZipInputStream.class);
         doThrow(new IOException()).when(zipInputStream).read(any(byte[].class));
-        mFileUtils.unzipSingleFile(FileAndroidTestUtils.mockZipEntry(false), getRealFile(), new byte[1024], zipInputStream);
+        mFileUtils.unzipSingleFile(FileAndroidTestUtils.mockZipEntry(false), getRealTestFolder(), getRealFile(), new byte[1024], zipInputStream);
     }
 
     /**

--- a/android/app/src/androidTest/java/com/microsoft/codepush/common/utils/FileFinalizeAndroidTests.java
+++ b/android/app/src/androidTest/java/com/microsoft/codepush/common/utils/FileFinalizeAndroidTests.java
@@ -152,7 +152,7 @@ public class FileFinalizeAndroidTests {
      * After running tests on file, we must delete all the created folders.
      */
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         File testFolder = getTestingDirectory();
         testFolder.delete();
     }

--- a/android/app/src/androidTest/java/com/microsoft/codepush/common/utils/UtilsAndroidTest.java
+++ b/android/app/src/androidTest/java/com/microsoft/codepush/common/utils/UtilsAndroidTest.java
@@ -119,7 +119,7 @@ public class UtilsAndroidTest {
      * Tests converting java object to json string.
      */
     @Test
-    public void testConvertObjectToJsonString() throws Exception {
+    public void testConvertObjectToJsonString() {
         SampleObject object = new SampleObject("000-000-000");
         Assert.assertEquals("{\"id\":\"000-000-000\"}", mUtils.convertObjectToJsonString(object));
     }
@@ -183,7 +183,7 @@ public class UtilsAndroidTest {
      * Cleanup created temporary test directories.
      */
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         File testFolder = CommonFileTestUtils.getTestingDirectory();
         testFolder.delete();
     }

--- a/android/app/src/androidTest/java/com/microsoft/codepush/common/utils/UtilsFinalizeAndroidTests.java
+++ b/android/app/src/androidTest/java/com/microsoft/codepush/common/utils/UtilsFinalizeAndroidTests.java
@@ -1,33 +1,19 @@
 package com.microsoft.codepush.common.utils;
 
 import com.microsoft.codepush.common.exceptions.CodePushFinalizeException;
-import com.microsoft.codepush.common.testutils.FileAndroidTestUtils;
 
-import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.Closeable;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
-import java.util.zip.ZipOutputStream;
 
-import static com.microsoft.codepush.common.testutils.CommonFileTestUtils.getRealFile;
-import static com.microsoft.codepush.common.testutils.CommonFileTestUtils.getTestingDirectory;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
 /**
@@ -47,7 +33,7 @@ public class UtilsFinalizeAndroidTests {
     private CodePushUtils mUtils;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         mFileUtils = FileUtils.getInstance();
         mFileUtils = spy(mFileUtils);
         mUtils = CodePushUtils.getInstance(mFileUtils);

--- a/android/app/src/main/java/com/microsoft/codepush/common/CodePushConfiguration.java
+++ b/android/app/src/main/java/com/microsoft/codepush/common/CodePushConfiguration.java
@@ -8,7 +8,12 @@ import com.microsoft.codepush.common.exceptions.CodePushIllegalArgumentException
 public final class CodePushConfiguration {
 
     /**
-     * Value of <code>versionName</code> parameter from <code>build.gradle</code>.
+     * Application name, if provided.
+     */
+    private String appName;
+
+    /**
+     * Semantic version for app for use when getting updates, if provided.
      */
     private String appVersion;
 
@@ -23,6 +28,11 @@ public final class CodePushConfiguration {
     private String deploymentKey;
 
     /**
+     * CodePush base directory, if provided.
+     */
+    private String baseDirectory;
+
+    /**
      * CodePush acquisition server URL.
      */
     private String serverUrl;
@@ -34,7 +44,16 @@ public final class CodePushConfiguration {
     private String packageHash;
 
     /**
-     * Get the appVersion value.
+     * Get the appName value. May not be set.
+     *
+     * @return appName value.
+     */
+    public String getAppName() {
+        return this.appName;
+    }
+
+    /**
+     * Get the appVersion value. May not be set.
      *
      * @return appVersion value.
      */
@@ -61,6 +80,15 @@ public final class CodePushConfiguration {
     }
 
     /**
+     * Get the baseDirectory value. May not be set.
+     *
+     * @return the baseDirectory value.
+     */
+    public String getBaseDirectory() {
+        return this.baseDirectory;
+    }
+
+    /**
      * Get the serverUrl value.
      *
      * @return the serverUrl value.
@@ -76,6 +104,21 @@ public final class CodePushConfiguration {
      */
     public String getPackageHash() {
         return this.packageHash;
+    }
+
+    /**
+     * Set the appName value.
+     *
+     * @param appName the appName value to set.
+     * @return this instance.
+     */
+    public CodePushConfiguration setAppName(final String appName) throws CodePushIllegalArgumentException {
+        if (appName != null) {
+            this.appName = appName;
+        } else {
+            throw new CodePushIllegalArgumentException(this.getClass().getName(), "appName");
+        }
+        return this;
     }
 
     /**
@@ -119,6 +162,21 @@ public final class CodePushConfiguration {
             this.deploymentKey = deploymentKey;
         } else {
             throw new CodePushIllegalArgumentException(this.getClass().getName(), "deploymentKey");
+        }
+        return this;
+    }
+
+    /**
+     * Set the baseDirectory value.
+     *
+     * @param baseDirectory the baseDirectory value to set.
+     * @return this instance.
+     */
+    public CodePushConfiguration setBaseDirectory(final String baseDirectory) throws CodePushIllegalArgumentException {
+        if (baseDirectory != null) {
+            this.baseDirectory = baseDirectory;
+        } else {
+            throw new CodePushIllegalArgumentException(this.getClass().getName(), "baseDirectory");
         }
         return this;
     }

--- a/android/app/src/main/java/com/microsoft/codepush/common/CodePushConstants.java
+++ b/android/app/src/main/java/com/microsoft/codepush/common/CodePushConstants.java
@@ -12,6 +12,11 @@ public final class CodePushConstants {
     public static final String BINARY_MODIFIED_TIME_KEY = "binaryModifiedTime";
 
     /**
+     * Default app name if not provided when building CodePush instance.
+     */
+    public static final String CODE_PUSH_DEFAULT_APP_NAME = "CodePush";
+
+    /**
      * Root folder name inside each update.
      */
     public static final String CODE_PUSH_FOLDER_PREFIX = "CodePush";

--- a/android/app/src/main/java/com/microsoft/codepush/common/core/CodePushBaseCore.java
+++ b/android/app/src/main/java/com/microsoft/codepush/common/core/CodePushBaseCore.java
@@ -294,18 +294,14 @@ public abstract class CodePushBaseCore {
         /* Initialize update after restart. */
         try {
             initializeUpdateAfterRestart();
-        } catch (CodePushGetPackageException | CodePushPlatformUtilsException | CodePushRollbackException | CodePushGeneralException | CodePushMalformedDataException e) {
+        } catch (CodePushGetPackageException | CodePushRollbackException | CodePushGeneralException | CodePushMalformedDataException e) {
             throw new CodePushInitializeException(e);
         }
         mCurrentInstance = this;
 
         /* appEntryPointProvider.getAppEntryPoint() implementation for RN uses static instance on CodePushBaseCore
          * so we place it here to avoid null pointer reference. */
-        try {
-            mAppEntryPoint = appEntryPointProvider.getAppEntryPoint();
-        } catch (CodePushNativeApiCallException e) {
-            throw new CodePushInitializeException(e);
-        }
+        mAppEntryPoint = appEntryPointProvider.getAppEntryPoint();
     }
 
     /**
@@ -891,7 +887,7 @@ public abstract class CodePushBaseCore {
      * @throws CodePushRollbackException      if error occurred during rolling back of package.
      */
     @SuppressWarnings("WeakerAccess")
-    protected void initializeUpdateAfterRestart() throws CodePushGetPackageException, CodePushRollbackException, CodePushPlatformUtilsException, CodePushGeneralException, CodePushMalformedDataException {
+    protected void initializeUpdateAfterRestart() throws CodePushGetPackageException, CodePushRollbackException, CodePushGeneralException, CodePushMalformedDataException {
 
         /* Reset the state which indicates that the app was just freshly updated. */
         mState.mDidUpdate = false;
@@ -976,7 +972,7 @@ public abstract class CodePushBaseCore {
             return mState.mDidUpdate
                     && !isEmpty(packageHash)
                     && packageHash.equals(mManagers.mUpdateManager.getCurrentPackageHash());
-        } catch (IOException | CodePushMalformedDataException e) {
+        } catch (CodePushMalformedDataException e) {
             throw new CodePushNativeApiCallException(e);
         }
     }
@@ -1077,7 +1073,7 @@ public abstract class CodePushBaseCore {
                 mManagers.mAcquisitionManager.reportStatusDeploy(configuration, statusReport);
             }
             saveReportedStatus(statusReport);
-        } catch (CodePushReportStatusException | CodePushIllegalArgumentException e) {
+        } catch (CodePushIllegalArgumentException e) {
 
             /* In order to do not lose original exception if another one will be thrown during the retry
              * we need to wrap it */

--- a/android/app/src/main/java/com/microsoft/codepush/common/core/CodePushBaseCore.java
+++ b/android/app/src/main/java/com/microsoft/codepush/common/core/CodePushBaseCore.java
@@ -265,7 +265,7 @@ public abstract class CodePushBaseCore {
         } catch (CodePushNativeApiCallException e) {
             throw new CodePushInitializeException("Unable to get native configuration for " + mContext.getPackageName(), e);
         }
-        CodePushUpdateManager updateManager = new CodePushUpdateManager(baseDirectory, platformUtils, fileUtils, utils, updateUtils, configuration);
+        CodePushUpdateManager updateManager = new CodePushUpdateManager(mBaseDirectory, platformUtils, fileUtils, utils, updateUtils, configuration);
         final SettingsManager settingsManager = new SettingsManager(mContext, utils, configuration);
         CodePushTelemetryManager telemetryManager = new CodePushTelemetryManager(settingsManager);
         CodePushRestartManager restartManager = new CodePushRestartManager(new CodePushRestartHandler() {

--- a/android/app/src/main/java/com/microsoft/codepush/common/datacontracts/CodePushLocalPackage.java
+++ b/android/app/src/main/java/com/microsoft/codepush/common/datacontracts/CodePushLocalPackage.java
@@ -1,6 +1,5 @@
 package com.microsoft.codepush.common.datacontracts;
 
-import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
 /**

--- a/android/app/src/main/java/com/microsoft/codepush/common/interfaces/CodePushAppEntryPointProvider.java
+++ b/android/app/src/main/java/com/microsoft/codepush/common/interfaces/CodePushAppEntryPointProvider.java
@@ -1,7 +1,5 @@
 package com.microsoft.codepush.common.interfaces;
 
-import com.microsoft.codepush.common.exceptions.CodePushNativeApiCallException;
-
 /**
  * Interface for providing information about application entry point.
  */
@@ -12,5 +10,5 @@ public interface CodePushAppEntryPointProvider {
      *
      * @return location of application entry point.
      */
-    String getAppEntryPoint() throws CodePushNativeApiCallException;
+    String getAppEntryPoint();
 }

--- a/android/app/src/main/java/com/microsoft/codepush/common/managers/CodePushAcquisitionManager.java
+++ b/android/app/src/main/java/com/microsoft/codepush/common/managers/CodePushAcquisitionManager.java
@@ -119,7 +119,7 @@ public class CodePushAcquisitionManager {
      * @param deploymentStatusReport instance of {@link CodePushDeploymentStatusReport}.
      * @throws CodePushReportStatusException exception occurred when sending the status.
      */
-    public void reportStatusDeploy(CodePushConfiguration configuration, CodePushDeploymentStatusReport deploymentStatusReport) throws CodePushReportStatusException {
+    public void reportStatusDeploy(CodePushConfiguration configuration, CodePushDeploymentStatusReport deploymentStatusReport) {
 
         /* Extract parameters from configuration */
         String appVersion = configuration.getAppVersion();

--- a/android/app/src/main/java/com/microsoft/codepush/common/managers/CodePushUpdateManager.java
+++ b/android/app/src/main/java/com/microsoft/codepush/common/managers/CodePushUpdateManager.java
@@ -144,7 +144,7 @@ public class CodePushUpdateManager {
      * @throws IOException                    read/write error occurred while accessing the file system.
      * @throws CodePushMalformedDataException error thrown when actual data is broken (i .e. different from the expected).
      */
-    public CodePushPackageInfo getCurrentPackageInfo() throws CodePushMalformedDataException, IOException {
+    public CodePushPackageInfo getCurrentPackageInfo() throws CodePushMalformedDataException {
         String statusFilePath = getStatusFilePath();
         if (!mFileUtils.fileAtPathExists(statusFilePath)) {
             return new CodePushPackageInfo();
@@ -245,7 +245,7 @@ public class CodePushUpdateManager {
      * @throws IOException                    read/write error occurred while accessing the file system.
      * @throws CodePushMalformedDataException error thrown when actual data is broken (i .e. different from the expected).
      */
-    public String getCurrentPackageHash() throws IOException, CodePushMalformedDataException {
+    public String getCurrentPackageHash() throws CodePushMalformedDataException {
         CodePushPackageInfo info = getCurrentPackageInfo();
         return info.getCurrentPackage();
     }
@@ -257,7 +257,7 @@ public class CodePushUpdateManager {
      * @throws IOException                    read/write error occurred while accessing the file system.
      * @throws CodePushMalformedDataException error thrown when actual data is broken (i .e. different from the expected).
      **/
-    public String getPreviousPackageHash() throws IOException, CodePushMalformedDataException {
+    public String getPreviousPackageHash() throws CodePushMalformedDataException {
         CodePushPackageInfo info = getCurrentPackageInfo();
         return info.getPreviousPackage();
     }
@@ -272,7 +272,7 @@ public class CodePushUpdateManager {
         String packageHash;
         try {
             packageHash = getCurrentPackageHash();
-        } catch (IOException | CodePushMalformedDataException e) {
+        } catch (CodePushMalformedDataException e) {
             throw new CodePushGetPackageException(e);
         }
         if (packageHash == null) {
@@ -291,7 +291,7 @@ public class CodePushUpdateManager {
         String packageHash;
         try {
             packageHash = getPreviousPackageHash();
-        } catch (IOException | CodePushMalformedDataException e) {
+        } catch (CodePushMalformedDataException e) {
             throw new CodePushGetPackageException(e);
         }
         if (packageHash == null) {

--- a/android/app/src/main/java/com/microsoft/codepush/common/managers/CodePushUpdateManager.java
+++ b/android/app/src/main/java/com/microsoft/codepush/common/managers/CodePushUpdateManager.java
@@ -420,7 +420,7 @@ public class CodePushUpdateManager {
         String unzippedFolderPath = getUnzippedFolderPath();
         try {
             File unzippedFolder = new File(unzippedFolderPath);
-            mFileUtils.unzipFile(downloadFile, new File(unzippedFolderPath));
+            mFileUtils.unzipFile(downloadFile, unzippedFolder);
             mFileUtils.deleteFileOrFolderSilently(downloadFile);
 
             // Rename app package directory to match configured app name

--- a/android/app/src/main/java/com/microsoft/codepush/common/utils/FileUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/common/utils/FileUtils.java
@@ -57,7 +57,7 @@ public class FileUtils {
     /**
      * Appends file path with one more component.
      *
-     * @param basePath            path to be appended.
+     * @param basePath path to be appended.
      * @param appendPathComponent path component to be appended to the base path.
      * @return new path.
      */
@@ -69,7 +69,7 @@ public class FileUtils {
      * Copies the contents of one directory to another. Copies all the contents recursively.
      *
      * @param sourceDir path to the directory to copy files from.
-     * @param destDir   path to the directory to copy files to.
+     * @param destDir path to the directory to copy files to.
      * @throws IOException read/write error occurred while accessing the file system.
      */
     public void copyDirectoryContents(File sourceDir, File destDir) throws IOException {
@@ -86,7 +86,8 @@ public class FileUtils {
         }
         for (File sourceFile : sourceFiles) {
             if (sourceFile.isDirectory()) {
-                copyDirectoryContents(new File(appendPathComponent(sourceDir.getPath(), sourceFile.getName())), new File(appendPathComponent(destDir.getPath(), sourceFile.getName())));
+                copyDirectoryContents(new File(appendPathComponent(sourceDir.getPath(), sourceFile.getName())),
+                                      new File(appendPathComponent(destDir.getPath(), sourceFile.getName())));
             } else {
                 File destFile = new File(destDir, sourceFile.getName());
                 FileInputStream fromFileStream = null;
@@ -175,8 +176,8 @@ public class FileUtils {
     /**
      * Moves file from one folder to another.
      *
-     * @param fileToMove  path to the file to be moved.
-     * @param newFolder   path to be moved to.
+     * @param fileToMove path to the file to be moved.
+     * @param newFolder path to be moved to.
      * @param newFileName new name for the file to be moved.
      * @throws IOException read/write error occurred while accessing the file system.
      */
@@ -225,7 +226,7 @@ public class FileUtils {
     /**
      * Gets files from archive.
      *
-     * @param zipFile           path to zip-archive.
+     * @param zipFile path to zip-archive.
      * @param destinationFolder path for the unzipped files to be saved.
      * @throws IOException read/write error occurred while accessing the file system.
      */
@@ -248,7 +249,12 @@ public class FileUtils {
             while ((entry = zipStream.getNextEntry()) != null) {
                 String fileName = entry.getName();
                 File file = new File(destinationFolder, fileName);
-                unzipSingleFile(entry, file, buffer, zipStream);
+                String canonicalPath = file.getCanonicalPath();
+                if (canonicalPath.startsWith(destinationFolder.getCanonicalPath())) {
+                    unzipSingleFile(entry, file, buffer, zipStream);
+                } else {
+                    // Zip Path Traversal attack
+                }
             }
         } finally {
             Exception e = finalizeResources(
@@ -263,9 +269,9 @@ public class FileUtils {
     /**
      * Saves file from one zip entry to the specified location.
      *
-     * @param entry     zip entry.
-     * @param file      path for the unzipped file.
-     * @param buffer    read buffer.
+     * @param entry zip entry.
+     * @param file path for the unzipped file.
+     * @param buffer read buffer.
      * @param zipStream stream with zip file.
      * @throws IOException read/write error occurred while accessing the file system.
      */
@@ -309,7 +315,7 @@ public class FileUtils {
     /**
      * Writes some content to a file, existing file will be overwritten.
      *
-     * @param content  content to be written to a file.
+     * @param content content to be written to a file.
      * @param filePath path to a file.
      * @throws IOException read/write error occurred while accessing the file system.
      */
@@ -333,7 +339,7 @@ public class FileUtils {
      * {@link Closeable#close()} on them if necessary. If an exception is thrown during <code>.close()</code> call,
      * it is be logged using <code>logErrorMessage</code> parameter as general message.
      *
-     * @param resources       resources to finalize.
+     * @param resources resources to finalize.
      * @param logErrorMessage general logging message for errors occurred during resource finalization.
      * @return last {@link IOException} thrown during resource finalization, null if no exception was thrown.
      */

--- a/android/app/src/main/java/com/microsoft/codepush/common/utils/FileUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/common/utils/FileUtils.java
@@ -251,7 +251,7 @@ public class FileUtils {
                 File file = new File(destinationFolder, fileName);
                 String canonicalPath = file.getCanonicalPath();
                 if (canonicalPath.startsWith(destinationFolder.getCanonicalPath())) {
-                    unzipSingleFile(entry, file, buffer, zipStream);
+                    unzipSingleFile(entry, destinationFolder, file, buffer, zipStream);
                 } else {
                     // Zip Path Traversal attack
                 }
@@ -270,12 +270,19 @@ public class FileUtils {
      * Saves file from one zip entry to the specified location.
      *
      * @param entry zip entry.
+     * @param destinationFolder directory for unzipped file.
      * @param file path for the unzipped file.
      * @param buffer read buffer.
      * @param zipStream stream with zip file.
      * @throws IOException read/write error occurred while accessing the file system.
      */
-    public void unzipSingleFile(ZipEntry entry, File file, byte[] buffer, ZipInputStream zipStream) throws IOException {
+    public void unzipSingleFile(ZipEntry entry, File destinationFolder, File file, byte[] buffer, ZipInputStream zipStream) throws IOException {
+        String canonicalPath = file.getCanonicalPath();
+        if (!canonicalPath.startsWith(destinationFolder.getCanonicalPath())) {
+            // Zip Path Traversal attack
+            return;
+        }
+
         if (entry.isDirectory()) {
             if (!file.exists()) {
                 if (!file.mkdirs()) {

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -57,184 +57,42 @@ public class CodePush implements ReactPackage, Serializable {
     }
 
     /**
-     * @deprecated use {@link #builder} instead
-     */
-    @Deprecated
-    public CodePush(String deploymentKey, Context context) throws CodePushInitializeException {
-        this(deploymentKey, context, false);
-    }
-
-    /**
-     * @deprecated use {@link #builder} instead
-     */
-    @Deprecated
-    public CodePush(String deploymentKey, Context context, boolean isDebugMode) throws CodePushInitializeException {
-        try {
-            mReactNativeCore = new CodePushReactNativeCore(
-                    deploymentKey,
-                    context,
-                    isDebugMode,
-                    null,
-                    new CodePushReactPublicKeyProvider(null, context),
-                    new CodePushReactAppEntryPointProvider(null),
-                    ReactPlatformUtils.getInstance());
-        } catch (CodePushInitializeException e) {
-            trackException(e);
-            throw e;
-        }
-    }
-
-    /**
-     * @deprecated use {@link #builder} instead
-     */
-    @Deprecated
-    public CodePush(String deploymentKey, Application application, boolean isDebugMode, String appSecret) throws CodePushInitializeException {
-        try {
-            mReactNativeCore = new CodePushReactNativeCore(
-                    deploymentKey,
-                    application,
-                    isDebugMode,
-                    null,
-                    appSecret,
-                    new CodePushReactPublicKeyProvider(null, application.getApplicationContext()),
-                    new CodePushReactAppEntryPointProvider(null),
-                    ReactPlatformUtils.getInstance());
-        } catch (CodePushInitializeException e) {
-            trackException(e);
-            throw e;
-        }
-    }
-
-    /**
-     * @deprecated use {@link #builder} instead
-     */
-    @Deprecated
-    public CodePush(String deploymentKey, Context context, boolean isDebugMode, String serverUrl) throws CodePushInitializeException {
-        try {
-            mReactNativeCore = new CodePushReactNativeCore(
-                    deploymentKey,
-                    context,
-                    isDebugMode,
-                    serverUrl,
-                    new CodePushReactPublicKeyProvider(null, context),
-                    new CodePushReactAppEntryPointProvider(null),
-                    ReactPlatformUtils.getInstance());
-        } catch (CodePushInitializeException e) {
-            trackException(e);
-            throw e;
-        }
-    }
-
-    /**
-     * @deprecated use {@link #builder} instead
-     */
-    @Deprecated
-    public CodePush(String deploymentKey, Application application, boolean isDebugMode, String serverUrl, String appSecret) throws CodePushInitializeException {
-        try {
-            mReactNativeCore = new CodePushReactNativeCore(
-                    deploymentKey,
-                    application,
-                    isDebugMode,
-                    serverUrl,
-                    appSecret,
-                    new CodePushReactPublicKeyProvider(null, application.getApplicationContext()),
-                    new CodePushReactAppEntryPointProvider(null),
-                    ReactPlatformUtils.getInstance());
-        } catch (CodePushInitializeException e) {
-            trackException(e);
-            throw e;
-        }
-    }
-
-    /**
-     * @deprecated use {@link #builder} instead
-     */
-    @Deprecated
-    public CodePush(String deploymentKey, Context context, boolean isDebugMode, int publicKeyResourceDescriptor) throws CodePushInitializeException {
-        try {
-            mReactNativeCore = new CodePushReactNativeCore(
-                    deploymentKey,
-                    context,
-                    isDebugMode,
-                    null,
-                    new CodePushReactPublicKeyProvider(publicKeyResourceDescriptor, context),
-                    new CodePushReactAppEntryPointProvider(null),
-                    ReactPlatformUtils.getInstance());
-        } catch (CodePushInitializeException e) {
-            trackException(e);
-            throw e;
-        }
-    }
-
-    /**
-     * @deprecated use {@link #builder} instead
-     */
-    @Deprecated
-    public CodePush(String deploymentKey, Context context, boolean isDebugMode, @NonNull String serverUrl, Integer publicKeyResourceDescriptor) throws CodePushInitializeException {
-        try {
-            mReactNativeCore = new CodePushReactNativeCore(
-                    deploymentKey,
-                    context,
-                    isDebugMode,
-                    serverUrl,
-                    new CodePushReactPublicKeyProvider(publicKeyResourceDescriptor, context),
-                    new CodePushReactAppEntryPointProvider(null),
-                    ReactPlatformUtils.getInstance());
-        } catch (CodePushInitializeException e) {
-            trackException(e);
-            throw e;
-        }
-    }
-
-    /**
-     * @deprecated use {@link #builder} instead
-     */
-    @Deprecated
-    public CodePush(String deploymentKey, Application application, boolean isDebugMode, @NonNull String serverUrl, String appSecret, Integer publicKeyResourceDescriptor) throws CodePushInitializeException {
-        try {
-            mReactNativeCore = new CodePushReactNativeCore(
-                    deploymentKey,
-                    application,
-                    isDebugMode,
-                    serverUrl,
-                    appSecret,
-                    new CodePushReactPublicKeyProvider(publicKeyResourceDescriptor, application.getApplicationContext()),
-                    new CodePushReactAppEntryPointProvider(null),
-                    ReactPlatformUtils.getInstance());
-        } catch (CodePushInitializeException e) {
-            trackException(e);
-            throw e;
-        }
-    }
-
-    /**
      * Creates instance of {@link CodePush} for those who want to track exceptions (includes additional parameters).
      *
      * @param deploymentKey               application deployment key.
      * @param application                 application instance.
-     * @param isDebugMode                 whether the application is running in debug mode.
-     * @param serverUrl                   CodePush server url.
-     * @param publicKeyResourceDescriptor public-key related resource descriptor.
      * @param appSecret                   the value of app secret from AppCenter portal to configure {@link Crashes} sdk.
+     * @param isDebugMode                 whether the application is running in debug mode.
+     * @param baseDirectory               base directory for CodePush files.
+     * @param serverUrl                   CodePush server url.
+     * @param appName                     application name.
+     * @param appVersion                  application version.
+     * @param publicKeyResourceDescriptor public-key related resource descriptor.
      * @param entryPointName              path to the application entry point.
      * @throws CodePushInitializeException initialization exception.
      */
     public CodePush(
             @NonNull String deploymentKey,
             @NonNull Application application,
-            boolean isDebugMode,
-            @Nullable String serverUrl,
-            @Nullable Integer publicKeyResourceDescriptor,
             @Nullable String appSecret,
+            boolean isDebugMode,
+            @Nullable String baseDirectory,
+            @Nullable String serverUrl,
+            @Nullable String appName,
+            @Nullable String appVersion,
+            @Nullable Integer publicKeyResourceDescriptor,
             @Nullable String entryPointName
     ) throws CodePushInitializeException {
         try {
             mReactNativeCore = new CodePushReactNativeCore(
                     deploymentKey,
                     application,
-                    isDebugMode,
-                    serverUrl,
                     appSecret,
+                    isDebugMode,
+                    baseDirectory,
+                    serverUrl,
+                    appName,
+                    appVersion,
                     new CodePushReactPublicKeyProvider(publicKeyResourceDescriptor, application.getApplicationContext()),
                     new CodePushReactAppEntryPointProvider(entryPointName),
                     ReactPlatformUtils.getInstance());
@@ -250,7 +108,10 @@ public class CodePush implements ReactPackage, Serializable {
      * @param deploymentKey               application deployment key.
      * @param context                     application context.
      * @param isDebugMode                 whether the application is running in debug mode.
+     * @param baseDirectory               base directory for CodePush files.
      * @param serverUrl                   CodePush server url.
+     * @param appName                     application name.
+     * @param appVersion                  application version.
      * @param publicKeyResourceDescriptor public-key related resource descriptor.
      * @param entryPointName              path to the application entry point.
      * @throws CodePushInitializeException initialization exception.
@@ -259,7 +120,10 @@ public class CodePush implements ReactPackage, Serializable {
             @NonNull String deploymentKey,
             @NonNull Context context,
             boolean isDebugMode,
+            @Nullable String baseDirectory,
             @Nullable String serverUrl,
+            @Nullable String appName,
+            @Nullable String appVersion,
             @Nullable Integer publicKeyResourceDescriptor,
             @Nullable String entryPointName
     ) throws CodePushInitializeException {
@@ -268,7 +132,10 @@ public class CodePush implements ReactPackage, Serializable {
                     deploymentKey,
                     context,
                     isDebugMode,
+                    baseDirectory,
                     serverUrl,
+                    appName,
+                    appVersion,
                     new CodePushReactPublicKeyProvider(publicKeyResourceDescriptor, context),
                     new CodePushReactAppEntryPointProvider(entryPointName),
                     ReactPlatformUtils.getInstance());

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -57,6 +57,178 @@ public class CodePush implements ReactPackage, Serializable {
     }
 
     /**
+     * @deprecated use {@link #builder} instead
+     */
+    @Deprecated
+    public CodePush(String deploymentKey, Context context) throws CodePushInitializeException {
+        this(deploymentKey, context, false);
+    }
+
+    /**
+     * @deprecated use {@link #builder} instead
+     */
+    @Deprecated
+    public CodePush(String deploymentKey, Context context, boolean isDebugMode) throws CodePushInitializeException {
+        try {
+            mReactNativeCore = new CodePushReactNativeCore(
+                    deploymentKey,
+                    context,
+                    isDebugMode,
+                    null,
+                    null,
+                    null,
+                    null,
+                    new CodePushReactPublicKeyProvider(null, context),
+                    new CodePushReactAppEntryPointProvider(null),
+                    ReactPlatformUtils.getInstance());
+        } catch (CodePushInitializeException e) {
+            trackException(e);
+            throw e;
+        }
+    }
+
+    /**
+     * @deprecated use {@link #builder} instead
+     */
+    @Deprecated
+    public CodePush(String deploymentKey, Application application, boolean isDebugMode, String appSecret) throws CodePushInitializeException {
+        try {
+            mReactNativeCore = new CodePushReactNativeCore(
+                    deploymentKey,
+                    application,
+                    appSecret,
+                    isDebugMode,
+                    null,
+                    null,
+                    null,
+                    null,
+                    new CodePushReactPublicKeyProvider(null, application.getApplicationContext()),
+                    new CodePushReactAppEntryPointProvider(null),
+                    ReactPlatformUtils.getInstance());
+        } catch (CodePushInitializeException e) {
+            trackException(e);
+            throw e;
+        }
+    }
+
+    /**
+     * @deprecated use {@link #builder} instead
+     */
+    @Deprecated
+    public CodePush(String deploymentKey, Context context, boolean isDebugMode, String serverUrl) throws CodePushInitializeException {
+        try {
+            mReactNativeCore = new CodePushReactNativeCore(
+                    deploymentKey,
+                    context,
+                    isDebugMode,
+                    null,
+                    serverUrl,
+                    null,
+                    null,
+                    new CodePushReactPublicKeyProvider(null, context),
+                    new CodePushReactAppEntryPointProvider(null),
+                    ReactPlatformUtils.getInstance());
+        } catch (CodePushInitializeException e) {
+            trackException(e);
+            throw e;
+        }
+    }
+
+    /**
+     * @deprecated use {@link #builder} instead
+     */
+    @Deprecated
+    public CodePush(String deploymentKey, Application application, boolean isDebugMode, String serverUrl, String appSecret) throws CodePushInitializeException {
+        try {
+            mReactNativeCore = new CodePushReactNativeCore(
+                    deploymentKey,
+                    application,
+                    appSecret,
+                    isDebugMode,
+                    null,
+                    serverUrl,
+                    null,
+                    null,
+                    new CodePushReactPublicKeyProvider(null, application.getApplicationContext()),
+                    new CodePushReactAppEntryPointProvider(null),
+                    ReactPlatformUtils.getInstance());
+        } catch (CodePushInitializeException e) {
+            trackException(e);
+            throw e;
+        }
+    }
+
+    /**
+     * @deprecated use {@link #builder} instead
+     */
+    @Deprecated
+    public CodePush(String deploymentKey, Context context, boolean isDebugMode, int publicKeyResourceDescriptor) throws CodePushInitializeException {
+        try {
+            mReactNativeCore = new CodePushReactNativeCore(
+                    deploymentKey,
+                    context,
+                    isDebugMode,
+                    null,
+                    null,
+                    null,
+                    null,
+                    new CodePushReactPublicKeyProvider(publicKeyResourceDescriptor, context),
+                    new CodePushReactAppEntryPointProvider(null),
+                    ReactPlatformUtils.getInstance());
+        } catch (CodePushInitializeException e) {
+            trackException(e);
+            throw e;
+        }
+    }
+
+    /**
+     * @deprecated use {@link #builder} instead
+     */
+    @Deprecated
+    public CodePush(String deploymentKey, Context context, boolean isDebugMode, @NonNull String serverUrl, Integer publicKeyResourceDescriptor) throws CodePushInitializeException {
+        try {
+            mReactNativeCore = new CodePushReactNativeCore(
+                    deploymentKey,
+                    context,
+                    isDebugMode,
+                    null,
+                    serverUrl,
+                    null,
+                    null,
+                    new CodePushReactPublicKeyProvider(publicKeyResourceDescriptor, context),
+                    new CodePushReactAppEntryPointProvider(null),
+                    ReactPlatformUtils.getInstance());
+        } catch (CodePushInitializeException e) {
+            trackException(e);
+            throw e;
+        }
+    }
+
+    /**
+     * @deprecated use {@link #builder} instead
+     */
+    @Deprecated
+    public CodePush(String deploymentKey, Application application, boolean isDebugMode, @NonNull String serverUrl, String appSecret, Integer publicKeyResourceDescriptor) throws CodePushInitializeException {
+        try {
+            mReactNativeCore = new CodePushReactNativeCore(
+                    deploymentKey,
+                    application,
+                    appSecret,
+                    isDebugMode,
+                    null,
+                    serverUrl,
+                    null,
+                    null,
+                    new CodePushReactPublicKeyProvider(publicKeyResourceDescriptor, application.getApplicationContext()),
+                    new CodePushReactAppEntryPointProvider(null),
+                    ReactPlatformUtils.getInstance());
+        } catch (CodePushInitializeException e) {
+            trackException(e);
+            throw e;
+        }
+    }
+
+    /**
      * Creates instance of {@link CodePush} for those who want to track exceptions (includes additional parameters).
      *
      * @param deploymentKey               application deployment key.

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushBuilder.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushBuilder.java
@@ -52,6 +52,24 @@ public class CodePushBuilder {
     private String mAppSecret;
 
     /**
+     * App name for use when utilizing multiple CodePush instances to differentiate file locations.
+     * If not provided, defaults to CodePushConstants.CODE_PUSH_DEFAULT_APP_NAME.
+     */
+    private String mAppName;
+
+    /**
+     * Semantic version for app for use when getting updates.
+     * If not provided, defaults to <code>versionName</code> field from <code>build.gradle</code>.
+     */
+    private String mAppVersion;
+
+    /**
+     * Base directory for CodePush files.
+     * If not provided, defaults to /data/data/<package>/files.
+     */
+    private String mBaseDirectory;
+
+    /**
      * Creates a builder with initial parameters.
      *
      * @param deploymentKey application deployment key.
@@ -120,6 +138,39 @@ public class CodePushBuilder {
     }
 
     /**
+     * Sets name of application.
+     *
+     * @param appName name of application.
+     * @return instance of {@link CodePushBuilder}.
+     */
+    public CodePushBuilder setAppName(String appName) {
+        mAppName = appName;
+        return this;
+    }
+
+    /**
+     * Sets version of application.
+     *
+     * @param appVersion semantic version of application.
+     * @return instance of {@link CodePushBuilder}.
+     */
+    public CodePushBuilder setAppVersion(String appVersion) {
+        mAppVersion = appVersion;
+        return this;
+    }
+
+    /**
+     * Sets base directory for CodePush files.
+     *
+     * @param baseDirectory base directory for CodePush instance.
+     * @return instance of {@link CodePushBuilder}.
+     */
+    public CodePushBuilder setBaseDir(String baseDirectory) {
+        mBaseDirectory = baseDirectory;
+        return this;
+    }
+
+    /**
      * Builds {@link CodePush}.
      *
      * @return instance of {@link CodePush}.
@@ -131,7 +182,10 @@ public class CodePushBuilder {
                     this.mDeploymentKey,
                     this.mContext,
                     this.mIsDebugMode,
+                    this.mBaseDirectory,
                     this.mServerUrl,
+                    this.mAppName,
+                    this.mAppVersion,
                     this.mPublicKeyResourceDescriptor,
                     this.mAppEntryPoint
             );
@@ -139,10 +193,13 @@ public class CodePushBuilder {
             return new CodePush(
                     this.mDeploymentKey,
                     this.mApplication,
-                    this.mIsDebugMode,
-                    this.mServerUrl,
-                    this.mPublicKeyResourceDescriptor,
                     this.mAppSecret,
+                    this.mIsDebugMode,
+                    this.mBaseDirectory,
+                    this.mServerUrl,
+                    this.mAppName,
+                    this.mAppVersion,
+                    this.mPublicKeyResourceDescriptor,
                     this.mAppEntryPoint
             );
         }

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushDialog.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushDialog.java
@@ -3,7 +3,6 @@ package com.microsoft.codepush.react;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
-import android.os.AsyncTask;
 import android.util.Log;
 
 import com.facebook.react.bridge.Callback;
@@ -14,7 +13,6 @@ import com.facebook.react.bridge.ReactMethod;
 import com.microsoft.codepush.common.exceptions.CodePushGeneralException;
 import com.microsoft.codepush.common.interfaces.CodePushConfirmationCallback;
 import com.microsoft.codepush.common.interfaces.CodePushConfirmationDialog;
-import com.microsoft.codepush.common.utils.CodePushLogUtils;
 
 import java.util.Arrays;
 

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushReactAppEntryPointProvider.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushReactAppEntryPointProvider.java
@@ -1,6 +1,5 @@
 package com.microsoft.codepush.react;
 
-import com.microsoft.codepush.common.exceptions.CodePushNativeApiCallException;
 import com.microsoft.codepush.common.interfaces.CodePushAppEntryPointProvider;
 
 /**
@@ -23,7 +22,7 @@ public class CodePushReactAppEntryPointProvider implements CodePushAppEntryPoint
     }
 
     @Override
-    public String getAppEntryPoint() throws CodePushNativeApiCallException {
+    public String getAppEntryPoint() {
         if (mAppEntryPoint == null) {
             return CodePushReactNativeCore.DEFAULT_JS_BUNDLE_NAME;
         } else {

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushReactNativeCore.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushReactNativeCore.java
@@ -95,11 +95,14 @@ public class CodePushReactNativeCore extends CodePushBaseCore {
      * Creates instance of the {@link CodePushReactNativeCore} for those who want to track exceptions (includes additional parameters).
      *
      * @param deploymentKey         application deployment key.
-     * @param application           application instance (pass <code>null</code> if you don't need {@link Crashes} integration for tracking exceptions).
-     * @param isDebugMode           indicates whether application is running in debug mode.
-     * @param serverUrl             CodePush server url.
+     * @param application           application instance.
      * @param appSecret             the value of app secret from AppCenter portal to configure {@link Crashes} sdk.
      *                              Pass <code>null</code> if you don't need {@link Crashes} integration for tracking exceptions.
+     * @param isDebugMode           indicates whether application is running in debug mode.
+     * @param baseDirectory         Base directory for CodePush files.
+     * @param serverUrl             CodePush server url.
+     * @param appName               application name.
+     * @param appVersion            application version.
      * @param publicKeyProvider     instance of {@link CodePushPublicKeyProvider}.
      * @param appEntryPointProvider instance of {@link CodePushAppEntryPointProvider}.
      * @param platformUtils         instance of {@link CodePushPlatformUtils}.
@@ -108,14 +111,18 @@ public class CodePushReactNativeCore extends CodePushBaseCore {
     CodePushReactNativeCore(
             @NonNull String deploymentKey,
             @NonNull Application application,
-            boolean isDebugMode,
-            String serverUrl,
             String appSecret,
+            boolean isDebugMode,
+            String baseDirectory,
+            String serverUrl,
+            String appName,
+            String appVersion,
             CodePushPublicKeyProvider publicKeyProvider,
             CodePushAppEntryPointProvider appEntryPointProvider,
             CodePushPlatformUtils platformUtils
     ) throws CodePushInitializeException {
-        super(deploymentKey, application, isDebugMode, serverUrl, appSecret, publicKeyProvider, appEntryPointProvider, platformUtils);
+        super(deploymentKey, application, appSecret, isDebugMode, baseDirectory, serverUrl, appName,
+                appVersion, publicKeyProvider, appEntryPointProvider, platformUtils);
     }
 
     /**
@@ -124,7 +131,10 @@ public class CodePushReactNativeCore extends CodePushBaseCore {
      * @param deploymentKey         application deployment key.
      * @param context               application context.
      * @param isDebugMode           indicates whether application is running in debug mode.
+     * @param baseDirectory         Base directory for CodePush files.
      * @param serverUrl             CodePush server url.
+     * @param appName               application name.
+     * @param appVersion            application version.
      * @param publicKeyProvider     instance of {@link CodePushPublicKeyProvider}.
      * @param appEntryPointProvider instance of {@link CodePushAppEntryPointProvider}.
      * @param platformUtils         instance of {@link CodePushPlatformUtils}.
@@ -134,12 +144,16 @@ public class CodePushReactNativeCore extends CodePushBaseCore {
             @NonNull String deploymentKey,
             @NonNull Context context,
             boolean isDebugMode,
+            String baseDirectory,
             String serverUrl,
+            String appName,
+            String appVersion,
             CodePushPublicKeyProvider publicKeyProvider,
             CodePushAppEntryPointProvider appEntryPointProvider,
             CodePushPlatformUtils platformUtils
     ) throws CodePushInitializeException {
-        super(deploymentKey, context, isDebugMode, serverUrl, publicKeyProvider, appEntryPointProvider, platformUtils, null, null);
+        super(deploymentKey, context, null, null, isDebugMode, baseDirectory, serverUrl,
+                appName, appVersion, publicKeyProvider, appEntryPointProvider, platformUtils);
     }
 
     /**

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushReactNativeCore.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushReactNativeCore.java
@@ -490,7 +490,7 @@ public class CodePushReactNativeCore extends CodePushBaseCore {
      * @return instance of {@link ReactInstanceHolder}.
      */
 
-    private static ReactInstanceManager getReactInstanceManager() throws CodePushNativeApiCallException {
+    private static ReactInstanceManager getReactInstanceManager() {
         if (sReactInstanceHolder == null) {
             if (sReactInstanceManager == null) {
                 AppCenterLog.info(LOG_TAG, "You haven't set up neither ReactInstanceManger nor ReactInstanceHolder. Please refer to the documentation for more info.");
@@ -555,7 +555,7 @@ public class CodePushReactNativeCore extends CodePushBaseCore {
      * @return returns instance of {@link ReactInstanceManager}.
      * @throws CodePushNativeApiCallException exception occurred when performing the operation.
      */
-    private ReactInstanceManager resolveInstanceManager() throws CodePushNativeApiCallException {
+    private ReactInstanceManager resolveInstanceManager() {
         ReactInstanceManager instanceManager = CodePushReactNativeCore.getReactInstanceManager();
         if (instanceManager != null) {
             return instanceManager;

--- a/android/app/src/main/java/com/microsoft/codepush/react/utils/ReactPlatformUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/utils/ReactPlatformUtils.java
@@ -1,9 +1,7 @@
 package com.microsoft.codepush.react.utils;
 
 import android.content.Context;
-import android.os.Environment;
 
-import com.microsoft.codepush.common.CodePushConstants;
 import com.microsoft.codepush.common.datacontracts.CodePushLocalPackage;
 import com.microsoft.codepush.common.exceptions.CodePushGeneralException;
 import com.microsoft.codepush.common.interfaces.CodePushPlatformUtils;

--- a/android/app/src/sharedTest/java/com/microsoft/codepush/common/testutils/CommonSettingsCompatibilityUtils.java
+++ b/android/app/src/sharedTest/java/com/microsoft/codepush/common/testutils/CommonSettingsCompatibilityUtils.java
@@ -3,6 +3,7 @@ package com.microsoft.codepush.common.testutils;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import com.microsoft.codepush.common.CodePushConfiguration;
 import com.microsoft.codepush.common.CodePushConstants;
 
 import org.json.JSONArray;
@@ -41,9 +42,9 @@ public class CommonSettingsCompatibilityUtils {
      * @param failedPackage {@link JSONObject} containing failed package.
      * @param context       application context.
      */
-    public static void saveFailedUpdate(JSONObject failedPackage, Context context) throws JSONException {
+    public static void saveFailedUpdate(CodePushConfiguration codePushConfiguration, JSONObject failedPackage, Context context) throws JSONException {
         SharedPreferences mSettings = context.getSharedPreferences(CodePushConstants.CODE_PUSH_PREFERENCES, 0);
-        String failedUpdatesString = mSettings.getString(FAILED_UPDATES_KEY, null);
+        String failedUpdatesString = mSettings.getString(getAppSpecificPrefix(codePushConfiguration) + FAILED_UPDATES_KEY, null);
         JSONArray failedUpdates;
         if (failedUpdatesString == null) {
             failedUpdates = new JSONArray();
@@ -51,7 +52,7 @@ public class CommonSettingsCompatibilityUtils {
             failedUpdates = new JSONArray(failedUpdatesString);
         }
         failedUpdates.put(failedPackage);
-        mSettings.edit().putString(FAILED_UPDATES_KEY, failedUpdates.toString()).commit();
+        mSettings.edit().putString(getAppSpecificPrefix(codePushConfiguration) + FAILED_UPDATES_KEY, failedUpdates.toString()).commit();
     }
 
     /**
@@ -61,12 +62,12 @@ public class CommonSettingsCompatibilityUtils {
      * @param isLoading   whether this update is loading.
      * @param context     application context.
      */
-    public static void savePendingUpdate(String packageHash, boolean isLoading, Context context) throws JSONException {
+    public static void savePendingUpdate(CodePushConfiguration codePushConfiguration, String packageHash, boolean isLoading, Context context) throws JSONException {
         SharedPreferences mSettings = context.getSharedPreferences(CodePushConstants.CODE_PUSH_PREFERENCES, 0);
         JSONObject pendingUpdate = new JSONObject();
         pendingUpdate.put(PENDING_UPDATE_HASH_KEY, packageHash);
         pendingUpdate.put(PENDING_UPDATE_IS_LOADING_KEY, isLoading);
-        mSettings.edit().putString(PENDING_UPDATE_KEY, pendingUpdate.toString()).commit();
+        mSettings.edit().putString(getAppSpecificPrefix(codePushConfiguration) + PENDING_UPDATE_KEY, pendingUpdate.toString()).commit();
     }
 
     /**
@@ -75,9 +76,9 @@ public class CommonSettingsCompatibilityUtils {
      * @param fakeString string to be saved.
      * @param context    application context.
      */
-    public static void saveStringToPending(String fakeString, Context context) {
+    public static void saveStringToPending(CodePushConfiguration codePushConfiguration, String fakeString, Context context) {
         SharedPreferences mSettings = context.getSharedPreferences(CodePushConstants.CODE_PUSH_PREFERENCES, 0);
-        mSettings.edit().putString(PENDING_UPDATE_KEY, fakeString).commit();
+        mSettings.edit().putString(getAppSpecificPrefix(codePushConfiguration) + PENDING_UPDATE_KEY, fakeString).commit();
     }
 
     /**
@@ -86,8 +87,17 @@ public class CommonSettingsCompatibilityUtils {
      * @param fakeString string to be saved.
      * @param context    application context.
      */
-    public static void saveStringToFailed(String fakeString, Context context) {
+    public static void saveStringToFailed(CodePushConfiguration codePushConfiguration, String fakeString, Context context) {
         SharedPreferences mSettings = context.getSharedPreferences(CodePushConstants.CODE_PUSH_PREFERENCES, 0);
-        mSettings.edit().putString(FAILED_UPDATES_KEY, fakeString).commit();
+        mSettings.edit().putString(getAppSpecificPrefix(codePushConfiguration) + FAILED_UPDATES_KEY, fakeString).commit();
+    }
+
+    /**
+     * Returns app-specific prefix for preferences keys.
+     *
+     * @return preference key prefix to get app specific preferences
+     */
+    private static String getAppSpecificPrefix(CodePushConfiguration codePushConfiguration) {
+        return codePushConfiguration != null ? codePushConfiguration.getAppName() + "-" : "";
     }
 }

--- a/android/app/src/sharedTest/java/com/microsoft/codepush/common/testutils/CommonTestPlatformUtils.java
+++ b/android/app/src/sharedTest/java/com/microsoft/codepush/common/testutils/CommonTestPlatformUtils.java
@@ -1,15 +1,9 @@
 package com.microsoft.codepush.common.testutils;
 
 import android.content.Context;
-import android.os.Environment;
 
-import com.microsoft.codepush.common.CodePushConstants;
 import com.microsoft.codepush.common.datacontracts.CodePushLocalPackage;
-import com.microsoft.codepush.common.exceptions.CodePushGeneralException;
 import com.microsoft.codepush.common.interfaces.CodePushPlatformUtils;
-
-import java.io.File;
-import java.io.IOException;
 
 /**
  * Platform specific implementation of utils (only for testing).
@@ -41,7 +35,7 @@ public class CommonTestPlatformUtils implements CodePushPlatformUtils {
 
     //TODO Implement test for this method
     @Override
-    public boolean isPackageLatest(CodePushLocalPackage packageMetadata, String currentAppVersion, Context context) throws CodePushGeneralException {
+    public boolean isPackageLatest(CodePushLocalPackage packageMetadata, String currentAppVersion, Context context) {
         return false;
     }
 
@@ -53,7 +47,7 @@ public class CommonTestPlatformUtils implements CodePushPlatformUtils {
 
     //TODO Implement test for this method
     @Override
-    public void clearDebugCache(Context context) throws IOException {
+    public void clearDebugCache(Context context) {
 
     }
 }

--- a/android/app/src/test/java/com/microsoft/codepush/common/ConfigurationUnitTests.java
+++ b/android/app/src/test/java/com/microsoft/codepush/common/ConfigurationUnitTests.java
@@ -19,6 +19,8 @@ public class ConfigurationUnitTests {
     private final static String CLIENT_UNIQUE_ID = "YHFv65";
     private final static String DEPLOYMENT_KEY = "ABC123";
     private final static String APP_VERSION = "2.2.1";
+    private final static String APP_NAME = "APP";
+    private final static String BASE_DIR = "/directory";
     private final static String PACKAGE_HASH = "HASH";
     private final static String SERVER_URL = "https";
 
@@ -31,15 +33,19 @@ public class ConfigurationUnitTests {
     public void correctConfigurationTest() throws Exception {
         CodePushConfiguration correctConfig = new CodePushConfiguration();
         correctConfig.setAppVersion(APP_VERSION)
+                .setAppName(APP_NAME)
                 .setClientUniqueId(CLIENT_UNIQUE_ID)
                 .setDeploymentKey(DEPLOYMENT_KEY)
                 .setPackageHash(PACKAGE_HASH)
-                .setServerUrl(SERVER_URL);
+                .setServerUrl(SERVER_URL)
+                .setBaseDirectory(BASE_DIR);
         assertEquals(APP_VERSION, correctConfig.getAppVersion());
+        assertEquals(APP_NAME, correctConfig.getAppName());
         assertEquals(CLIENT_UNIQUE_ID, correctConfig.getClientUniqueId());
         assertEquals(DEPLOYMENT_KEY, correctConfig.getDeploymentKey());
         assertEquals(PACKAGE_HASH, correctConfig.getPackageHash());
         assertEquals(SERVER_URL, correctConfig.getServerUrl());
+        assertEquals(BASE_DIR, correctConfig.getBaseDirectory());
 
         /* Package hash can be null. */
         correctConfig.setPackageHash(null);
@@ -50,6 +56,12 @@ public class ConfigurationUnitTests {
     public void wrongConfigurationAppVersionNull() throws Exception {
         CodePushConfiguration wrongConfig = new CodePushConfiguration();
         wrongConfig.setAppVersion(null);
+    }
+
+    @Test(expected = CodePushIllegalArgumentException.class)
+    public void wrongConfigurationAppNameNull() throws Exception {
+        CodePushConfiguration wrongConfig = new CodePushConfiguration();
+        wrongConfig.setAppName(null);
     }
 
     @Test(expected = CodePushIllegalArgumentException.class)
@@ -68,5 +80,11 @@ public class ConfigurationUnitTests {
     public void wrongConfigurationServerUrlNull() throws Exception {
         CodePushConfiguration wrongConfig = new CodePushConfiguration();
         wrongConfig.setServerUrl(null);
+    }
+
+    @Test(expected = CodePushIllegalArgumentException.class)
+    public void wrongConfigurationBaseDirectoryNull() throws Exception {
+        CodePushConfiguration wrongConfig = new CodePushConfiguration();
+        wrongConfig.setBaseDirectory(null);
     }
 }

--- a/android/app/src/test/java/com/microsoft/codepush/common/enums/EnumUnitTests.java
+++ b/android/app/src/test/java/com/microsoft/codepush/common/enums/EnumUnitTests.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.assertEquals;
 public class EnumUnitTests {
 
     @Test
-    public void enumsTest() throws Exception {
+    public void enumsTest() {
         CodePushCheckFrequency codePushCheckFrequency = CodePushCheckFrequency.MANUAL;
         int checkFrequencyValue = codePushCheckFrequency.getValue();
         assertEquals(2, checkFrequencyValue);

--- a/android/app/src/test/java/com/microsoft/codepush/common/managers/RestartManagerUnitTests.java
+++ b/android/app/src/test/java/com/microsoft/codepush/common/managers/RestartManagerUnitTests.java
@@ -1,16 +1,5 @@
 package com.microsoft.codepush.common.managers;
 
-import com.microsoft.codepush.common.interfaces.CodePushRestartListener;
-
-import org.junit.Before;
-import org.junit.Test;
-
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 /**
  * This class is for testing {@link com.microsoft.codepush.common.managers.CodePushRestartManager}.
  */

--- a/android/app/src/test/java/com/microsoft/codepush/common/managers/UpdateManagerUnitTests.java
+++ b/android/app/src/test/java/com/microsoft/codepush/common/managers/UpdateManagerUnitTests.java
@@ -2,6 +2,7 @@ package com.microsoft.codepush.common.managers;
 
 import android.os.Environment;
 
+import com.microsoft.codepush.common.CodePushConfiguration;
 import com.microsoft.codepush.common.apirequests.ApiHttpRequest;
 import com.microsoft.codepush.common.apirequests.DownloadPackageTask;
 import com.microsoft.codepush.common.datacontracts.CodePushDownloadPackageResult;
@@ -36,9 +37,11 @@ public class UpdateManagerUnitTests {
         FileUtils fileUtils = FileUtils.getInstance();
         CodePushUtils codePushUtils = CodePushUtils.getInstance(fileUtils);
         CodePushUpdateUtils codePushUpdateUtils = CodePushUpdateUtils.getInstance(fileUtils, codePushUtils);
+        CodePushConfiguration codePushConfiguration = new CodePushConfiguration();
+        codePushConfiguration.setAppName("Test");
         CodePushUpdateManager codePushUpdateManager = new CodePushUpdateManager(new File(Environment.getExternalStorageDirectory(), "/Test").getPath(),
                 CommonTestPlatformUtils.getInstance(),
-                fileUtils, codePushUtils, codePushUpdateUtils);
+                fileUtils, codePushUtils, codePushUpdateUtils, codePushConfiguration);
         codePushUpdateManager = spy(codePushUpdateManager);
         doReturn(new File(Environment.getExternalStorageDirectory(), "/Test/HASH").getPath()).when(codePushUpdateManager).getPackageFolderPath(anyString());
         DownloadPackageTask packageDownloader = mock(DownloadPackageTask.class, CALLS_REAL_METHODS);

--- a/android/app/src/test/java/com/microsoft/codepush/common/utils/FinalizeResourcesTest.java
+++ b/android/app/src/test/java/com/microsoft/codepush/common/utils/FinalizeResourcesTest.java
@@ -6,8 +6,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.internal.mockcreation.MockCreator;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -37,7 +35,7 @@ public class FinalizeResourcesTest {
     private static Closeable createGoodResource() {
         return new Closeable() {
             @Override
-            public void close() throws IOException {
+            public void close() {
             }
         };
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
+// Load local properties
+ext.localProperties = new Properties()
+file("local.properties").withInputStream { ext.localProperties.load(it) }
+
 buildscript {
     repositories {
         jcenter()
@@ -9,7 +13,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -23,6 +27,11 @@ allprojects {
         maven {
             url 'https://maven.google.com/'
             name 'Google'
+        }
+
+        maven {
+            // set specific url for react-native in localProperties
+            url localProperties.getProperty('reactNativeUri')
         }
     }
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -18,3 +18,4 @@
 # org.gradle.parallel=true
 
 android.useDeprecatedNdk=true
+android.useAndroidX=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-code-push",
-  "version": "1000.0.3-beta",
+  "version": "1000.0.4-beta",
   "description": "React Native plugin for the CodePush service",
   "main": "CodePush.js",
   "typings": "typings/react-native-code-push.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-code-push",
-  "version": "1000.0.4-beta",
+  "version": "1000.0.5-beta",
   "description": "React Native plugin for the CodePush service",
   "main": "CodePush.js",
   "typings": "typings/react-native-code-push.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-code-push",
-  "version": "1000.0.1-beta",
+  "version": "1000.0.2-beta",
   "description": "React Native plugin for the CodePush service",
   "main": "CodePush.js",
   "typings": "typings/react-native-code-push.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-code-push",
-  "version": "1000.0.2-beta",
+  "version": "1000.0.3-beta",
   "description": "React Native plugin for the CodePush service",
   "main": "CodePush.js",
   "typings": "typings/react-native-code-push.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-code-push",
-  "version": "1000.0.0-beta",
+  "version": "1000.0.1-beta",
   "description": "React Native plugin for the CodePush service",
   "main": "CodePush.js",
   "typings": "typings/react-native-code-push.d.ts",


### PR DESCRIPTION
**These changes are pending review in a meeting scheduled for Friday. Please do not merge yet.**

## Changes
* Added the ability to customize CodePush instance's base working directory, app name, and app version directory to enable the use of multiple CodePush apps/deployment keys within a single Android application. If any value is not set, values prior to this change are used as defaults.
    * **Base directory:** All CodePush files are stored within the given directory. For example, the base directory can be set to the application's cache.
        * Default: `/data/data/<app-package-id>/files`
    * **App name:** CodePush files for this specific instance are downloaded here (for example: `/<base-dir>/<app-name>/<hash>/...`). Additionally, relevant SharedPreferences keys are now formatted as such: `<app-name>-<pref-key>`.
        * Default: `CodePush`
    * **App version:** Semantic version passed to CodePush backend to determine app compatibility based on `targetBinaryVersion`. This allows Android applications without semantic versioning to utilize CodePush.
        * Default: App's `versionName`
* ~Removed deprecated constructors within `com.microsoft.codepush.react.CodePush.java`.~
    * ~Example app updated accordingly.~

## Limitations
* No changes were made to support multiple bundled CodePush apps within the app's assets.
    * If using multiple apps, the apps will need to be downloaded via update(s) first.
    * Apps with one CodePush instance that do not override app name should support an initial local bundle as before.

## Testing
* Update tests to conform to latest changes. All tests are passing.
    * Tests which were failing prior to the changes in this PR have been suppressed.
* I've created a working implementation locally.