### PR TITLE
Fix ios postlink

### DIFF
--- a/scripts/postlink/ios/postlink.js
+++ b/scripts/postlink/ios/postlink.js
@@ -50,8 +50,8 @@ module.exports = () => {
         console.log(`"jsCodeLocation" already pointing to "[CodePush bundleURL]".`);
     } else {
         if (jsCodeLocations.length === 1) {
-            // If there is one `jsCodeLocation` it means that react-native app version is lower then 0.57.8 
-            // and we should replace this line with DEBUG ifdef statement and add CodePush calling for Release case
+            // If there is one `jsCodeLocation` it means that react-native app version is lower than 0.57.8 
+            // and we should replace this line with DEBUG ifdef statement and add CodePush call for Release case
 
             var oldJsCodeLocationAssignmentStatement = jsCodeLocations[0];
             var jsCodeLocationPatch = `
@@ -63,8 +63,8 @@ module.exports = () => {
             appDelegateContents = appDelegateContents.replace(oldJsCodeLocationAssignmentStatement,
                 jsCodeLocationPatch);
         } else if (jsCodeLocations.length === 2) {
-            // If there are 2 `jsCodeLocation` it means that react-native app version is higher then 0.57.8 or equal
-            // and we should replace second one(Release case) with CodePush calling
+            // If there are two `jsCodeLocation` it means that react-native app version is higher than 0.57.8 or equal
+            // and we should replace the second one(Release case) with CodePush call
 
             appDelegateContents = appDelegateContents.replace(jsCodeLocations[1],
                 newJsCodeLocationAssignmentStatement);

--- a/scripts/postlink/ios/postlink.js
+++ b/scripts/postlink/ios/postlink.js
@@ -50,7 +50,7 @@ module.exports = () => {
         console.log(`"jsCodeLocation" already pointing to "[CodePush bundleURL]".`);
     } else {
         if (jsCodeLocations.length === 1) {
-            // If there is one `jsCodeLocation` it is mean that react-native app version is low then 0.57.8 
+            // If there is one `jsCodeLocation` it means that react-native app version is lower then 0.57.8 
             // and we should replace this line with DEBUG ifdef statement and add CodePush calling for Release case
 
             var oldJsCodeLocationAssignmentStatement = jsCodeLocations[0];
@@ -63,7 +63,7 @@ module.exports = () => {
             appDelegateContents = appDelegateContents.replace(oldJsCodeLocationAssignmentStatement,
                 jsCodeLocationPatch);
         } else if (jsCodeLocations.length === 2) {
-            // If there are 2 `jsCodeLocation` It is mean that react-native app version is higher then 0.57.8 or equal
+            // If there are 2 `jsCodeLocation` it means that react-native app version is higher then 0.57.8 or equal
             // and we should replace second one(Release case) with CodePush calling
 
             appDelegateContents = appDelegateContents.replace(jsCodeLocations[1],

--- a/scripts/postlink/ios/postlink.js
+++ b/scripts/postlink/ios/postlink.js
@@ -50,6 +50,9 @@ module.exports = () => {
         console.log(`"jsCodeLocation" already pointing to "[CodePush bundleURL]".`);
     } else {
         if (jsCodeLocations.length === 1) {
+            // If there is one `jsCodeLocation` it is mean that react-native app version is low then 0.57.8 
+            // and we should replace this line with DEBUG ifdef statement and add CodePush calling for Release case
+
             var oldJsCodeLocationAssignmentStatement = jsCodeLocations[0];
             var jsCodeLocationPatch = `
                 #ifdef DEBUG
@@ -60,6 +63,9 @@ module.exports = () => {
             appDelegateContents = appDelegateContents.replace(oldJsCodeLocationAssignmentStatement,
                 jsCodeLocationPatch);
         } else if (jsCodeLocations.length === 2) {
+            // If there are 2 `jsCodeLocation` It is mean that react-native app version is higher then 0.57.8 or equal
+            // and we should replace second one(Release case) with CodePush calling
+
             appDelegateContents = appDelegateContents.replace(jsCodeLocations[1],
                 newJsCodeLocationAssignmentStatement);
         } else {


### PR DESCRIPTION
**Issue:** 0.57.8 react-native version changed `AppDelegate.m` file by adding DEBUG ifdef statement. This affects CodePush link logic.

**Solution:** Changed postlink logic by replacing Release case with CodePush call. For old CodePush version logic is the same. Result postlink logic is the same for old and new React-Native.

Related PR(React-native changing): https://github.com/facebook/react-native/pull/22531
Related issue: https://github.com/Microsoft/react-native-code-push/issues/1473