### PR TITLE
[Feature] Re-try mechanism for CodePush Rollbacks 

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -254,9 +254,9 @@ async function shouldUpdateBeIgnored(remotePackage, syncOptions) {
     return true;
   }
 
-  const { delayInHours, maxAttempts } = rollbackRetryOptions;
+  const { delayInHours, maxRetryAttempts } = rollbackRetryOptions;
   const hoursSinceLatestRollback = (Date.now() - latestRollbackInfo.time) / (1000 * 60 * 60);
-  if (hoursSinceLatestRollback >= delayInHours && maxAttempts >= latestRollbackInfo.count) {
+  if (hoursSinceLatestRollback >= delayInHours && maxRetryAttempts >= latestRollbackInfo.count) {
     log("Previous rollback should be ignored due to rollback retry options.");
     return false;
   }
@@ -278,13 +278,13 @@ function validateRollbackRetryOptions(rollbackRetryOptions) {
     return false;
   }
 
-  if (typeof rollbackRetryOptions.maxAttempts !== "number") {
-    log("The 'maxAttempts' rollback retry parameter must be a number.");
+  if (typeof rollbackRetryOptions.maxRetryAttempts !== "number") {
+    log("The 'maxRetryAttempts' rollback retry parameter must be a number.");
     return false;
   }
 
-  if (rollbackRetryOptions.maxAttempts < 1) {
-    log("The 'maxAttempts' rollback retry parameter cannot be less then 1.");
+  if (rollbackRetryOptions.maxRetryAttempts < 1) {
+    log("The 'maxRetryAttempts' rollback retry parameter cannot be less then 1.");
     return false;
   }
 
@@ -656,7 +656,7 @@ if (NativeCodePush) {
     },
     DEFAULT_ROLLBACK_RETRY_OPTIONS: {
       delayInHours: 24,
-      maxAttempts: 1
+      maxRetryAttempts: 1
     }
   });
 } else {

--- a/CodePush.js
+++ b/CodePush.js
@@ -362,13 +362,15 @@ async function syncInternal(options = {}, syncStatusChangeCallback, downloadProg
     };
 
     const latestRollbackInfo = await NativeCodePush.getLatestRollbackInfo();
+
     let shouldIgnoreRollback = false;
-    if (latestRollbackInfo && latestRollbackInfo.hash == remotePackage.packageHash && latestRollbackInfo.time) {
-      log("latestRollbackInfo: " + JSON.stringify(latestRollbackInfo));
-      log("Date.now() - latestRollbackInfo.time = " + ((Date.now() - latestRollbackInfo.time) / 1000));
-      if (Date.now() - latestRollbackInfo.time >= 20000) {
+    if (latestRollbackInfo && latestRollbackInfo.packageHash === remotePackage.packageHash) {
+      const secSinceLatestRollback = (Date.now() - latestRollbackInfo.time) / 1000;
+      if (secSinceLatestRollback >= 15) {
         shouldIgnoreRollback = true;
       }
+      log("latestRollbackInfo: " + JSON.stringify(latestRollbackInfo));
+      log("Time since latest rollback: " + secSinceLatestRollback + "s.");
     }
 
     const updateShouldBeIgnored = remotePackage && !shouldIgnoreRollback && (remotePackage.failedInstall && syncOptions.ignoreFailedUpdates);

--- a/CodePush.js
+++ b/CodePush.js
@@ -294,6 +294,7 @@ async function syncInternal(options = {}, syncStatusChangeCallback, downloadProg
   const syncOptions = {
     deploymentKey: null,
     ignoreFailedUpdates: true,
+    rollbackRetryOptions: null,
     installMode: CodePush.InstallMode.ON_NEXT_RESTART,
     mandatoryInstallMode: CodePush.InstallMode.IMMEDIATE,
     minimumBackgroundDuration: 0,
@@ -361,40 +362,37 @@ async function syncInternal(options = {}, syncStatusChangeCallback, downloadProg
       return CodePush.SyncStatus.UPDATE_INSTALLED;
     };
 
-    const latestRollbackShouldBeIgnored = (latestRollbackInfo, rollbackRetryOptions) => {
-      const MILLISECONDS_IN_HOUR = 1000 * 60 * 60;
+    const shouldRetryPackage = async (packageHash) => {
       const DEFAULT_DELAY_IN_HOURS = 24;
       const DEFAULT_MAX_ATTEMPTS = 1;
 
-      if (!rollbackRetryOptions || typeof rollbackRetryOptions !== "object") {
+      if (!syncOptions.rollbackRetryOptions || typeof syncOptions.rollbackRetryOptions !== "object") {
         log("'rollbackRetryOptions' must be an Object");
         return false;
       }
-      
-      const { delayInHours = DEFAULT_DELAY_IN_HOURS, maxAttempts = DEFAULT_MAX_ATTEMPTS } = rollbackRetryOptions;
+
+      const latestRollbackInfo = await NativeCodePush.getLatestRollbackInfo();
+      if (!latestRollbackInfo || latestRollbackInfo.packageHash !== packageHash) {
+        return false;
+      }
+
+      const { delayInHours = DEFAULT_DELAY_IN_HOURS, maxAttempts = DEFAULT_MAX_ATTEMPTS } = syncOptions.rollbackRetryOptions;
       if (maxAttempts < 1) {
         return false;
       }
 
-      const hoursSinceLatestRollback = (Date.now() - latestRollbackInfo.time) / MILLISECONDS_IN_HOUR;
+      const hoursSinceLatestRollback = (Date.now() - latestRollbackInfo.time) / 1000 * 60 * 60;
       if (hoursSinceLatestRollback >= delayInHours && maxAttempts >= latestRollbackInfo.count) {
-        log("Previous rollback is being ignored due to rollback retry options.");
+        log("Previous rollback should be ignored due to rollback retry options.");
         return true;
       }
     }
 
-    const isFailedPackage = remotePackage && remotePackage.failedInstall;
-    
-    let rollbackShouldBeIgnored = false;
-    if (isFailedPackage && syncOptions.rollbackRetryOptions) {
-      const latestRollbackInfo = await NativeCodePush.getLatestRollbackInfo();
-      if (latestRollbackInfo && latestRollbackInfo.packageHash === remotePackage.packageHash) {
-        rollbackShouldBeIgnored = latestRollbackShouldBeIgnored(latestRollbackInfo, syncOptions.rollbackRetryOptions);
-      }
-    }
+    const updateShouldBeIgnored = remotePackage &&
+      remotePackage.failedInstall &&
+      syncOptions.ignoreFailedUpdates &&
+      (!syncOptions.rollbackRetryOptions || !await shouldRetryPackage(remotePackage.packageHash));
 
-    const updateShouldBeIgnored = isFailedPackage && syncOptions.ignoreFailedUpdates && !rollbackShouldBeIgnored;
-    
     if (!remotePackage || updateShouldBeIgnored) {
       if (updateShouldBeIgnored) {
           log("An update is available, but it is being ignored due to having been previously rolled back.");

--- a/CodePush.js
+++ b/CodePush.js
@@ -244,7 +244,7 @@ async function shouldUpdateBeIgnored(remotePackage, syncOptions) {
   }
 
   const { delayInHours = 24, maxAttempts = 1 } = rollbackRetryOptions;
-  if (maxAttempts < 1) {
+  if (typeof delayInHours !== "number" || typeof maxAttempts !== "number" || maxAttempts < 1) {
     return true;
   }
 

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushConstants.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushConstants.java
@@ -27,4 +27,8 @@ public class CodePushConstants {
     public static final String UNZIPPED_FOLDER_NAME = "unzipped";
     public static final String CODE_PUSH_APK_BUILD_TIME_KEY = "CODE_PUSH_APK_BUILD_TIME";
     public static final String BUNDLE_JWT_FILE = ".codepushrelease";
+    public static final String LATEST_ROLLBACK_PACKAGE_HASH_KEY = "hash";
+    public static final String LATEST_ROLLBACK_TIME_KEY = "time";
+    public static final String LATEST_ROLLBACK_COUNTER = "counter";
+    public static final String LATEST_ROLLBACK_INFO = "LATEST_ROLLBACK_INFO";
 }

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -528,14 +528,11 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
         } catch (CodePushUnknownException e) {
             CodePushUtils.log(e);
             promise.reject(e);
-        } catch (JSONException e) {
-            e.printStackTrace();
         }
     }
 
     @ReactMethod
     public void setLatestRollbackInfo(String packageHash, Promise promise) {
-        CodePushUtils.log("setLatestRollbackInfo");
         try {
             mSettingsManager.setLatestRollbackInfo(packageHash);
             promise.resolve(null);

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -510,7 +510,48 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
     public void isFailedUpdate(String packageHash, Promise promise) {
         try {
             promise.resolve(mSettingsManager.isFailedHash(packageHash));
-        } catch(CodePushUnknownException e) {
+        } catch (CodePushUnknownException e) {
+            CodePushUtils.log(e);
+            promise.reject(e);
+        }
+    }
+
+    @ReactMethod
+    public void removePackageFromFailedUpdates(String packageHash, Promise promise) {
+        CodePushUtils.log("removePackageFromFailedUpdates");
+        try {
+            mSettingsManager.removePackageFromFailedUpdates(packageHash);
+            promise.resolve(null);
+        } catch (CodePushUnknownException e) {
+            CodePushUtils.log(e);
+            promise.reject(e);
+        }
+    }
+
+    @ReactMethod
+    public void getLatestRollbackInfo(Promise promise) {
+        try {
+            if (mSettingsManager.getLatestRollbackInfo() != null) {
+                CodePushUtils.log("getLatestRollbackInfo: " + mSettingsManager.getLatestRollbackInfo().toString(2));
+                promise.resolve(CodePushUtils.convertJsonObjectToWritable(mSettingsManager.getLatestRollbackInfo()));
+            } else {
+                promise.resolve(null);
+            }
+        } catch (CodePushUnknownException e) {
+            CodePushUtils.log(e);
+            promise.reject(e);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @ReactMethod
+    public void setLatestRollbackInfo(String packageHash, Promise promise) {
+        CodePushUtils.log("setLatestRollbackInfo");
+        try {
+            mSettingsManager.setLatestRollbackInfo(packageHash);
+            promise.resolve(null);
+        } catch (CodePushUnknownException e) {
             CodePushUtils.log(e);
             promise.reject(e);
         }

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUtils.java
@@ -22,6 +22,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Iterator;
 
+import static java.lang.Math.toIntExact;
+
 public class CodePushUtils {
 
     public static String appendPathComponent(String basePath, String appendPathComponent) {
@@ -83,6 +85,9 @@ public class CodePushUtils {
                 map.putDouble(key, (Double) obj);
             else if (obj instanceof Integer)
                 map.putInt(key, (Integer) obj);
+            // TODO: Fix it
+            else if (obj instanceof Long)
+                map.putDouble(key, ((Long) obj).doubleValue());
             else if (obj instanceof Boolean)
                 map.putBoolean(key, (Boolean) obj);
             else if (obj == null)

--- a/android/app/src/main/java/com/microsoft/codepush/react/SettingsManager.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/SettingsManager.java
@@ -107,6 +107,77 @@ public class SettingsManager {
         mSettings.edit().putString(CodePushConstants.FAILED_UPDATES_KEY, failedUpdates.toString()).commit();
     }
 
+    public void removePackageFromFailedUpdates(String packageHash) {
+        String failedUpdatesString = mSettings.getString(CodePushConstants.FAILED_UPDATES_KEY, null);
+        if (failedUpdatesString != null) {
+            try {
+                JSONArray failedUpdates = new JSONArray(failedUpdatesString);
+                JSONArray newFailedUpdates = new JSONArray();
+                if (packageHash != null) {
+                    for (int i = 0; i < failedUpdates.length(); i++) {
+                        JSONObject failedPackage = failedUpdates.getJSONObject(i);
+                        String failedPackageHash = failedPackage.getString(CodePushConstants.PACKAGE_HASH_KEY);
+                        CodePushUtils.log(failedPackageHash + " - " + packageHash);
+                        if (!packageHash.equals(failedPackageHash)) {
+                            newFailedUpdates.put(failedPackage);
+                        } else {
+                            CodePushUtils.log("Failed hash removed: " + packageHash);
+                        }
+                    }
+                }
+                mSettings.edit().putString(CodePushConstants.FAILED_UPDATES_KEY, newFailedUpdates.toString()).commit();
+            } catch (JSONException e) {
+                // Should not happen.
+                throw new CodePushMalformedDataException("Unable to parse failed updates information "
+                        + failedUpdatesString + " stored in SharedPreferences", e);
+            }
+        }
+    }
+
+    public void setLatestRollbackInfo(String packageHash) {
+        JSONObject latestRollbackInfo = getLatestRollbackInfo();
+        long count;
+
+        if (latestRollbackInfo == null) {
+            latestRollbackInfo = new JSONObject();
+            count = 0;
+        } else {
+            try {
+                count = latestRollbackInfo.getLong(CodePushConstants.LATEST_ROLLBACK_COUNTER);
+            } catch (JSONException e) {
+                count = 0;
+                e.printStackTrace();
+            }
+        }
+
+        try {
+            long latestRollbackTime = System.currentTimeMillis();
+            latestRollbackInfo.put(CodePushConstants.LATEST_ROLLBACK_PACKAGE_HASH_KEY, packageHash);
+            latestRollbackInfo.put(CodePushConstants.LATEST_ROLLBACK_TIME_KEY, latestRollbackTime);
+            latestRollbackInfo.put(CodePushConstants.LATEST_ROLLBACK_COUNTER, count + 1);
+            mSettings.edit().putString(CodePushConstants.LATEST_ROLLBACK_INFO, latestRollbackInfo.toString()).commit();
+            CodePushUtils.log("setLatestRollbackInfo - Time: " + latestRollbackTime + " Hash: " + packageHash);
+        } catch (JSONException e) {
+            throw new CodePushUnknownException("Unable to save latest rollback info.", e);
+        }
+    }
+
+    public JSONObject getLatestRollbackInfo() {
+        String latestRollbackInfoString = mSettings.getString(CodePushConstants.LATEST_ROLLBACK_INFO, null);
+        if (latestRollbackInfoString == null) {
+            return null;
+        }
+
+        try {
+            return new JSONObject(latestRollbackInfoString);
+        } catch (JSONException e) {
+            // Should not happen.
+            CodePushUtils.log("Unable to parse latest rollback metadata " + latestRollbackInfoString +
+                    " stored in SharedPreferences");
+            return null;
+        }
+    }
+
     public void savePendingUpdate(String packageHash, boolean isLoading) {
         JSONObject pendingUpdate = new JSONObject();
         try {

--- a/docs/api-js.md
+++ b/docs/api-js.md
@@ -148,6 +148,14 @@ The `codePush` decorator accepts an "options" object that allows you to customiz
 
     * __title__ *(String)* - The text used as the header of an update notification that is displayed to the end user. Defaults to `"Update available"`.
 
+* __rollbackRetryOptions__ *(RollbackRetryOptions)* - An "options" object used to determine whether a rollback retry mechanism should be enabled, and if so, what settings to use. Defaults to `null`, which has the effect of disabling the retry mechanism completely. Setting this to any truthy value will enable the retry mechanism with the default settings, and passing an object to this parameter allows enabling the retry mechanism as well as overriding one or more of the default values. The rollback retry mechanism allows the application to attempt to reinstall an update that was previously rolled back (with the restrictions specified in the options).
+
+    The following list represents the available options and their defaults:
+
+    * __delayInHours__ *(Number)* - Specifies the minimum time in hours that the app will wait after the latest rollback before attempting to reinstall the same rolled-back package. Defaults to `24`.
+
+    * __maxRetryAttempts__ *(Number)* - Specifies the maximum number of retry attempts that the app can make before it stops trying. Cannot be less than `1`. Defaults to `1`.
+
 ##### codePushStatusDidChange (event hook)
 
 Called when the sync process moves from one stage to another in the overall update process. The event hook is called with a status code which represents the current state, and can be any of the [`SyncStatus`](#syncstatus) values.

--- a/ios/CodePush/CodePush.h
+++ b/ios/CodePush/CodePush.h
@@ -62,6 +62,10 @@
  */
 + (BOOL)isFailedHash:(NSString*)packageHash;
 
++ (NSDictionary*)getRollbackInfo:(NSString*)packageHash;
+
++ (void)setLatestRollbackInfo:(NSString*)packageHash;
+
 /*
  * This method checks to see whether a specific package hash
  * represents a downloaded and installed update, that hasn't

--- a/typings/react-native-code-push.d.ts
+++ b/typings/react-native-code-push.d.ts
@@ -135,6 +135,15 @@ export interface SyncOptions {
      * overriding one or more of the default strings.
      */
     updateDialog?: UpdateDialog;
+
+    /**
+     * An "options" object used to determine whether a rollback retry mechanism should be enabled, and if so, what settings to use.
+     * Defaults to `null`, which has the effect of disabling the retry mechanism completely. Setting this to any truthy value will enable
+     * the retry mechanism with the default settings, and passing an object to this parameter allows enabling the retry mechanism as well
+     * as overriding one or more of the default values. The rollback retry mechanism allows the application to attempt to reinstall
+     * an update that was previously rolled back (with the restrictions specified in the options).
+     */
+    rollbackRetryOptions?: RollbackRetryOptions;
 }
 
 export interface UpdateDialog {
@@ -180,6 +189,20 @@ export interface UpdateDialog {
      * The text used as the header of an update notification that is displayed to the end user. Defaults to "Update available".
      */
     title?: string;
+}
+
+export interface RollbackRetryOptions {
+    /**
+     * Specifies the minimum time in hours that the app will wait after the latest rollback
+     * before attempting to reinstall same rolled-back package. Defaults to `24`.
+     */
+    delayInHours?: number;
+
+    /**
+     * Specifies the maximum number of retry attempts that the app can make before it stops trying.
+     * Cannot be less than `1`. Defaults to `1`.
+     */
+    maxRetryAttempts?: number;
 }
 
 export interface StatusReport {


### PR DESCRIPTION
CodePush rollbacks can occur for several reasons including closing an app during install, faulty cellular reception, etc. As of now, when this occurs the app never re-tries to download this update which results in a customer being stuck on an old version of an app until the developer decides to push a new release or the user re-installs or clears the app (This is a bad experience). Users are essentially stuck running old versions. 

This feature would solve this problem and additionally enable developers to have more control over their updating process. 

Adds an option in 'sync' method that would enable developers to control their retry logic. 
For example:
```
rollbackRetryOptions: {
    delayInHours: 24,
    maxAttempts: 2
}
```