### PR TITLE
Change docs for react-native@0.59

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ We try our best to maintain backwards compatibility of our plugin with previous 
 | v0.46                   | v4.0+ *(RN refactored js bundle loader code)*         |
 | v0.46-v0.53             | v5.1+ *(RN removed unused registration of JS modules)*|
 | v0.54-v0.55             | v5.3+ *(Android Gradle Plugin 3.x integration)*       |
-| v0.56-v0.59             | v5.4+ *(RN upgraded versions for Android tools)*      |
+| v0.56-v0.58             | v5.4+ *(RN upgraded versions for Android tools)*      |
+| v0.59                   | v5.6+ *(RN refactored js bundle loader code)*         |
 
 We work hard to respond to new RN releases, but they do occasionally break us. We will update this chart with each RN release, so that users can check to see what our "official" support is.
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ We try our best to maintain backwards compatibility of our plugin with previous 
 | v0.46                   | v4.0+ *(RN refactored js bundle loader code)*         |
 | v0.46-v0.53             | v5.1+ *(RN removed unused registration of JS modules)*|
 | v0.54-v0.55             | v5.3+ *(Android Gradle Plugin 3.x integration)*       |
-| v0.56-v0.57             | v5.4+ *(RN upgraded versions for Android tools)*      |
+| v0.56-v0.59             | v5.4+ *(RN upgraded versions for Android tools)*      |
 
 We work hard to respond to new RN releases, but they do occasionally break us. We will update this chart with each RN release, so that users can check to see what our "official" support is.
 

--- a/docs/setup-ios.md
+++ b/docs/setup-ios.md
@@ -97,6 +97,22 @@ Once your Xcode project has been setup to build/link the CodePush plugin, you ne
     #import <CodePush/CodePush.h>
     ```
 
+For React Native 0.59 and above:
+
+2. Find the following line of code, which set source URL for bridge for production releases:
+
+    ```objective-c
+    return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+    ```
+
+3. Replace it with this line:
+
+    ```objective-c
+    return [CodePush bundleURL];
+    ```
+
+For React Native 0.58 and below:
+
 2. Find the following line of code, which loads your JS Bundle from the app binary for production releases:
 
     ```objective-c

--- a/docs/setup-ios.md
+++ b/docs/setup-ios.md
@@ -131,7 +131,20 @@ This change configures your app to always load the most recent version of your a
 
 Typically, you're only going to want to use CodePush to resolve your JS bundle location within release builds, and therefore, we recommend using the `DEBUG` pre-processor macro to dynamically switch between using the packager server and CodePush, depending on whether you are debugging or not. This will make it much simpler to ensure you get the right behavior you want in production, while still being able to use the Chrome Dev Tools, live reload, etc. at debug-time.
 
-For React Native 0.49 and above:
+For React Native 0.59 and above:
+
+```objective-c
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
+{
+  #if DEBUG
+    return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+  #else
+    return [CodePush bundleURL];
+  #endif
+}
+```
+
+For React Native 0.49 - 0.58:
 
 ```objective-c
 NSURL *jsCodeLocation;


### PR DESCRIPTION
**Issue:** New react-native@0.59 required other changes for setting source URL.

**Solution:** Update docs and support table.