### PR TITLE
Handle JSON parsing exception

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -213,7 +213,15 @@ public class CodePush implements ReactPackage {
         this.mAssetsBundleFileName = assetsBundleFileName;
         String binaryJsBundleUrl = CodePushConstants.ASSETS_BUNDLE_PREFIX + assetsBundleFileName;
 
-        String packageFilePath = mUpdateManager.getCurrentPackageBundlePath(this.mAssetsBundleFileName);
+        String packageFilePath = null;
+        try {
+            packageFilePath = mUpdateManager.getCurrentPackageBundlePath(this.mAssetsBundleFileName);
+        } catch (CodePushMalformedDataException e) {
+            // We need to recover the app in case 'codepush.json' is corrupted
+            CodePushUtils.log(e.getMessage());
+            clearUpdates();
+        }
+
         if (packageFilePath == null) {
             // There has not been any downloaded updates.
             CodePushUtils.logBundleUrl(binaryJsBundleUrl);

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -349,6 +349,11 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
                         CodePushUtils.setJSONValueForKey(currentPackage, "isPending", currentUpdateIsPending);
                         promise.resolve(CodePushUtils.convertJsonObjectToWritable(currentPackage));
                     }
+                } catch (CodePushMalformedDataException e) {
+                    // We need to recover the app in case 'codepush.json' is corrupted
+                    CodePushUtils.log(e.getMessage());
+                    clearUpdates();
+                    promise.resolve(null);
                 } catch(CodePushUnknownException e) {
                     CodePushUtils.log(e);
                     promise.reject(e);


### PR DESCRIPTION
There are cases when the `codepush.json` is empty due to some hardware issues. So we have to deal with this.

Related issues: #1149, #1507.