### PR TITLE
Fixed issue with loss of the public key

### DIFF
--- a/ios/CodePush/CodePushConfig.m
+++ b/ios/CodePush/CodePushConfig.m
@@ -49,14 +49,14 @@ static NSString * const PublicKeyKey = @"publicKey";
         serverURL = @"https://codepush.azurewebsites.net/";
     }
 
-    _configDictionary = [[NSMutableDictionary alloc] initWithObjectsAndKeys:
-                            appVersion,AppVersionConfigKey,
-                            buildVersion,BuildVersionConfigKey,
-                            serverURL,ServerURLConfigKey,
-                            clientUniqueId,ClientUniqueIDConfigKey,
-                            deploymentKey,DeploymentKeyConfigKey,
-                            publicKey,PublicKeyKey,
-                            nil];
+    _configDictionary = [NSMutableDictionary dictionary];
+
+    if (appVersion) [_configDictionary setObject:appVersion forKey:AppVersionConfigKey];
+    if (buildVersion) [_configDictionary setObject:buildVersion forKey:BuildVersionConfigKey];
+    if (serverURL) [_configDictionary setObject:serverURL forKey:ServerURLConfigKey];
+    if (clientUniqueId) [_configDictionary setObject:clientUniqueId forKey:ClientUniqueIDConfigKey];
+    if (deploymentKey) [_configDictionary setObject:deploymentKey forKey:DeploymentKeyConfigKey];
+    if (publicKey) [_configDictionary setObject:publicKey forKey:PublicKeyKey];
 
     return self;
 }


### PR DESCRIPTION
**Issue:** Public key is lost in case if deploymentKey doesn't exist in `info.plist`(for example if developer set deployment ket in js code). This trigger installing update without checking signing even if `CodePushPublicKey` exist in `info.plist`. The reason of this issue in `initWithObjectsAndKeys` method as deploymentKey is nil public key would not be set.

**Solution:** Replaced `initWithObjectsAndKeys` method with separately setting ever property with `setObject` method.

Related issue: https://github.com/Microsoft/react-native-code-push/issues/1500