### PR TITLE
Replace deprecated 'compile' gradle configuration with 'implementation'

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,6 +26,6 @@ android {
 }
 
 dependencies {
-    compile "com.facebook.react:react-native:+"
-    compile 'com.nimbusds:nimbus-jose-jwt:5.1'
+    implementation "com.facebook.react:react-native:+"
+    implementation 'com.nimbusds:nimbus-jose-jwt:5.1'
 }


### PR DESCRIPTION
According to [ReactNative@0.57](https://github.com/react-native-community/react-native-releases/blob/master/CHANGELOG.md#057) default gradle version is now `4.4`.