### PR TITLE
Prevent removing ReactNativeDevBundle in LiveReload

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -11,6 +11,8 @@ import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.devsupport.DevInternalSettings;
+import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.facebook.react.uimanager.ViewManager;
 
 import org.json.JSONException;
@@ -76,7 +78,7 @@ public class CodePush implements ReactPackage {
 
         mCurrentInstance = this;
 
-        clearDebugCacheIfNeeded();
+        clearDebugCacheIfNeeded(null);
         initializeUpdateAfterRestart();
     }
 
@@ -119,8 +121,18 @@ public class CodePush implements ReactPackage {
         return publicKey;
     }
 
-    public void clearDebugCacheIfNeeded() {
-        if (mIsDebugMode && mSettingsManager.isPendingUpdate(null)) {
+    public void clearDebugCacheIfNeeded(ReactInstanceManager instanceManager) {
+        boolean isLiveReloadEnabled = false;
+
+        if(instanceManager != null) {
+            DevSupportManager devSupportManager = instanceManager.getDevSupportManager();
+            if(devSupportManager != null) {
+                DevInternalSettings devInternalSettings = (DevInternalSettings)devSupportManager.getDevSettings();
+                isLiveReloadEnabled = devInternalSettings.isReloadOnJSChangeEnabled();
+            }
+        }
+
+        if (mIsDebugMode && mSettingsManager.isPendingUpdate(null) && !isLiveReloadEnabled) {
             // This needs to be kept in sync with https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManager.java#L78
             File cachedDevBundle = new File(mContext.getFilesDir(), "ReactNativeDevBundle.js");
             if (cachedDevBundle.exists()) {

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -118,7 +118,12 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
 
     private void loadBundle() {
         clearLifecycleEventListener();
-        mCodePush.clearDebugCacheIfNeeded();
+        try {
+            mCodePush.clearDebugCacheIfNeeded(resolveInstanceManager());
+        } catch(Exception e) {
+            mCodePush.clearDebugCacheIfNeeded(null);
+        }
+
         try {
             // #1) Get the ReactInstanceManager instance, which is what includes the
             //     logic to reload the current React context.


### PR DESCRIPTION
Fix for https://github.com/Microsoft/react-native-code-push/issues/1272
Prevent removing `ReactNativeDevBundle.js` file in case if LiveReload mode is enabled.
In other cases all behaviour is same.