### PR TITLE
Fix test debugger

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
             "name": "Tests-android",
             "type": "node",
             "request": "launch",
-            "preLaunchTask": "Setup-tests-android",
+            "preLaunchTask": "Setup-android",
             "runtimeExecutable": "npm",
             "runtimeArgs": [
                 "run",
@@ -23,7 +23,7 @@
             "name": "Tests-ios",
             "type": "node",
             "request": "launch",
-            "preLaunchTask": "Setup-tests-ios",
+            "preLaunchTask": "Setup-ios",
             "runtimeExecutable": "npm",
             "runtimeArgs": [
                 "run",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -20,6 +20,7 @@
         {
             "type": "shell",
             "label": "Setup-android",
+            "dependsOn": "Build",
             "command": "npm",
             "args": [
                 "run",
@@ -36,6 +37,7 @@
         {
             "type": "shell",
             "label": "Setup-ios",
+            "dependsOn": "Build",
             "command": "npm",
             "args": [
                 "run",
@@ -47,20 +49,6 @@
             },
             "problemMatcher": [
                 "$tsc"
-            ]
-        },
-        {
-            "label": "Setup-tests-android",
-            "dependsOn": [
-                "Build",
-                "Setup-android"
-            ]
-        },
-        {
-            "label": "Setup-tests-ios",
-            "dependsOn": [
-                "Build",
-                "Setup-ios"
             ]
         }
     ]

--- a/tslint.json
+++ b/tslint.json
@@ -11,9 +11,6 @@
         "one-line": [true,
             "check-open-brace"
         ],
-        "no-unreachable": true,
-        "no-unused-variable": true,
-        "no-use-before-declare": true,
         "quotemark": [true,
             "double"
         ],


### PR DESCRIPTION
In the last PR #1765  we made a mistake that led to the build task does not run in debug mode. In this PR, we fixed it.

**Changes:**

- Updated tasks in `tasks.json`
- Removed `tslint` rules that were deprecated