### PR TITLE
Chore: Migrate to new cli configuration to support RN 0.60.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,19 +39,5 @@
     "run-sequence": "latest",
     "tslint": "^5.18.0",
     "typescript": "^2.9.2"
-  },
-  "rnpm": {
-    "android": {
-      "packageInstance": "new CodePush(getResources().getString(R.string.reactNativeCodePush_androidDeploymentKey), getApplicationContext(), BuildConfig.DEBUG)"
-    },
-    "ios": {
-      "sharedLibraries": [
-        "libz"
-      ]
-    },
-    "commands": {
-      "postlink": "node node_modules/react-native-code-push/scripts/postlink/run",
-      "postunlink": "node node_modules/react-native-code-push/scripts/postunlink/run"
-    }
   }
 }

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  project: {
+    android: {
+      packageInstance: "new CodePush(getResources().getString(R.string.reactNativeCodePush_androidDeploymentKey), getApplicationContext(), BuildConfig.DEBUG)"
+    },
+    ios: {
+      sharedLibraries: [
+        "libz"
+      ]
+    },
+  },
+  hooks: {
+    "postlink": "node node_modules/react-native-code-push/scripts/postlink/run",
+    "postunlink": "node node_modules/react-native-code-push/scripts/postunlink/run"
+  }
+};


### PR DESCRIPTION
# Summary
As `rnpm` is deprecated, this PR migrates the configuration to `react-native.config.js` following this instruction https://github.com/react-native-community/cli/blob/master/docs/configuration.md#migration-guide
![image](https://user-images.githubusercontent.com/40555128/66741261-4bc62b80-ee9f-11e9-8dae-54ecff3fe37f.png)
