### PR TITLE
Update api-android.md

### DIFF
--- a/docs/api-android.md
+++ b/docs/api-android.md
@@ -25,10 +25,18 @@ Constructs the CodePush client runtime and represents the `ReactPackage` instanc
 As an alternative to constructors *you can also use `CodePushBuilder`* to setup a CodePush instance configured with *only parameters you want*.
 
 ```java
+    private int getCodePushPublicKeyResourceIdentifier() {
+        Resources resources = getApplicationContext().getResources();
+        String packageName = getPackageName();
+
+        return resources.getIdentifier("code_push_public_key", "string", packageName);
+    }
+
+
     @Override
     protected List<ReactPackage> getPackages() {
 
-        int publicKeyResourceDescriptor = ...;
+        int publicKeyResourceDescriptor = getCodePushPublicKeyResourceIdentifier();
         return Arrays.<ReactPackage>asList(
             new MainReactPackage(),
             new CodePushBuilder("deployment-key-here",getApplicationContext())

--- a/docs/api-android.md
+++ b/docs/api-android.md
@@ -42,7 +42,7 @@ As an alternative to constructors *you can also use `CodePushBuilder`* to setup 
                 .setPublicKeyResourceDescriptor(getCodePushPublicKeyResourceIdentifier())
                 .setServerUrl("https://yourcodepush.server.com")
                 .build() //return configured CodePush instance
-      );
+        );
     }
 ```
 

--- a/docs/api-android.md
+++ b/docs/api-android.md
@@ -35,13 +35,11 @@ As an alternative to constructors *you can also use `CodePushBuilder`* to setup 
 
     @Override
     protected List<ReactPackage> getPackages() {
-
-        int publicKeyResourceDescriptor = getCodePushPublicKeyResourceIdentifier();
         return Arrays.<ReactPackage>asList(
             new MainReactPackage(),
             new CodePushBuilder("deployment-key-here",getApplicationContext())
                 .setIsDebugMode(BuildConfig.DEBUG)
-                .setPublicKeyResourceDescriptor(publicKeyResouceDescriptor)
+                .setPublicKeyResourceDescriptor(getCodePushPublicKeyResourceIdentifier())
                 .setServerUrl("https://yourcodepush.server.com")
                 .build() //return configured CodePush instance
       );

--- a/docs/api-android.md
+++ b/docs/api-android.md
@@ -27,11 +27,13 @@ As an alternative to constructors *you can also use `CodePushBuilder`* to setup 
 ```java
     @Override
     protected List<ReactPackage> getPackages() {
-      return Arrays.<ReactPackage>asList(
+
+        int publicKeyResourceDescriptor = ...;
+        return Arrays.<ReactPackage>asList(
             new MainReactPackage(),
             new CodePushBuilder("deployment-key-here",getApplicationContext())
                 .setIsDebugMode(BuildConfig.DEBUG)
-                .setPublicKeyResourceDescriptor(R.string.publicKey)
+                .setPublicKeyResourceDescriptor(publicKeyResouceDescriptor)
                 .setServerUrl("https://yourcodepush.server.com")
                 .build() //return configured CodePush instance
       );


### PR DESCRIPTION
`setPublicKeyResourceDescriptor` does not take a string as the documentation would suggest–it takes an int.