### PR TITLE
Fixed 'Too many open files in system' problem in 'create-app.js'

### DIFF
--- a/Examples/create-app.js
+++ b/Examples/create-app.js
@@ -178,7 +178,6 @@ function optimizeToTestInDebugMode() {
 
 function grantAccess(folderPath) {
     execSync('chown -R `whoami` ' + folderPath);
-    execSync('chmod -R 755 ' + folderPath);
 }
 
 function copyRecursiveSync(src, dest) {


### PR DESCRIPTION
Deleted ```chmod``` command as not necessary and caused ```Too many open files in system```
