### PR TITLE
remove AcquisitionManager import from package-mixins

### DIFF
--- a/package-mixins.js
+++ b/package-mixins.js
@@ -1,4 +1,3 @@
-import { AcquisitionManager as Sdk } from "code-push/script/acquisition-sdk";
 import { NativeEventEmitter } from "react-native";
 import RestartManager from "./RestartManager";
 import log from "./logging";


### PR DESCRIPTION
[Minor] 
Problem : AcquisitionManager is unused in `package-mixins.js`
Solution : Removing AcquisitionManager import from `package-mixins.js` 
