### PR TITLE
Updated proguard rules to keep `mBundleLoader` field

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -16,13 +16,9 @@
 #   public *;
 #}
 
-# Invoked via reflection, when forcing javascript restarts.
--keepclassmembers class com.facebook.react.ReactInstanceManagerImpl {
-    void recreateReactContextInBackground();
-}
-
--keepclassmembers class com.facebook.react.XReactInstanceManagerImpl {
-    void recreateReactContextInBackground();
+# Invoked via reflection, when setting js bundle.
+-keepclassmembers class com.facebook.react.ReactInstanceManager {
+    private final ** mBundleLoader;
 }
 
 # Can't find referenced class org.bouncycastle.**


### PR DESCRIPTION
**Problem**:  android app cannot restart after codepush update in release mode.
**Cause**: private field `mBundleLoader` of `ReactInstanceManager` is obfuscated so it cannot be found via reflection.
**Solution**: add a rule to keep the field unchanged.
(Also removed outdated rules)
