### PR TITLE
log when load bundle fails.

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -161,6 +161,7 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
         } catch (Exception e) {
             // Our reflection logic failed somewhere
             // so fall back to restarting the Activity (if it exists)
+            CodePushUtils.log("Failed to load the bundle, falling back to restarting the Activity (if it exists). " + e.getMessage());
             loadBundleLegacy();
         }
     }


### PR DESCRIPTION
Took some time for us to figure why the new bundle was not getting installed on onResume. Since our application class does not extend `ReactApplication` it was throwing a class cast exception. Solved it by passing in the `ReactHolder` instance. 
Adding a log message to save some time for other devs.