### PR TITLE
Update to react native config from deprecated rnpm config. Configured as dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,19 +39,5 @@
     "run-sequence": "latest",
     "tslint": "^5.18.0",
     "typescript": "^2.9.2"
-  },
-  "rnpm": {
-    "android": {
-      "packageInstance": "new CodePush(getResources().getString(R.string.reactNativeCodePush_androidDeploymentKey), getApplicationContext(), BuildConfig.DEBUG)"
-    },
-    "ios": {
-      "sharedLibraries": [
-        "libz"
-      ]
-    },
-    "commands": {
-      "postlink": "node node_modules/react-native-code-push/scripts/postlink/run",
-      "postunlink": "node node_modules/react-native-code-push/scripts/postunlink/run"
-    }
   }
 }

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+  dependency: {
+    platforms: {
+      android: {
+        packageInstance:
+          "new CodePush(getResources().getString(R.string.reactNativeCodePush_androidDeploymentKey), getApplicationContext(), BuildConfig.DEBUG)"
+      },
+      ios: {
+        sharedLibraries: ["libz"]
+      }
+    },
+    hooks: {
+      postlink: "node node_modules/react-native-code-push/scripts/postlink/run",
+      postunlink: "node node_modules/react-native-code-push/scripts/postunlink/run"
+    }
+  }
+};


### PR DESCRIPTION
This commit will migrate from the deprecated `rnpm` to use `react-native.config.js`.

This resolves the warning:

> warn The following packages use deprecated "rnpm" config that will stop working from next release:
>  - react-native-code-push: https://microsoft.github.io/code-push
Please notify their maintainers about it. You can find more details at https://github.com/react-native-community/cli/blob/master/docs/configuration.md#migration-guide.

This PR configures the library as a `dependency`.