### PR TITLE
Fix Gradle warning: 'compile' dependencies are obsolete

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,6 +26,6 @@ android {
 }
 
 dependencies {
-    compile "com.facebook.react:react-native:+"
-    compile 'com.nimbusds:nimbus-jose-jwt:5.1'
+    implementation "com.facebook.react:react-native:+"
+    implementation 'com.nimbusds:nimbus-jose-jwt:5.1'
 }


### PR DESCRIPTION
When using the React code push plugin, Android Studio shows this warning and links to:

https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration?#new_configurations