### PR TITLE
remove deprecated gradle compile dependency calls

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,6 +26,6 @@ android {
 }
 
 dependencies {
-    compile "com.facebook.react:react-native:+"
-    compile 'com.nimbusds:nimbus-jose-jwt:5.1'
+    compileOnly "com.facebook.react:react-native:+"
+    implementation 'com.nimbusds:nimbus-jose-jwt:5.1'
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,6 +26,6 @@ android {
 }
 
 dependencies {
-    compileOnly "com.facebook.react:react-native:+"
+    api "com.facebook.react:react-native:+"
     implementation 'com.nimbusds:nimbus-jose-jwt:5.1'
 }


### PR DESCRIPTION
Dynamically link to react-native and statically link to jwt dependency

For details on the deprecation see: https://developer.android.com/studio/build/dependencies?utm_source=android-studio#dependency_configurations