### PR TITLE
Add support react-native@0.59

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "hoist-non-react-statics": "^2.3.1",
     "inquirer": "1.1.2",
     "plist": "3.0.1",
+    "semver": "^5.6.0",
     "xcode": "1.0.0"
   },
   "devDependencies": {

--- a/scripts/postlink/ios/postlink.js
+++ b/scripts/postlink/ios/postlink.js
@@ -42,10 +42,10 @@ module.exports = () => {
     }
 
     // 2. Modify jsCodeLocation value assignment
-    var pacakgeJson = JSON.parse(fs.readFileSync(packageJsonPath[0], "utf8"));
-    var reactnativeVersion = pacakgeJson["dependencies"]["react-native"];
+    var packageJson = JSON.parse(fs.readFileSync(packageJsonPath[0], "utf8"));
+    var reactnativeVersion = packageJson["dependencies"]["react-native"];
 
-    if (semver.compare(reactnativeVersion, "0.59.0") >= 0) {
+    if (semver.gte(reactnativeVersion, "0.59.0")) {
         var oldBundleUrl = "[[NSBundle mainBundle] URLForResource:@\"main\" withExtension:@\"jsbundle\"]";
         var codePushBundleUrl = "[CodePush bundleURL]";
 
@@ -132,7 +132,7 @@ module.exports = () => {
     // Helper that filters an array with AppDelegate.m paths for a path with the app name inside it
     // Should cover nearly all cases
     function findFileByAppName(array, appName) {
-        if (array.length === 0 || !appName) return null;
+        if (array.length === 0 || !appName) return null;
 
         for (var i = 0; i < array.length; i++) {
             var path = array[i];

--- a/scripts/postlink/ios/postlink.js
+++ b/scripts/postlink/ios/postlink.js
@@ -43,9 +43,13 @@ module.exports = () => {
 
     // 2. Modify jsCodeLocation value assignment
     var packageJson = JSON.parse(fs.readFileSync(packageJsonPath[0], "utf8"));
-    var reactnativeVersion = packageJson["dependencies"]["react-native"];
+    var reactNativeVersion = packageJson && packageJson.dependencies && packageJson.dependencies["react-native"];
 
-    if (semver.gte(reactnativeVersion, "0.59.0")) {
+    if (!reactNativeVersion) {
+        console.log(`Can't take react-native version from package.json`);
+    }
+
+    if (semver.gte(reactNativeVersion, "0.59.0")) {
         var oldBundleUrl = "[[NSBundle mainBundle] URLForResource:@\"main\" withExtension:@\"jsbundle\"]";
         var codePushBundleUrl = "[CodePush bundleURL]";
 

--- a/scripts/postlink/ios/postlink.js
+++ b/scripts/postlink/ios/postlink.js
@@ -45,7 +45,7 @@ module.exports = () => {
 
     if (!reactNativeVersion) {
         console.log(`Can't take react-native version from package.json`);
-    } else if (semver.gte(reactNativeVersion, "0.59.0")) {
+    } else if (semver.gte(semver.coerce(reactNativeVersion), "0.59.0")) {
         var oldBundleUrl = "[[NSBundle mainBundle] URLForResource:@\"main\" withExtension:@\"jsbundle\"]";
         var codePushBundleUrl = "[CodePush bundleURL]";
 

--- a/scripts/postlink/ios/postlink.js
+++ b/scripts/postlink/ios/postlink.js
@@ -15,7 +15,6 @@ module.exports = () => {
     var ignoreNodeModules = { ignore: "node_modules/**" };
     var ignoreNodeModulesAndPods = { ignore: ["node_modules/**", "ios/Pods/**"] };
     var appDelegatePaths = glob.sync("**/AppDelegate.+(mm|m)", ignoreNodeModules);
-    var packageJsonPath = glob.sync("./package.json", ignoreNodeModules);
 
     // Fix for https://github.com/Microsoft/react-native-code-push/issues/477
     // Typical location of AppDelegate.m for newer RN versions: $PROJECT_ROOT/ios/<project_name>/AppDelegate.m
@@ -42,8 +41,7 @@ module.exports = () => {
     }
 
     // 2. Modify jsCodeLocation value assignment
-    var packageJson = JSON.parse(fs.readFileSync(packageJsonPath[0], "utf8"));
-    var reactNativeVersion = packageJson && packageJson.dependencies && packageJson.dependencies["react-native"];
+    var reactNativeVersion = package && package.dependencies && package.dependencies["react-native"];
 
     if (!reactNativeVersion) {
         console.log(`Can't take react-native version from package.json`);

--- a/scripts/postlink/ios/postlink.js
+++ b/scripts/postlink/ios/postlink.js
@@ -44,14 +44,13 @@ module.exports = () => {
     var pacakgeJson = JSON.parse(fs.readFileSync(packageJsonPath[0], "utf8"));
     var reactnativeVersion = pacakgeJson["dependencies"]["react-native"];
 
-    if(reactnativeVersion >= "0.59.0") {
+    if (reactnativeVersion >= "0.59.0") {
         var old = "[[NSBundle mainBundle] URLForResource:@\"main\" withExtension:@\"jsbundle\"]";
 
-        appDelegateContents = appDelegateContents.replace(old,
-            "[CodePush bundleURL]");
+        appDelegateContents = appDelegateContents.replace(old, "[CodePush bundleURL]");
     } else {
         var jsCodeLocations = appDelegateContents.match(/(jsCodeLocation = .*)/g);
-    
+
         if (!jsCodeLocations) {
             console.log('Couldn\'t find jsCodeLocation setting in AppDelegate.');
         }

--- a/scripts/postlink/ios/postlink.js
+++ b/scripts/postlink/ios/postlink.js
@@ -4,6 +4,7 @@ var inquirer = require('inquirer');
 var path = require("path");
 var plist = require("plist");
 var xcode = require("xcode");
+var semver = require('semver');
 
 var package = require('../../../../../package.json');
 
@@ -44,7 +45,7 @@ module.exports = () => {
     var pacakgeJson = JSON.parse(fs.readFileSync(packageJsonPath[0], "utf8"));
     var reactnativeVersion = pacakgeJson["dependencies"]["react-native"];
 
-    if (reactnativeVersion >= "0.59.0") {
+    if (semver.compare(reactnativeVersion, "0.59.0") >= 0) {
         var old = "[[NSBundle mainBundle] URLForResource:@\"main\" withExtension:@\"jsbundle\"]";
 
         appDelegateContents = appDelegateContents.replace(old, "[CodePush bundleURL]");

--- a/scripts/postlink/ios/postlink.js
+++ b/scripts/postlink/ios/postlink.js
@@ -15,7 +15,7 @@ module.exports = () => {
     var ignoreNodeModules = { ignore: "node_modules/**" };
     var ignoreNodeModulesAndPods = { ignore: ["node_modules/**", "ios/Pods/**"] };
     var appDelegatePaths = glob.sync("**/AppDelegate.+(mm|m)", ignoreNodeModules);
-    var packageJsonPath = glob.sync("**/package.json", ignoreNodeModules);
+    var packageJsonPath = glob.sync("./package.json", ignoreNodeModules);
 
     // Fix for https://github.com/Microsoft/react-native-code-push/issues/477
     // Typical location of AppDelegate.m for newer RN versions: $PROJECT_ROOT/ios/<project_name>/AppDelegate.m

--- a/scripts/postlink/ios/postlink.js
+++ b/scripts/postlink/ios/postlink.js
@@ -46,9 +46,18 @@ module.exports = () => {
     var reactnativeVersion = pacakgeJson["dependencies"]["react-native"];
 
     if (semver.compare(reactnativeVersion, "0.59.0") >= 0) {
-        var old = "[[NSBundle mainBundle] URLForResource:@\"main\" withExtension:@\"jsbundle\"]";
+        var oldBundleUrl = "[[NSBundle mainBundle] URLForResource:@\"main\" withExtension:@\"jsbundle\"]";
+        var codePushBundleUrl = "[CodePush bundleURL]";
 
-        appDelegateContents = appDelegateContents.replace(old, "[CodePush bundleURL]");
+        if (~appDelegateContents.indexOf(codePushBundleUrl)) {
+            console.log(`"BundleUrl" already pointing to "[CodePush bundleURL]".`);
+        } else {
+            if (~appDelegateContents.indexOf(oldBundleUrl)) {
+                appDelegateContents = appDelegateContents.replace(oldBundleUrl, codePushBundleUrl);
+            } else {
+                console.log(`AppDelegate isn't compatible for linking`);
+            }
+        }
     } else {
         var jsCodeLocations = appDelegateContents.match(/(jsCodeLocation = .*)/g);
 

--- a/scripts/postlink/ios/postlink.js
+++ b/scripts/postlink/ios/postlink.js
@@ -45,57 +45,57 @@ module.exports = () => {
     var packageJson = JSON.parse(fs.readFileSync(packageJsonPath[0], "utf8"));
     var reactNativeVersion = packageJson && packageJson.dependencies && packageJson.dependencies["react-native"];
 
-    if (!reactNativeVersion) {
-        console.log(`Can't take react-native version from package.json`);
-    }
+    if (reactNativeVersion) {
+        if (semver.gte(reactNativeVersion, "0.59.0")) {
+            var oldBundleUrl = "[[NSBundle mainBundle] URLForResource:@\"main\" withExtension:@\"jsbundle\"]";
+            var codePushBundleUrl = "[CodePush bundleURL]";
 
-    if (semver.gte(reactNativeVersion, "0.59.0")) {
-        var oldBundleUrl = "[[NSBundle mainBundle] URLForResource:@\"main\" withExtension:@\"jsbundle\"]";
-        var codePushBundleUrl = "[CodePush bundleURL]";
-
-        if (~appDelegateContents.indexOf(codePushBundleUrl)) {
-            console.log(`"BundleUrl" already pointing to "[CodePush bundleURL]".`);
-        } else {
-            if (~appDelegateContents.indexOf(oldBundleUrl)) {
-                appDelegateContents = appDelegateContents.replace(oldBundleUrl, codePushBundleUrl);
+            if (~appDelegateContents.indexOf(codePushBundleUrl)) {
+                console.log(`"BundleUrl" already pointing to "[CodePush bundleURL]".`);
             } else {
-                console.log(`AppDelegate isn't compatible for linking`);
+                if (~appDelegateContents.indexOf(oldBundleUrl)) {
+                    appDelegateContents = appDelegateContents.replace(oldBundleUrl, codePushBundleUrl);
+                } else {
+                    console.log(`AppDelegate isn't compatible for linking`);
+                }
+            }
+        } else {
+            var jsCodeLocations = appDelegateContents.match(/(jsCodeLocation = .*)/g);
+
+            if (!jsCodeLocations) {
+                console.log('Couldn\'t find jsCodeLocation setting in AppDelegate.');
+            }
+
+            var newJsCodeLocationAssignmentStatement = "jsCodeLocation = [CodePush bundleURL];";
+            if (~appDelegateContents.indexOf(newJsCodeLocationAssignmentStatement)) {
+                console.log(`"jsCodeLocation" already pointing to "[CodePush bundleURL]".`);
+            } else {
+                if (jsCodeLocations.length === 1) {
+                    // If there is one `jsCodeLocation` it means that react-native app version is lower than 0.57.8 
+                    // and we should replace this line with DEBUG ifdef statement and add CodePush call for Release case
+
+                    var oldJsCodeLocationAssignmentStatement = jsCodeLocations[0];
+                    var jsCodeLocationPatch = `
+                        #ifdef DEBUG
+                            ${oldJsCodeLocationAssignmentStatement}
+                        #else
+                            ${newJsCodeLocationAssignmentStatement}
+                        #endif`;
+                    appDelegateContents = appDelegateContents.replace(oldJsCodeLocationAssignmentStatement,
+                        jsCodeLocationPatch);
+                } else if (jsCodeLocations.length === 2) {
+                    // If there are two `jsCodeLocation` it means that react-native app version is higher than 0.57.8 or equal
+                    // and we should replace the second one(Release case) with CodePush call
+
+                    appDelegateContents = appDelegateContents.replace(jsCodeLocations[1],
+                        newJsCodeLocationAssignmentStatement);
+                } else {
+                    console.log(`AppDelegate isn't compatible for linking`);
+                }
             }
         }
     } else {
-        var jsCodeLocations = appDelegateContents.match(/(jsCodeLocation = .*)/g);
-
-        if (!jsCodeLocations) {
-            console.log('Couldn\'t find jsCodeLocation setting in AppDelegate.');
-        }
-
-        var newJsCodeLocationAssignmentStatement = "jsCodeLocation = [CodePush bundleURL];";
-        if (~appDelegateContents.indexOf(newJsCodeLocationAssignmentStatement)) {
-            console.log(`"jsCodeLocation" already pointing to "[CodePush bundleURL]".`);
-        } else {
-            if (jsCodeLocations.length === 1) {
-                // If there is one `jsCodeLocation` it means that react-native app version is lower than 0.57.8 
-                // and we should replace this line with DEBUG ifdef statement and add CodePush call for Release case
-
-                var oldJsCodeLocationAssignmentStatement = jsCodeLocations[0];
-                var jsCodeLocationPatch = `
-                    #ifdef DEBUG
-                        ${oldJsCodeLocationAssignmentStatement}
-                    #else
-                        ${newJsCodeLocationAssignmentStatement}
-                    #endif`;
-                appDelegateContents = appDelegateContents.replace(oldJsCodeLocationAssignmentStatement,
-                    jsCodeLocationPatch);
-            } else if (jsCodeLocations.length === 2) {
-                // If there are two `jsCodeLocation` it means that react-native app version is higher than 0.57.8 or equal
-                // and we should replace the second one(Release case) with CodePush call
-
-                appDelegateContents = appDelegateContents.replace(jsCodeLocations[1],
-                    newJsCodeLocationAssignmentStatement);
-            } else {
-                console.log(`AppDelegate isn't compatible for linking`);
-            }
-        }
+        console.log(`Can't take react-native version from package.json`);
     }
 
     var plistPath = getPlistPath();

--- a/scripts/postlink/ios/postlink.js
+++ b/scripts/postlink/ios/postlink.js
@@ -45,57 +45,55 @@ module.exports = () => {
     var packageJson = JSON.parse(fs.readFileSync(packageJsonPath[0], "utf8"));
     var reactNativeVersion = packageJson && packageJson.dependencies && packageJson.dependencies["react-native"];
 
-    if (reactNativeVersion) {
-        if (semver.gte(reactNativeVersion, "0.59.0")) {
-            var oldBundleUrl = "[[NSBundle mainBundle] URLForResource:@\"main\" withExtension:@\"jsbundle\"]";
-            var codePushBundleUrl = "[CodePush bundleURL]";
+    if (!reactNativeVersion) {
+        console.log(`Can't take react-native version from package.json`);
+    } else if (semver.gte(reactNativeVersion, "0.59.0")) {
+        var oldBundleUrl = "[[NSBundle mainBundle] URLForResource:@\"main\" withExtension:@\"jsbundle\"]";
+        var codePushBundleUrl = "[CodePush bundleURL]";
 
-            if (~appDelegateContents.indexOf(codePushBundleUrl)) {
-                console.log(`"BundleUrl" already pointing to "[CodePush bundleURL]".`);
-            } else {
-                if (~appDelegateContents.indexOf(oldBundleUrl)) {
-                    appDelegateContents = appDelegateContents.replace(oldBundleUrl, codePushBundleUrl);
-                } else {
-                    console.log(`AppDelegate isn't compatible for linking`);
-                }
-            }
+        if (~appDelegateContents.indexOf(codePushBundleUrl)) {
+            console.log(`"BundleUrl" already pointing to "[CodePush bundleURL]".`);
         } else {
-            var jsCodeLocations = appDelegateContents.match(/(jsCodeLocation = .*)/g);
-
-            if (!jsCodeLocations) {
-                console.log('Couldn\'t find jsCodeLocation setting in AppDelegate.');
-            }
-
-            var newJsCodeLocationAssignmentStatement = "jsCodeLocation = [CodePush bundleURL];";
-            if (~appDelegateContents.indexOf(newJsCodeLocationAssignmentStatement)) {
-                console.log(`"jsCodeLocation" already pointing to "[CodePush bundleURL]".`);
+            if (~appDelegateContents.indexOf(oldBundleUrl)) {
+                appDelegateContents = appDelegateContents.replace(oldBundleUrl, codePushBundleUrl);
             } else {
-                if (jsCodeLocations.length === 1) {
-                    // If there is one `jsCodeLocation` it means that react-native app version is lower than 0.57.8 
-                    // and we should replace this line with DEBUG ifdef statement and add CodePush call for Release case
-
-                    var oldJsCodeLocationAssignmentStatement = jsCodeLocations[0];
-                    var jsCodeLocationPatch = `
-                        #ifdef DEBUG
-                            ${oldJsCodeLocationAssignmentStatement}
-                        #else
-                            ${newJsCodeLocationAssignmentStatement}
-                        #endif`;
-                    appDelegateContents = appDelegateContents.replace(oldJsCodeLocationAssignmentStatement,
-                        jsCodeLocationPatch);
-                } else if (jsCodeLocations.length === 2) {
-                    // If there are two `jsCodeLocation` it means that react-native app version is higher than 0.57.8 or equal
-                    // and we should replace the second one(Release case) with CodePush call
-
-                    appDelegateContents = appDelegateContents.replace(jsCodeLocations[1],
-                        newJsCodeLocationAssignmentStatement);
-                } else {
-                    console.log(`AppDelegate isn't compatible for linking`);
-                }
+                console.log(`AppDelegate isn't compatible for linking`);
             }
         }
     } else {
-        console.log(`Can't take react-native version from package.json`);
+        var jsCodeLocations = appDelegateContents.match(/(jsCodeLocation = .*)/g);
+
+        if (!jsCodeLocations) {
+            console.log('Couldn\'t find jsCodeLocation setting in AppDelegate.');
+        }
+
+        var newJsCodeLocationAssignmentStatement = "jsCodeLocation = [CodePush bundleURL];";
+        if (~appDelegateContents.indexOf(newJsCodeLocationAssignmentStatement)) {
+            console.log(`"jsCodeLocation" already pointing to "[CodePush bundleURL]".`);
+        } else {
+            if (jsCodeLocations.length === 1) {
+                // If there is one `jsCodeLocation` it means that react-native app version is lower than 0.57.8 
+                // and we should replace this line with DEBUG ifdef statement and add CodePush call for Release case
+
+                var oldJsCodeLocationAssignmentStatement = jsCodeLocations[0];
+                var jsCodeLocationPatch = `
+                    #ifdef DEBUG
+                        ${oldJsCodeLocationAssignmentStatement}
+                    #else
+                        ${newJsCodeLocationAssignmentStatement}
+                    #endif`;
+                appDelegateContents = appDelegateContents.replace(oldJsCodeLocationAssignmentStatement,
+                    jsCodeLocationPatch);
+            } else if (jsCodeLocations.length === 2) {
+                // If there are two `jsCodeLocation` it means that react-native app version is higher than 0.57.8 or equal
+                // and we should replace the second one(Release case) with CodePush call
+
+                appDelegateContents = appDelegateContents.replace(jsCodeLocations[1],
+                    newJsCodeLocationAssignmentStatement);
+            } else {
+                console.log(`AppDelegate isn't compatible for linking`);
+            }
+        }
     }
 
     var plistPath = getPlistPath();


### PR DESCRIPTION
**Issue:** New version of react-native replaced JsCodeLocation with `sourceURLForBridge` method in  `appDelegate.m`

**Solution:** Changed `link` logic for making possible to update new version of `appDelegate.m` with CodePush bundleURL method.

Related issue: https://github.com/Microsoft/react-native-code-push/issues/1539