### PR TITLE
add matchingFallbacks to android multi deploy docs

### DIFF
--- a/docs/multi-deployment-testing-android.md
+++ b/docs/multi-deployment-testing-android.md
@@ -26,6 +26,7 @@ To set this up, perform the following steps:
             releaseStaging {
                 ...
                 buildConfigField "String", "CODEPUSH_KEY", '"<INSERT_STAGING_KEY>"'
+                matchingFallbacks = ['release', 'debug']
                 ...
             }
 


### PR DESCRIPTION
I needed this line and for android to build properly (otherwise dependencies can't fall back to debug/release) .. It's probably worth adding either directly in the documentation or as a note below.