### PR TITLE
Replace app store version with binary version in docs

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -39,7 +39,7 @@ async function checkForUpdate(deploymentKey = null, handleBinaryVersionMismatchC
    * then we want to use its package hash to determine whether a new
    * release has been made on the server. Otherwise, we only need
    * to send the app version to the server, since we are interested
-   * in any updates for current app store version, regardless of hash.
+   * in any updates for current binary version, regardless of hash.
    */
   let queryPackage;
   if (localPackage) {
@@ -58,7 +58,7 @@ async function checkForUpdate(deploymentKey = null, handleBinaryVersionMismatchC
    * ----------------------------------------------------------------
    * 1) The server said there isn't an update. This is the most common case.
    * 2) The server said there is an update but it requires a newer binary version.
-   *    This would occur when end-users are running an older app store version than
+   *    This would occur when end-users are running an older binary version than
    *    is available, and CodePush is making sure they don't get an update that
    *    potentially wouldn't be compatible with what they are running.
    * 3) The server said there is an update, but the update's hash is the same as

--- a/docs/api-ios.md
+++ b/docs/api-ios.md
@@ -12,7 +12,7 @@ The `CodePush` class' methods can be thought of as composite resolvers which alw
 
 2. As soon as you begin releasing CodePush updates, your end-users will get the JS bundle that represents the latest release for the configured deployment. This is the behavior that allows you to iterate beyond what you shipped to the store.
 
-3. As soon as you release an update to the app store (like `1.1.0`), and your end-users update it, they will once again get the JS bundle that is contained within the binary. This behavior ensures that CodePush updates that targetted a previous app store version aren't used (since we don't know if they would work), and your end-users always have a working version of your app.
+3. As soon as you release an update to the app store (like `1.1.0`), and your end-users update it, they will once again get the JS bundle that is contained within the binary. This behavior ensures that CodePush updates that targetted a previous binary version aren't used (since we don't know if they would work), and your end-users always have a working version of your app.
 
 4. Repeat #2 and #3 as the CodePush releases and app store releases continue on into infinity (and beyond?)
 

--- a/ios/CodePush/CodePush.h
+++ b/ios/CodePush/CodePush.h
@@ -45,7 +45,7 @@
 /*
  * This method allows the version of the app's binary interface
  * to be specified, which would otherwise default to the
- * App Store version of the app.
+ * binary version of the app.
  */
 + (void)overrideAppVersion:(NSString *)appVersion;
 


### PR DESCRIPTION
*Issue:* Docs says app store version where it should be binary version as it is more understandable for users.
*Solution:* Replaced app store version with binary version in docs.

Related issue: https://github.com/microsoft/code-push/issues/605
Related PR: https://github.com/microsoft/code-push/pull/634