### PR TITLE
Mitigate Zipperdown vulnerability in file name validation #1283

### DIFF
--- a/CodePush.podspec
+++ b/CodePush.podspec
@@ -17,11 +17,11 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/CodePush/*.{h,m}'
   s.public_header_files = ['ios/CodePush/CodePush.h']
 
-  # Note: Even though there are copy/pasted versions of some of these dependencies in the repo, 
-  # we explicitly let CocoaPods pull in the versions below so all dependencies are resolved and 
+  # Note: Even though there are copy/pasted versions of some of these dependencies in the repo,
+  # we explicitly let CocoaPods pull in the versions below so all dependencies are resolved and
   # linked properly at a parent workspace level.
   s.dependency 'React'
-  s.dependency 'SSZipArchive', '~> 2.1'
+  s.dependency 'SSZipArchive', '~> 2.2.2'
   s.dependency 'JWT', '~> 3.0.0-beta.7'
   s.dependency 'Base64', '~> 1.1'
 end

--- a/android/app/src/main/java/com/microsoft/codepush/react/FileUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/FileUtils.java
@@ -123,6 +123,20 @@ public class FileUtils {
         }
     }
 
+    private static String validateFileName(String fileName, String targetDirectory) throws IOException {
+        File file = new File(fileName);
+        String canonicalPath = file.getCanonicalPath();
+
+        File targetFile = new File(targetDirectory);
+        String targetCanonicalPath = targetFile.getCanonicalPath();
+
+        if (!canonicalPath.startsWith(targetCanonicalPath)) {
+            throw new IllegalStateException("File is outside extraction target directory.");
+        }
+
+        return canonicalPath;
+    }
+
     public static void unzipFile(File zipFile, String destination) throws IOException {
         FileInputStream fileStream = null;
         BufferedInputStream bufferedStream = null;
@@ -137,12 +151,12 @@ public class FileUtils {
             if (destinationFolder.exists()) {
                 deleteFileOrFolderSilently(destinationFolder);
             }
-            
+
             destinationFolder.mkdirs();
 
             byte[] buffer = new byte[WRITE_BUFFER_SIZE];
             while ((entry = zipStream.getNextEntry()) != null) {
-                String fileName = entry.getName();
+                String fileName = validateFileName(entry.getName(), ".");
                 File file = new File(destinationFolder, fileName);
                 if (entry.isDirectory()) {
                     file.mkdirs();


### PR DESCRIPTION
Addresses the vulnerability identified in https://github.com/microsoft/react-native-code-push/issues/1283. This vulnerability is flagged by [Data Theorem](https://www.datatheorem.com/) and other scanning tools.

1. This addresses the issue with https://github.com/microsoft/react-native-code-push/pull/1537, as that pull request appears to have been abandoned.

1. I've confirmed that this update leads to a passing security scan in Data Theorem.