### PR TITLE
[ts] Remove invalid Promise declaration

### DIFF
--- a/typings/react-native-code-push.d.ts
+++ b/typings/react-native-code-push.d.ts
@@ -1,22 +1,3 @@
-// Define an interal interface for Promise, so that
-// we don't need to reference an additional d.ts file.
-interface Promise<T> {
-    /**
-     * Append a rejection handler callback to the promise.
-     *
-     * @param onRejected Callback to be triggered when the promise is rejected.
-     */
-    catch(onRejected?: (reason: any) => Promise<T>): Promise<T>;
-
-    /**
-     * Append a fulfillment and/or rejection handler to the promise.
-     *
-     * @param onFulfilled Callback to be triggered when the promise is fulfilled.
-     * @param onRejected Callback to be triggered when the promise is rejected.
-     */
-    then(onFulfilled?: (value: T) => void, onRejected?: (reason: any) => Promise<T>): Promise<T>;
-}
-
 export type DowloadProgressCallback = (progress: DownloadProgress) => void;
 export type SyncStatusChangedCallback = (status: CodePush.SyncStatus) => void;
 export type HandleBinaryVersionMismatchCallback = (update: RemotePackage) => void;


### PR DESCRIPTION
The promise type defined in this library's TypeScript Declaration is incorrect.

`Promise` will already be ambiently declared in the library user's configuration, because by using this library they must also have Promises configured. Making the fix removing this type.

Defining `Promise` in TypeScript Declarations is not standard. See the [`react-native` typings](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-native/index.d.ts), where `Promise` is not defined by is used. Which will be used by all user's of this library.