### PR TITLE
Update android multi deployment testing docs

### DIFF
--- a/docs/multi-deployment-testing-android.md
+++ b/docs/multi-deployment-testing-android.md
@@ -26,6 +26,9 @@ To set this up, perform the following steps:
             releaseStaging {
                 ...
                 buildConfigField "String", "CODEPUSH_KEY", '"<INSERT_STAGING_KEY>"'
+                // Note: It is a good idea to provide matchingFallbacks for the new buildType you create to prevent build issues
+                // Add the following line if not already there
+                matchingFallbacks = ['release']
                 ...
             }
 


### PR DESCRIPTION
Add information about `matchingFallbacks` as [here](https://docs.microsoft.com/en-us/appcenter/distribution/codepush/react-native#android).

Related to #1557