### PR TITLE
added ios/Frameworks to ignore list for ios/postLink.js

### DIFF
--- a/scripts/postlink/ios/postlink.js
+++ b/scripts/postlink/ios/postlink.js
@@ -11,8 +11,8 @@ module.exports = () => {
 
     console.log("Running ios postlink script");
 
-    var ignoreNodeModules = { ignore: "node_modules/**" };
-    var ignoreNodeModulesAndPods = { ignore: ["node_modules/**", "ios/Pods/**"] };
+    var ignoreNodeModules = { ignore: [ "node_modules/**", "ios/Frameworks/**" ] };
+    var ignoreNodeModulesAndPods = { ignore: ["node_modules/**", "ios/Pods/**", "ios/Frameworks/**"] };
     var appDelegatePaths = glob.sync("**/AppDelegate.+(mm|m)", ignoreNodeModules);
 
     // Fix for https://github.com/Microsoft/react-native-code-push/issues/477


### PR DESCRIPTION
Some ios configurations include a Frameworks folders that have example xcodeproj and jsCodeLocation files, which break ios/postLink. This pull request adds ios/Frameworks to the ignore list.