### PR TITLE
[Tests] Fixed launch of Android emulator

### DIFF
--- a/code-push-plugin-testing-framework/script/platform.js
+++ b/code-push-plugin-testing-framework/script/platform.js
@@ -170,9 +170,28 @@ var AndroidEmulatorManager = (function () {
         if (this.targetEmulator)
             return Q(this.targetEmulator);
         else {
-            this.targetEmulator = testUtil_1.TestUtil.readMochaCommandLineOption(AndroidEmulatorManager.ANDROID_EMULATOR_OPTION_NAME, AndroidEmulatorManager.DEFAULT_ANDROID_EMULATOR);
-            console.log("Using Android emulator named " + this.targetEmulator);
-            return Q(this.targetEmulator);
+            const deferred = Q.defer();
+            const targetAndroidEmulator = testUtil_1.TestUtil.readMochaCommandLineOption(AndroidEmulatorManager.ANDROID_EMULATOR_OPTION_NAME);
+            if (!targetAndroidEmulator) {
+                // If no Android simulator is specified, get the most recent Android simulator to run tests on.
+                testUtil_1.TestUtil.getProcessOutput("emulator -list-avds", { noLogCommand: true, noLogStdOut: true, noLogStdErr: true })
+                    .then((Devices) => {
+                    const listOfDevices = Devices.trim().split("\n");
+                    deferred.resolve(listOfDevices[listOfDevices.length - 1]);
+                }, (error) => {
+                    deferred.reject(error);
+                });
+            }
+            else {
+                // Use the simulator specified on the command line.
+                deferred.resolve(targetAndroidEmulator);
+            }
+            return deferred.promise
+                .then((targetEmulator) => {
+                this.targetEmulator = targetEmulator;
+                console.log("Using Android simulator named " + this.targetEmulator);
+                return this.targetEmulator;
+            });
         }
     };
     /**
@@ -254,7 +273,6 @@ var AndroidEmulatorManager = (function () {
         return commandWithCheckAppExistence("adb uninstall", appId);
     };
     AndroidEmulatorManager.ANDROID_EMULATOR_OPTION_NAME = "--androidemu";
-    AndroidEmulatorManager.DEFAULT_ANDROID_EMULATOR = "emulator";
     return AndroidEmulatorManager;
 }());
 exports.AndroidEmulatorManager = AndroidEmulatorManager;

--- a/code-push-plugin-testing-framework/typings/code-push-plugin-testing-framework.d.ts
+++ b/code-push-plugin-testing-framework/typings/code-push-plugin-testing-framework.d.ts
@@ -127,7 +127,6 @@ declare module 'code-push-plugin-testing-framework/script/platform' {
 	}
 	export class AndroidEmulatorManager implements IEmulatorManager {
 	    private static ANDROID_EMULATOR_OPTION_NAME;
-	    private static DEFAULT_ANDROID_EMULATOR;
 	    private targetEmulator;
 	    /**
 	     * Returns the target emulator, which is specified through the command line.


### PR DESCRIPTION
To run the tests requires an Android or Ios emulator. The command to launch the android emulator did not work, in this PR we fixed it.

**Changes:**

- Added command to launch the most recent Android emulator to run tests on