### PR TITLE
Added compatibility with latest RN version(0.56) 

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,12 +1,17 @@
 apply plugin: "com.android.library"
 
+def DEFAULT_COMPILE_SDK_VERSION = 26
+def DEFAULT_BUILD_TOOLS_VERSION = "26.0.3"
+def DEFAULT_TARGET_SDK_VERSION = 26
+def DEFAULT_MIN_SDK_VERSION = 16
+
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.3"
+    compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
+    buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 26
+        minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : DEFAULT_MIN_SDK_VERSION
+        targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
         versionCode 1
         versionName "1.0"
     }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: "com.android.library"
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
* Added using project-wide properties.
* Upgrade default compileSdkVersion to 26 version
* Upgrade default buildToolsVersion to 26.0.3 version
* Upgrade default targedSdkVersion to 26 version

Versions in React-native: https://github.com/facebook/react-native/blob/master/ReactAndroid/build.gradle#L247-L253