### PR TITLE
Fix imports for Cocoapods + Swift projects

### DIFF
--- a/ios/CodePush/CodePushPackage.m
+++ b/ios/CodePush/CodePushPackage.m
@@ -1,5 +1,10 @@
 #import "CodePush.h"
+
+#if __has_include(<SSZipArchive/SSZipArchive.h>)
+#import <SSZipArchive/SSZipArchive.h>
+#else
 #import "SSZipArchive.h"
+#endif
 
 @implementation CodePushPackage
 

--- a/ios/CodePush/CodePushUpdateUtils.m
+++ b/ios/CodePush/CodePushUpdateUtils.m
@@ -1,6 +1,12 @@
 #import "CodePush.h"
 #include <CommonCrypto/CommonDigest.h>
+
+#if __has_include(<JWT/JWT.h>)
+#import <JWT/JWT.h>
+#else
 #import "JWT.h"
+#endif
+
 
 @implementation CodePushUpdateUtils
 


### PR DESCRIPTION
This PR fixes an error we encountered in a hybrid (Swift + React Native) app we’re developing. 
We use cocoapods and RN 0.61.1, so the setup with autolinking was simple, however when building the iOS app, we got a build failure with a message of "JWT.h file not found" in the CodePushUpdateUtils.m file (same for SSZipArchive in CodePushPackage.m).

  In this PR we change the imports of JWT and SSZipArchive to a similar style that is used throughout the project for native React modules. This fixes the issue on our end and shouldn’t break anything for anyone else due to the conditional character of the import statements.

  Would appreciate any input on this and of course will answer any questions that would help reproduce if needed.