### PR TITLE
Replaced codepush home page link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![Switching tags](https://cloud.githubusercontent.com/assets/8598682/17350832/ce0dec40-58de-11e6-9c8c-906bb114c34f.png)
 
-This plugin provides client-side integration for the [CodePush service](http://codepush.tools), allowing you to easily add a dynamic update experience to your React Native app(s).
+This plugin provides client-side integration for the [CodePush service](https://microsoft.github.io/code-push/), allowing you to easily add a dynamic update experience to your React Native app(s).
 
 <!-- React Native Catalog -->
 


### PR DESCRIPTION
http://codepush.tools link has expired. Replaced it with https://microsoft.github.io/code-push/ mirror.