### PR TITLE
[Tests] Fix server response

### DIFF
--- a/code-push-plugin-testing-framework/script/serverUtil.js
+++ b/code-push-plugin-testing-framework/script/serverUtil.js
@@ -83,15 +83,15 @@ exports.UpdateCheckRequestMock = UpdateCheckRequestMock;
  */
 function createDefaultResponse() {
     var defaultResponse = new CheckForUpdateResponseMock();
-    defaultResponse.downloadURL = "";
+    defaultResponse.download_url = "";
     defaultResponse.description = "";
-    defaultResponse.isAvailable = false;
+    defaultResponse.is_available = false;
     defaultResponse.isMandatory = false;
-    defaultResponse.appVersion = "";
-    defaultResponse.packageHash = "";
+    defaultResponse.app_version = "";
+    defaultResponse.package_hash = "";
     defaultResponse.label = "";
-    defaultResponse.packageSize = 0;
-    defaultResponse.updateAppVersion = false;
+    defaultResponse.package_size = 0;
+    defaultResponse.update_app_version = false;
     return defaultResponse;
 }
 exports.createDefaultResponse = createDefaultResponse;
@@ -102,19 +102,19 @@ function createUpdateResponse(mandatory, targetPlatform, randomHash) {
     if (mandatory === void 0) { mandatory = false; }
     if (randomHash === void 0) { randomHash = true; }
     var updateResponse = new CheckForUpdateResponseMock();
-    updateResponse.isAvailable = true;
-    updateResponse.appVersion = "1.0.0";
-    updateResponse.downloadURL = "mock.url/download";
+    updateResponse.is_available = true;
+    updateResponse.app_version = "1.0.0";
+    updateResponse.download_url = "mock.url/v0.1/public/codepush/report_status/download";
     updateResponse.isMandatory = mandatory;
     updateResponse.label = "mock-update";
-    updateResponse.packageHash = "12345-67890";
-    updateResponse.packageSize = 12345;
-    updateResponse.updateAppVersion = false;
+    updateResponse.package_hash = "12345-67890";
+    updateResponse.package_size = 12345;
+    updateResponse.update_app_version = false;
     if (!!targetPlatform)
-        updateResponse.downloadURL = targetPlatform.getServerUrl() + "/download";
+        updateResponse.download_url = targetPlatform.getServerUrl() + "/v0.1/public/codepush/report_status/download";
     // We need unique hashes to avoid conflicts.
     if (randomHash) {
-        updateResponse.packageHash = "randomHash-" + Math.floor(Math.random() * 10000);
+        updateResponse.package_hash = "randomHash-" + Math.floor(Math.random() * 10000);
     }
     return updateResponse;
 }

--- a/code-push-plugin-testing-framework/script/serverUtil.js
+++ b/code-push-plugin-testing-framework/script/serverUtil.js
@@ -84,13 +84,15 @@ exports.UpdateCheckRequestMock = UpdateCheckRequestMock;
 function createDefaultResponse() {
     var defaultResponse = new CheckForUpdateResponseMock();
     defaultResponse.download_url = "";
+    defaultResponse.is_disabled = false;
     defaultResponse.description = "";
     defaultResponse.is_available = false;
-    defaultResponse.isMandatory = false;
-    defaultResponse.app_version = "";
+    defaultResponse.is_mandatory = false;
+    defaultResponse.target_binary_range = "";
     defaultResponse.package_hash = "";
     defaultResponse.label = "";
     defaultResponse.package_size = 0;
+    defaultResponse.should_run_binary_version = false;
     defaultResponse.update_app_version = false;
     return defaultResponse;
 }
@@ -103,12 +105,14 @@ function createUpdateResponse(mandatory, targetPlatform, randomHash) {
     if (randomHash === void 0) { randomHash = true; }
     var updateResponse = new CheckForUpdateResponseMock();
     updateResponse.is_available = true;
-    updateResponse.app_version = "1.0.0";
+    updateResponse.is_disabled = false;
+    updateResponse.target_binary_range = "1.0.0";
     updateResponse.download_url = "mock.url/v0.1/public/codepush/report_status/download";
-    updateResponse.isMandatory = mandatory;
+    updateResponse.is_mandatory = mandatory;
     updateResponse.label = "mock-update";
     updateResponse.package_hash = "12345-67890";
     updateResponse.package_size = 12345;
+    updateResponse.should_run_binary_version = false;
     updateResponse.update_app_version = false;
     if (!!targetPlatform)
         updateResponse.download_url = targetPlatform.getServerUrl() + "/v0.1/public/codepush/report_status/download";

--- a/code-push-plugin-testing-framework/typings/code-push-plugin-testing-framework.d.ts
+++ b/code-push-plugin-testing-framework/typings/code-push-plugin-testing-framework.d.ts
@@ -298,17 +298,17 @@ declare module 'code-push-plugin-testing-framework/script/serverUtil' {
 	 * Class used to mock the codePush.checkForUpdate() response from the server.
 	 */
 	export class CheckForUpdateResponseMock {
-	    download_url: string;
+		download_url: string;
 		is_available: boolean;
 		should_run_binary_version: boolean;
-	    package_size: number;
-	    update_app_version: boolean;
+		package_size: number;
+		update_app_version: boolean;
 		target_binary_range: string;
 		is_disabled: boolean;
-	    description: string;
-	    label: string;
-	    package_hash: string;
-	    is_mandatory: boolean;
+		description: string;
+		label: string;
+		package_hash: string;
+		is_mandatory: boolean;
 	}
 	/**
 	 * The model class of the codePush.checkForUpdate() request to the server.

--- a/code-push-plugin-testing-framework/typings/code-push-plugin-testing-framework.d.ts
+++ b/code-push-plugin-testing-framework/typings/code-push-plugin-testing-framework.d.ts
@@ -300,14 +300,16 @@ declare module 'code-push-plugin-testing-framework/script/serverUtil' {
 	 */
 	export class CheckForUpdateResponseMock {
 	    download_url: string;
-	    is_available: boolean;
+		is_available: boolean;
+		should_run_binary_version: boolean;
 	    package_size: number;
 	    update_app_version: boolean;
-	    app_version: string;
+		target_binary_range: string;
+		is_disabled: boolean;
 	    description: string;
 	    label: string;
 	    package_hash: string;
-	    isMandatory: boolean;
+	    is_mandatory: boolean;
 	}
 	/**
 	 * The model class of the codePush.checkForUpdate() request to the server.

--- a/code-push-plugin-testing-framework/typings/code-push-plugin-testing-framework.d.ts
+++ b/code-push-plugin-testing-framework/typings/code-push-plugin-testing-framework.d.ts
@@ -299,14 +299,14 @@ declare module 'code-push-plugin-testing-framework/script/serverUtil' {
 	 * Class used to mock the codePush.checkForUpdate() response from the server.
 	 */
 	export class CheckForUpdateResponseMock {
-	    downloadURL: string;
-	    isAvailable: boolean;
-	    packageSize: number;
-	    updateAppVersion: boolean;
-	    appVersion: string;
+	    download_url: string;
+	    is_available: boolean;
+	    package_size: number;
+	    update_app_version: boolean;
+	    app_version: string;
 	    description: string;
 	    label: string;
-	    packageHash: string;
+	    package_hash: string;
 	    isMandatory: boolean;
 	}
 	/**

--- a/test/test.ts
+++ b/test/test.ts
@@ -20,27 +20,27 @@ interface RNPlatform {
      * Returns the name of the bundle to be created for this platform.
      */
     getBundleName(): string;
-    
+
     /**
      * Returns whether or not this platform supports diffs.
      */
     isDiffsSupported(): boolean;
-    
+
     /**
      * Returns the path to the binary of the given project on this platform.
      */
     getBinaryPath(projectDirectory: string): string;
-    
+
     /**
      * Installs the platform on the given project.
      */
     installPlatform(projectDirectory: string): Q.Promise<void>;
-    
+
     /**
      * Installs the binary of the given project on this platform.
      */
     installApp(projectDirectory: string): Q.Promise<void>;
-    
+
     /**
      * Builds the binary of the project on this platform.
      */
@@ -51,28 +51,28 @@ class RNAndroid extends Platform.Android implements RNPlatform {
     constructor() {
         super(new Platform.AndroidEmulatorManager());
     }
-    
+
     /**
      * Returns the name of the bundle to be created for this platform.
      */
     getBundleName(): string {
         return "index.android.bundle";
     }
-    
+
     /**
      * Returns whether or not this platform supports diffs.
      */
     isDiffsSupported(): boolean {
         return false;
     }
-    
+
     /**
      * Returns the path to the binary of the given project on this platform.
      */
     getBinaryPath(projectDirectory: string): string {
         return path.join(projectDirectory, TestConfig.TestAppName, "android", "app", "build", "outputs", "apk", "release", "app-release.apk");
     }
-    
+
     /**
      * Installs the platform on the given project.
      */
@@ -92,7 +92,7 @@ class RNAndroid extends Platform.Android implements RNPlatform {
         TestUtil.replaceString(buildGradle, "versionName \"1.0\"", "versionName \"1.0.0\"");
         // Set the app version to 1.0.0 in AndroidManifest.xml
         TestUtil.replaceString(path.join(innerprojectDirectory, "android", "app", "src", "main", "AndroidManifest.xml"), "android:versionName=\"1.0\"", "android:versionName=\"1.0.0\"");
-            
+
         //// Replace the MainApplication.java with the correct server url and deployment key
         const string = path.join(innerprojectDirectory, "android", "app", "src", "main", "res", "values", "strings.xml");
         const AndroidManifest = path.join(innerprojectDirectory, "android", "app", "src", "main", "AndroidManifest.xml");
@@ -100,10 +100,10 @@ class RNAndroid extends Platform.Android implements RNPlatform {
         TestUtil.replaceString(string, TestUtil.ANDROID_KEY_PLACEHOLDER, this.getDefaultDeploymentKey());
         TestUtil.replaceString(AndroidManifest, "android:allowBackup=\"false\"", "android:allowBackup=\"false\"" + "\n\t" + "android:usesCleartextTraffic=\"true\"");
 
-        
+
         return Q<void>(null);
     }
-    
+
     /**
      * Installs the binary of the given project on this platform.
      */
@@ -111,7 +111,7 @@ class RNAndroid extends Platform.Android implements RNPlatform {
         const androidDirectory: string = path.join(projectDirectory, TestConfig.TestAppName, "android");
         return TestUtil.getProcessOutput("adb install -r " + this.getBinaryPath(projectDirectory), { cwd: androidDirectory }).then(() => { return null; });
     }
-    
+
     /**
      * Builds the binary of the project on this platform.
      */
@@ -128,28 +128,28 @@ class RNIOS extends Platform.IOS implements RNPlatform {
     constructor() {
         super(new Platform.IOSEmulatorManager());
     }
-    
+
     /**
      * Returns the name of the bundle to be created for this platform.
      */
     getBundleName(): string {
         return "main.jsbundle";
     }
-    
+
     /**
      * Returns whether or not this platform supports diffs.
      */
     isDiffsSupported(): boolean {
         return true;
     }
-    
+
     /**
      * Returns the path to the binary of the given project on this platform.
      */
     getBinaryPath(projectDirectory: string): string {
         return path.join(projectDirectory, TestConfig.TestAppName, "ios", "build", "Build", "Products", "Release-iphonesimulator", TestConfig.TestAppName + ".app");
     }
-    
+
     /**
      * Installs the platform on the given project.
      */
@@ -159,28 +159,30 @@ class RNIOS extends Platform.IOS implements RNPlatform {
         const appDelegatePath: string = path.join(iOSProject, TestConfig.TestAppName, "AppDelegate.m");
         // Create and install the Podfile
         return TestUtil.getProcessOutput("pod init", { cwd: iOSProject })
-            .then(() => { return fs.writeFileSync(path.join(iOSProject, "Podfile"),
-                "target '" + TestConfig.TestAppName + "'\n  pod 'React', :path => '../node_modules/react-native', :subspecs => [ 'Core', 'RCTImage', 'RCTNetwork', 'RCTText', 'RCTWebSocket', ]\n  pod 'CodePush', :path => '../node_modules/react-native-code-push'\n"); })
+            .then(() => {
+                return fs.writeFileSync(path.join(iOSProject, "Podfile"),
+                    "target '" + TestConfig.TestAppName + "'\n  pod 'React', :path => '../node_modules/react-native', :subspecs => [ 'Core', 'RCTImage', 'RCTNetwork', 'RCTText', 'RCTWebSocket', ]\n  pod 'CodePush', :path => '../node_modules/react-native-code-push'\n");
+            })
             // Put the IOS deployment key in the Info.plist
             .then(TestUtil.replaceString.bind(undefined, infoPlistPath,
                 "</dict>\n</plist>",
                 "<key>CodePushDeploymentKey</key>\n\t<string>" + this.getDefaultDeploymentKey() + "</string>\n\t<key>CodePushServerURL</key>\n\t<string>" + this.getServerUrl() + "</string>\n\t</dict>\n</plist>"))
             // Add the correct linker flags to the project.pbxproj
-            .then(TestUtil.replaceString.bind(undefined, path.join(iOSProject, TestConfig.TestAppName + ".xcodeproj", "project.pbxproj"), 
+            .then(TestUtil.replaceString.bind(undefined, path.join(iOSProject, TestConfig.TestAppName + ".xcodeproj", "project.pbxproj"),
                 "\"-lc[+][+]\",", "\"-lc++\", \"$(inherited)\""))
             // Install the Pod
             .then(TestUtil.getProcessOutput.bind(undefined, "pod install", { cwd: iOSProject }))
             // Add the correct bundle identifier to the Info.plist
-            .then(TestUtil.replaceString.bind(undefined, infoPlistPath, 
+            .then(TestUtil.replaceString.bind(undefined, infoPlistPath,
                 "org[.]reactjs[.]native[.]example[.][$][(]PRODUCT_NAME:rfc1034identifier[)]",
                 TestConfig.TestNamespace))
             // Set the app version to 1.0.0 instead of 1.0 in the Info.plist
             .then(TestUtil.replaceString.bind(undefined, infoPlistPath, "1.0", "1.0.0"))
             // Fix the linker flag list in project.pbxproj (pod install adds an extra comma)
-            .then(TestUtil.replaceString.bind(undefined, path.join(iOSProject, TestConfig.TestAppName + ".xcodeproj", "project.pbxproj"), 
+            .then(TestUtil.replaceString.bind(undefined, path.join(iOSProject, TestConfig.TestAppName + ".xcodeproj", "project.pbxproj"),
                 "\"[$][(]inherited[)]\",\\s*[)];", "\"$(inherited)\"\n\t\t\t\t);"))
             // Prevent the packager from starting during builds by replacing the script that starts it with nothing.
-            .then(TestUtil.replaceString.bind(undefined, 
+            .then(TestUtil.replaceString.bind(undefined,
                 path.join(projectDirectory, TestConfig.TestAppName, "node_modules", "react-native", "React", "React.xcodeproj", "project.pbxproj"),
                 "shellScript = \".*\";",
                 "shellScript = \"\";"))
@@ -190,14 +192,14 @@ class RNIOS extends Platform.IOS implements RNPlatform {
                 appDelegatePath, true))
             .then<void>(TestUtil.replaceString.bind(undefined, appDelegatePath, TestUtil.CODE_PUSH_TEST_APP_NAME_PLACEHOLDER, TestConfig.TestAppName));
     }
-    
+
     /**
      * Installs the binary of the given project on this platform.
      */
     installApp(projectDirectory: string): Q.Promise<void> {
         return TestUtil.getProcessOutput("xcrun simctl install booted " + this.getBinaryPath(projectDirectory)).then(() => { return null; });
     }
-    
+
     /**
      * Maps project directories to whether or not they have built an IOS project before.
      * 
@@ -210,19 +212,19 @@ class RNIOS extends Platform.IOS implements RNPlatform {
      *  }
      */
     private static iosFirstBuild: any = {};
-    
+
     /**
      * Builds the binary of the project on this platform.
      */
     buildApp(projectDirectory: string): Q.Promise<void> {
         const iOSProject: string = path.join(projectDirectory, TestConfig.TestAppName, "ios");
-        
+
         return this.getEmulatorManager().getTargetEmulator()
             .then((targetEmulator: string) => {
                 const hashRegEx = /[(][0-9A-Z-]*[)]/g;
                 const hashWithParen = targetEmulator.match(hashRegEx)[0];
                 const hash = hashWithParen.substr(1, hashWithParen.length - 2);
-                return TestUtil.getProcessOutput("xcodebuild -workspace " + path.join(iOSProject, TestConfig.TestAppName) + ".xcworkspace -scheme " + TestConfig.TestAppName + 
+                return TestUtil.getProcessOutput("xcodebuild -workspace " + path.join(iOSProject, TestConfig.TestAppName) + ".xcworkspace -scheme " + TestConfig.TestAppName +
                     " -configuration Release -destination \"platform=iOS Simulator,id=" + hash + "\" -derivedDataPath build", { cwd: iOSProject, maxBuffer: 1024 * 1000 * 10, noLogStdOut: true });
             })
             .then<void>(
@@ -255,21 +257,21 @@ class RNProjectManager extends ProjectManager {
     public getPluginName(): string {
         return "React-Native";
     }
-    
+
     /**
      * Copies over the template files into the specified project, overwriting existing files.
      */
     public copyTemplate(templatePath: string, projectDirectory: string): Q.Promise<void> {
         function copyDirectoryRecursively(directoryFrom: string, directoryTo: string): Q.Promise<void> {
             const promises: Q.Promise<void>[] = [];
-            
+
             fs.readdirSync(directoryFrom).forEach(file => {
                 let fileStats: fs.Stats;
                 const fileInFrom: string = path.join(directoryFrom, file);
                 const fileInTo: string = path.join(directoryTo, file);
-                
+
                 try { fileStats = fs.statSync(fileInFrom); } catch (e) { /* fs.statSync throws if the file doesn't exist. */ }
-                
+
                 // If it is a file, just copy directly
                 if (fileStats && fileStats.isFile()) {
                     promises.push(TestUtil.copyFile(fileInFrom, fileInTo, true));
@@ -280,11 +282,11 @@ class RNProjectManager extends ProjectManager {
                     promises.push(copyDirectoryRecursively(fileInFrom, fileInTo));
                 }
             });
-            
+
             // Chain promise so that it maintains Q.Promise<void> type instead of Q.Promise<void[]>
             return Q.all<void>(promises).then(() => { return null; });
         }
-        
+
         return copyDirectoryRecursively(templatePath, path.join(projectDirectory, TestConfig.TestAppName));
     }
 
@@ -303,7 +305,7 @@ class RNProjectManager extends ProjectManager {
             .then<void>(TestUtil.getProcessOutput.bind(undefined, TestConfig.thisPluginInstallString, { cwd: path.join(projectDirectory, TestConfig.TestAppName) }))
             .then(() => { return null; });
     }
-    
+
     /** JSON mapping project directories to the current scenario
      *
      *  EXAMPLE:
@@ -313,7 +315,7 @@ class RNProjectManager extends ProjectManager {
      *  }
      */
     private static currentScenario: any = {};
-    
+
     /** JSON mapping project directories to whether or not they've built the current scenario
      *
      *  EXAMPLE:
@@ -323,7 +325,7 @@ class RNProjectManager extends ProjectManager {
      *  }
      */
     private static currentScenarioHasBuilt: any = {};
-    
+
     /**
      * Sets up the scenario for a test in an already existing project.
      */
@@ -332,13 +334,13 @@ class RNProjectManager extends ProjectManager {
         if (RNProjectManager.currentScenario[projectDirectory] === jsPath) return Q<void>(null);
         RNProjectManager.currentScenario[projectDirectory] = jsPath;
         RNProjectManager.currentScenarioHasBuilt[projectDirectory] = false;
-        
+
         const indexHtml = "index.js";
         const templateIndexPath = path.join(templatePath, indexHtml);
         const destinationIndexPath = path.join(projectDirectory, TestConfig.TestAppName, indexHtml);
-        
+
         const scenarioJs = "scenarios/" + jsPath;
-        
+
         console.log("Setting up scenario " + jsPath + " in " + projectDirectory);
 
         // Copy index html file and replace
@@ -367,7 +369,7 @@ class RNProjectManager extends ProjectManager {
                 { cwd: path.join(projectDirectory, TestConfig.TestAppName) }))
             .then<string>(TestUtil.archiveFolder.bind(undefined, bundleFolder, "", path.join(projectDirectory, TestConfig.TestAppName, "update.zip"), (<RNPlatform><any>targetPlatform).isDiffsSupported() && isDiff));
     }
-    
+
     /** JSON file containing the platforms the plugin is currently installed for.
      *  Keys must match targetPlatform.getName()!
      *
@@ -378,22 +380,22 @@ class RNProjectManager extends ProjectManager {
      *  }
      */
     private static platformsJSON: string = "platforms.json";
-    
+
     /**
      * Prepares a specific platform for tests.
      */
     public preparePlatform(projectDirectory: string, targetPlatform: Platform.IPlatform): Q.Promise<void> {
-        const deferred= Q.defer<string>();
-        
+        const deferred = Q.defer<string>();
+
         const platformsJSONPath = path.join(projectDirectory, RNProjectManager.platformsJSON);
-        
+
         // We create a JSON file in the project folder to contain the installed platforms.
         // Check the file to see if the plugin for this platform has been installed and update the file appropriately.
         fs.exists(platformsJSONPath, (exists) => {
             if (!exists) {
                 fs.writeFileSync(platformsJSONPath, "{}");
             }
-            
+
             const platformJSON = eval("(" + fs.readFileSync(platformsJSONPath, "utf8") + ")");
             if (platformJSON[targetPlatform.getName()] === true) deferred.reject("Platform " + targetPlatform.getName() + " is already installed in " + projectDirectory + "!");
             else {
@@ -402,13 +404,13 @@ class RNProjectManager extends ProjectManager {
                 deferred.resolve(undefined);
             }
         });
-        
+
         return deferred.promise
             .then<void>(() => {
                 return (<RNPlatform><any>targetPlatform).installPlatform(projectDirectory);
             }, (error: any) => { /* The platform is already installed! */ console.log(error); return null; });
     }
-    
+
     /**
      * Cleans up a specific platform after tests.
      */
@@ -422,7 +424,7 @@ class RNProjectManager extends ProjectManager {
      */
     public runApplication(projectDirectory: string, targetPlatform: Platform.IPlatform): Q.Promise<void> {
         console.log("Running project in " + projectDirectory + " on " + targetPlatform.getName());
-        
+
         return Q<void>(null)
             .then(() => {
                 // Build if this scenario has not yet been built.
@@ -481,9 +483,9 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                 TestBuilder.it("window.codePush.checkForUpdate.noUpdate", false,
                     (done: MochaDone) => {
                         const noUpdateResponse = ServerUtil.createDefaultResponse();
-                        noUpdateResponse.isAvailable = false;
-                        noUpdateResponse.appVersion = "0.0.1";
-                        ServerUtil.updateResponse = { updateInfo: noUpdateResponse };
+                        noUpdateResponse.is_available = false;
+                        noUpdateResponse.app_version = "0.0.1";
+                        ServerUtil.updateResponse = { update_info: noUpdateResponse };
 
                         ServerUtil.testMessageCallback = (requestBody: any) => {
                             try {
@@ -496,7 +498,7 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
 
                         projectManager.runApplication(TestConfig.testRunDirectory, targetPlatform);
                     });
-                
+
                 TestBuilder.it("window.codePush.checkForUpdate.sendsBinaryHash", false,
                     (done: MochaDone) => {
                         if (!(<RNPlatform><any>targetPlatform).isDiffsSupported()) {
@@ -504,40 +506,20 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             done();
                             return;
                         }
-                        
+
                         const noUpdateResponse = ServerUtil.createDefaultResponse();
-                            noUpdateResponse.isAvailable = false;
-                            noUpdateResponse.appVersion = "0.0.1";
+                        noUpdateResponse.is_available = false;
+                        noUpdateResponse.app_version = "0.0.1";
 
-                            ServerUtil.updateCheckCallback = (request: any) => {
-                                try {
-                                    assert(request.query.packageHash);
-                                } catch (e) {
-                                    done(e);
-                                }
-                            };
-                            
-                            ServerUtil.updateResponse = { updateInfo: noUpdateResponse };
+                        ServerUtil.updateCheckCallback = (request: any) => {
+                            try {
+                                assert(request.query.package_hash);
+                            } catch (e) {
+                                done(e);
+                            }
+                        };
 
-                            ServerUtil.testMessageCallback = (requestBody: any) => {
-                                try {
-                                    assert.equal(requestBody.message, ServerUtil.TestMessage.CHECK_UP_TO_DATE);
-                                    done();
-                                } catch (e) {
-                                    done(e);
-                                }
-                            };
-
-                            projectManager.runApplication(TestConfig.testRunDirectory, targetPlatform);
-                    });
-                
-                TestBuilder.it("window.codePush.checkForUpdate.noUpdate.updateAppVersion", false,
-                    (done: MochaDone) => {
-                        const updateAppVersionResponse = ServerUtil.createDefaultResponse();
-                        updateAppVersionResponse.updateAppVersion = true;
-                        updateAppVersionResponse.appVersion = "2.0.0";
-
-                        ServerUtil.updateResponse = { updateInfo: updateAppVersionResponse };
+                        ServerUtil.updateResponse = { update_info: noUpdateResponse };
 
                         ServerUtil.testMessageCallback = (requestBody: any) => {
                             try {
@@ -550,23 +532,43 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
 
                         projectManager.runApplication(TestConfig.testRunDirectory, targetPlatform);
                     });
-                
+
+                TestBuilder.it("window.codePush.checkForUpdate.noUpdate.updateAppVersion", false,
+                    (done: MochaDone) => {
+                        const updateAppVersionResponse = ServerUtil.createDefaultResponse();
+                        updateAppVersionResponse.is_available = true;
+                        updateAppVersionResponse.app_version = "2.0.0";
+
+                        ServerUtil.updateResponse = { update_info: updateAppVersionResponse };
+
+                        ServerUtil.testMessageCallback = (requestBody: any) => {
+                            try {
+                                assert.equal(requestBody.message, ServerUtil.TestMessage.CHECK_UP_TO_DATE);
+                                done();
+                            } catch (e) {
+                                done(e);
+                            }
+                        };
+
+                        projectManager.runApplication(TestConfig.testRunDirectory, targetPlatform);
+                    });
+
                 TestBuilder.it("window.codePush.checkForUpdate.update", true,
                     (done: MochaDone) => {
                         const updateResponse = ServerUtil.createUpdateResponse();
-                        ServerUtil.updateResponse = { updateInfo: updateResponse };
+                        ServerUtil.updateResponse = { update_info: updateResponse };
 
                         ServerUtil.testMessageCallback = (requestBody: any) => {
                             try {
                                 assert.equal(requestBody.message, ServerUtil.TestMessage.CHECK_UPDATE_AVAILABLE);
                                 assert.notEqual(requestBody.args[0], null);
                                 const remotePackage: any = requestBody.args[0];
-                                assert.equal(remotePackage.downloadUrl, updateResponse.downloadURL);
+                                assert.equal(remotePackage.download_url, updateResponse.download_url);
                                 assert.equal(remotePackage.isMandatory, updateResponse.isMandatory);
                                 assert.equal(remotePackage.label, updateResponse.label);
-                                assert.equal(remotePackage.packageHash, updateResponse.packageHash);
-                                assert.equal(remotePackage.packageSize, updateResponse.packageSize);
-                                assert.equal(remotePackage.deploymentKey, targetPlatform.getDefaultDeploymentKey());
+                                assert.equal(remotePackage.packageHash, updateResponse.package_hash);
+                                assert.equal(remotePackage.packageSize, updateResponse.package_size);
+                                assert.equal(remotePackage.deployment_key, targetPlatform.getDefaultDeploymentKey());
                                 done();
                             } catch (e) {
                                 done(e);
@@ -576,7 +578,7 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                         ServerUtil.updateCheckCallback = (request: any) => {
                             try {
                                 assert.notEqual(null, request);
-                                assert.equal(request.query.deploymentKey, targetPlatform.getDefaultDeploymentKey());
+                                assert.equal(request.query.deployment_key, targetPlatform.getDefaultDeploymentKey());
                             } catch (e) {
                                 done(e);
                             }
@@ -584,7 +586,7 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
 
                         projectManager.runApplication(TestConfig.testRunDirectory, targetPlatform);
                     });
-                
+
                 TestBuilder.it("window.codePush.checkForUpdate.error", false,
                     (done: MochaDone) => {
                         ServerUtil.updateResponse = "invalid {{ json";
@@ -601,71 +603,71 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                         projectManager.runApplication(TestConfig.testRunDirectory, targetPlatform);
                     });
             }, ScenarioCheckForUpdatePath);
-        
+
         TestBuilder.describe("#window.codePush.checkForUpdate.customKey",
             () => {
                 TestBuilder.it("window.codePush.checkForUpdate.customKey.update", false,
-                (done: MochaDone) => {
-                    const updateResponse = ServerUtil.createUpdateResponse();
-                    ServerUtil.updateResponse = { updateInfo: updateResponse };
+                    (done: MochaDone) => {
+                        const updateResponse = ServerUtil.createUpdateResponse();
+                        ServerUtil.updateResponse = { update_info: updateResponse };
 
-                    ServerUtil.updateCheckCallback = (request: any) => {
-                        try {
-                            assert.notEqual(null, request);
-                            assert.equal(request.query.deploymentKey, "CUSTOM-DEPLOYMENT-KEY");
-                            done();
-                        } catch (e) {
-                            done(e);
-                        }
-                    };
+                        ServerUtil.updateCheckCallback = (request: any) => {
+                            try {
+                                assert.notEqual(null, request);
+                                assert.equal(request.query.deployment_key, "CUSTOM-DEPLOYMENT-KEY");
+                                done();
+                            } catch (e) {
+                                done(e);
+                            }
+                        };
 
-                    projectManager.runApplication(TestConfig.testRunDirectory, targetPlatform);
-                });
+                        projectManager.runApplication(TestConfig.testRunDirectory, targetPlatform);
+                    });
             }, ScenarioCheckForUpdateCustomKey);
-            
+
         TestBuilder.describe("#remotePackage.download",
             () => {
                 TestBuilder.it("remotePackage.download.success", false,
                     (done: MochaDone) => {
-                        ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(false, targetPlatform) };
+                        ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
 
                         /* pass the path to any file for download (here, index.js) to make sure the download completed callback is invoked */
                         ServerUtil.updatePackagePath = path.join(TestConfig.templatePath, "index.js");
-                        
+
                         projectManager.runApplication(TestConfig.testRunDirectory, targetPlatform);
-                        
+
                         ServerUtil.expectTestMessages([
                             ServerUtil.TestMessage.CHECK_UPDATE_AVAILABLE,
                             ServerUtil.TestMessage.DOWNLOAD_SUCCEEDED])
                             .then(() => { done(); }, (e) => { done(e); });
                     });
-                
+
                 TestBuilder.it("remotePackage.download.error", false,
                     (done: MochaDone) => {
-                        ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(false, targetPlatform) };
+                        ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
 
                         /* pass an invalid update url */
-                        ServerUtil.updateResponse.updateInfo.downloadURL = "invalid_url";
-                        
+                        ServerUtil.updateResponse.update_info.download_url = "invalid_url";
+
                         projectManager.runApplication(TestConfig.testRunDirectory, targetPlatform);
-                        
+
                         ServerUtil.expectTestMessages([
                             ServerUtil.TestMessage.CHECK_UPDATE_AVAILABLE,
                             ServerUtil.TestMessage.DOWNLOAD_ERROR])
                             .then(() => { done(); }, (e) => { done(e); });
                     });
             }, ScenarioDownloadUpdate);
-            
+
         TestBuilder.describe("#localPackage.install",
             () => {
                 // // CHANGE THIS TEST CASE, accepts both a jsbundle and a zip
                 // TestBuilder.it("localPackage.install.unzip.error",
                 //     (done: MochaDone) => {
-                //         ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(false, targetPlatform) };
+                //         ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
 
                 //         /* pass an invalid zip file, here, index.js */
                 //         ServerUtil.updatePackagePath = path.join(TestConfig.templatePath, "index.js");
-                        
+
                 //         var deferred = Q.defer<void>();
                 //         deferred.promise.then(() => { done(); }, (e) => { done(e); });
 
@@ -676,7 +678,7 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
 
                 //         projectManager.runApplication(TestConfig.testRunDirectory, targetPlatform);
                 //     }, false),
-                
+
                 TestBuilder.it("localPackage.install.handlesDiff.againstBinary", false,
                     (done: MochaDone) => {
                         if (!(<RNPlatform><any>targetPlatform).isDiffsSupported()) {
@@ -684,8 +686,8 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             done();
                             return;
                         }
-                        
-                        ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(false, targetPlatform) };
+
+                        ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
 
                         /* create an update */
                         setupUpdateScenario(projectManager, targetPlatform, UpdateNotifyApplicationReady, "Diff Update 1")
@@ -705,10 +707,10 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             })
                             .done(() => { done(); }, (e) => { done(e); });
                     });
-                
+
                 TestBuilder.it("localPackage.install.immediately", false,
                     (done: MochaDone) => {
-                        ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(false, targetPlatform) };
+                        ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
 
                         /* create an update */
                         setupUpdateScenario(projectManager, targetPlatform, UpdateNotifyApplicationReady, "Update 1")
@@ -729,12 +731,12 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             .done(() => { done(); }, (e) => { done(e); });
                     });
             }, ScenarioInstall);
-            
+
         TestBuilder.describe("#localPackage.install.revert",
             () => {
                 TestBuilder.it("localPackage.install.revert.dorevert", false,
                     (done: MochaDone) => {
-                        ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(false, targetPlatform) };
+                        ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
 
                         /* create an update */
                         setupUpdateScenario(projectManager, targetPlatform, UpdateDeviceReady, "Update 1 (bad update)")
@@ -748,7 +750,7 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             })
                             .then<void>(() => {
                                 /* restart the app to ensure it was reverted and send it another update */
-                                ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(false, targetPlatform) };
+                                ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
                                 targetPlatform.getEmulatorManager().restartApplication(TestConfig.TestNamespace);
                                 return ServerUtil.expectTestMessages([
                                     ServerUtil.TestMessage.CHECK_UPDATE_AVAILABLE,
@@ -762,10 +764,10 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             })
                             .done(() => { done(); }, (e) => { done(e); });
                     });
-                
+
                 TestBuilder.it("localPackage.install.revert.norevert", false,
                     (done: MochaDone) => {
-                        ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(false, targetPlatform) };
+                        ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
 
                         /* create an update */
                         setupUpdateScenario(projectManager, targetPlatform, UpdateNotifyApplicationReady, "Update 1 (good update)")
@@ -785,68 +787,68 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             .done(() => { done(); }, (e) => { done(e); });
                     });
             }, ScenarioInstallWithRevert),
-        
-        TestBuilder.describe("#localPackage.installOnNextResume",
-            () => {
-                TestBuilder.it("localPackage.installOnNextResume.dorevert", true,
-                    (done: MochaDone) => {
-                        ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(false, targetPlatform) };
 
-                        setupUpdateScenario(projectManager, targetPlatform, UpdateDeviceReady, "Update 1")
-                            .then<void>((updatePath: string) => {
-                                ServerUtil.updatePackagePath = updatePath;
-                                projectManager.runApplication(TestConfig.testRunDirectory, targetPlatform);
-                                return ServerUtil.expectTestMessages([
-                                    ServerUtil.TestMessage.CHECK_UPDATE_AVAILABLE,
-                                    ServerUtil.TestMessage.DOWNLOAD_SUCCEEDED,
-                                    ServerUtil.TestMessage.UPDATE_INSTALLED]);
-                            })
-                            .then<void>(() => {
-                                /* resume the application */
-                                targetPlatform.getEmulatorManager().resumeApplication(TestConfig.TestNamespace);
-                                return ServerUtil.expectTestMessages([ServerUtil.TestMessage.DEVICE_READY_AFTER_UPDATE]);
-                            })
-                            .then<void>(() => {
-                                /* restart to revert it */
-                                targetPlatform.getEmulatorManager().restartApplication(TestConfig.TestNamespace);
-                                return ServerUtil.expectTestMessages([ServerUtil.TestMessage.UPDATE_FAILED_PREVIOUSLY]);
-                            })
-                            .done(() => { done(); }, (e) => { done(e); });
-                    });
-                
-                TestBuilder.it("localPackage.installOnNextResume.norevert", false,
-                    (done: MochaDone) => {
-                        ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(false, targetPlatform) };
+            TestBuilder.describe("#localPackage.installOnNextResume",
+                () => {
+                    TestBuilder.it("localPackage.installOnNextResume.dorevert", true,
+                        (done: MochaDone) => {
+                            ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
 
-                        /* create an update */
-                        setupUpdateScenario(projectManager, targetPlatform, UpdateNotifyApplicationReady, "Update 1 (good update)")
-                            .then<void>((updatePath: string) => {
-                                ServerUtil.updatePackagePath = updatePath;
-                                projectManager.runApplication(TestConfig.testRunDirectory, targetPlatform);
-                                return ServerUtil.expectTestMessages([
-                                    ServerUtil.TestMessage.CHECK_UPDATE_AVAILABLE,
-                                    ServerUtil.TestMessage.DOWNLOAD_SUCCEEDED,
-                                    ServerUtil.TestMessage.UPDATE_INSTALLED]);
-                            })
-                            .then<void>(() => {
-                                /* resume the application */
-                                targetPlatform.getEmulatorManager().resumeApplication(TestConfig.TestNamespace);
-                                return ServerUtil.expectTestMessages([ServerUtil.TestMessage.DEVICE_READY_AFTER_UPDATE]);
-                            })
-                            .then<void>(() => {
-                                /* restart to make sure it did not revert */
-                                targetPlatform.getEmulatorManager().restartApplication(TestConfig.TestNamespace);
-                                return ServerUtil.expectTestMessages([ServerUtil.TestMessage.DEVICE_READY_AFTER_UPDATE]);
-                            })
-                            .done(() => { done(); }, (e) => { done(e); });
-                    });
-            }, ScenarioInstallOnResumeWithRevert);
-            
+                            setupUpdateScenario(projectManager, targetPlatform, UpdateDeviceReady, "Update 1")
+                                .then<void>((updatePath: string) => {
+                                    ServerUtil.updatePackagePath = updatePath;
+                                    projectManager.runApplication(TestConfig.testRunDirectory, targetPlatform);
+                                    return ServerUtil.expectTestMessages([
+                                        ServerUtil.TestMessage.CHECK_UPDATE_AVAILABLE,
+                                        ServerUtil.TestMessage.DOWNLOAD_SUCCEEDED,
+                                        ServerUtil.TestMessage.UPDATE_INSTALLED]);
+                                })
+                                .then<void>(() => {
+                                    /* resume the application */
+                                    targetPlatform.getEmulatorManager().resumeApplication(TestConfig.TestNamespace);
+                                    return ServerUtil.expectTestMessages([ServerUtil.TestMessage.DEVICE_READY_AFTER_UPDATE]);
+                                })
+                                .then<void>(() => {
+                                    /* restart to revert it */
+                                    targetPlatform.getEmulatorManager().restartApplication(TestConfig.TestNamespace);
+                                    return ServerUtil.expectTestMessages([ServerUtil.TestMessage.UPDATE_FAILED_PREVIOUSLY]);
+                                })
+                                .done(() => { done(); }, (e) => { done(e); });
+                        });
+
+                    TestBuilder.it("localPackage.installOnNextResume.norevert", false,
+                        (done: MochaDone) => {
+                            ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
+
+                            /* create an update */
+                            setupUpdateScenario(projectManager, targetPlatform, UpdateNotifyApplicationReady, "Update 1 (good update)")
+                                .then<void>((updatePath: string) => {
+                                    ServerUtil.updatePackagePath = updatePath;
+                                    projectManager.runApplication(TestConfig.testRunDirectory, targetPlatform);
+                                    return ServerUtil.expectTestMessages([
+                                        ServerUtil.TestMessage.CHECK_UPDATE_AVAILABLE,
+                                        ServerUtil.TestMessage.DOWNLOAD_SUCCEEDED,
+                                        ServerUtil.TestMessage.UPDATE_INSTALLED]);
+                                })
+                                .then<void>(() => {
+                                    /* resume the application */
+                                    targetPlatform.getEmulatorManager().resumeApplication(TestConfig.TestNamespace);
+                                    return ServerUtil.expectTestMessages([ServerUtil.TestMessage.DEVICE_READY_AFTER_UPDATE]);
+                                })
+                                .then<void>(() => {
+                                    /* restart to make sure it did not revert */
+                                    targetPlatform.getEmulatorManager().restartApplication(TestConfig.TestNamespace);
+                                    return ServerUtil.expectTestMessages([ServerUtil.TestMessage.DEVICE_READY_AFTER_UPDATE]);
+                                })
+                                .done(() => { done(); }, (e) => { done(e); });
+                        });
+                }, ScenarioInstallOnResumeWithRevert);
+
         TestBuilder.describe("localPackage installOnNextRestart",
             () => {
                 TestBuilder.it("localPackage.installOnNextRestart.dorevert", false,
                     (done: MochaDone) => {
-                        ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(false, targetPlatform) };
+                        ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
 
                         setupUpdateScenario(projectManager, targetPlatform, UpdateDeviceReady, "Update 1")
                             .then<void>((updatePath: string) => {
@@ -859,22 +861,22 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             })
                             .then<void>(() => {
                                 /* restart the application */
-                                console.log("Update hash: " + ServerUtil.updateResponse.updateInfo.packageHash);
+                                console.log("Update hash: " + ServerUtil.updateResponse.update_info.packageHash);
                                 targetPlatform.getEmulatorManager().restartApplication(TestConfig.TestNamespace);
                                 return ServerUtil.expectTestMessages([ServerUtil.TestMessage.DEVICE_READY_AFTER_UPDATE]);
                             })
                             .then<void>(() => {
                                 /* restart the application */
-                                console.log("Update hash: " + ServerUtil.updateResponse.updateInfo.packageHash);
+                                console.log("Update hash: " + ServerUtil.updateResponse.update_info.packageHash);
                                 targetPlatform.getEmulatorManager().restartApplication(TestConfig.TestNamespace);
                                 return ServerUtil.expectTestMessages([ServerUtil.TestMessage.UPDATE_FAILED_PREVIOUSLY]);
                             })
                             .done(() => { done(); }, (e) => { done(e); });
                     });
-                
+
                 TestBuilder.it("localPackage.installOnNextRestart.norevert", true,
                     (done: MochaDone) => {
-                        ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(false, targetPlatform) };
+                        ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
 
                         /* create an update */
                         setupUpdateScenario(projectManager, targetPlatform, UpdateNotifyApplicationReady, "Update 1 (good update)")
@@ -898,10 +900,10 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             })
                             .done(() => { done(); }, (e) => { done(e); });
                     });
-                
+
                 TestBuilder.it("localPackage.installOnNextRestart.revertToPrevious", false,
                     (done: MochaDone) => {
-                        ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(false, targetPlatform) };
+                        ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
 
                         /* create an update */
                         setupUpdateScenario(projectManager, targetPlatform, UpdateNotifyApplicationReadyConditional, "Update 1 (good update)")
@@ -915,7 +917,7 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             })
                             .then<void>(() => {
                                 /* run good update, set up another (bad) update */
-                                ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(false, targetPlatform) };
+                                ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
                                 setupUpdateScenario(projectManager, targetPlatform, UpdateDeviceReady, "Update 2 (bad update)")
                                     .then(() => { return targetPlatform.getEmulatorManager().restartApplication(TestConfig.TestNamespace); });
                                 return ServerUtil.expectTestMessages([
@@ -934,7 +936,7 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                                 ServerUtil.testMessageResponse = ServerUtil.TestMessageResponse.SKIP_NOTIFY_APPLICATION_READY;
                                 targetPlatform.getEmulatorManager().restartApplication(TestConfig.TestNamespace);
                                 return ServerUtil.expectTestMessages([
-                                    ServerUtil.TestMessage.DEVICE_READY_AFTER_UPDATE, 
+                                    ServerUtil.TestMessage.DEVICE_READY_AFTER_UPDATE,
                                     ServerUtil.TestMessage.SKIPPED_NOTIFY_APPLICATION_READY]);
                             })
                             .then<void>(() => {
@@ -942,18 +944,18 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                                 ServerUtil.testMessageResponse = undefined;
                                 targetPlatform.getEmulatorManager().restartApplication(TestConfig.TestNamespace);
                                 return ServerUtil.expectTestMessages([
-                                    ServerUtil.TestMessage.DEVICE_READY_AFTER_UPDATE, 
+                                    ServerUtil.TestMessage.DEVICE_READY_AFTER_UPDATE,
                                     ServerUtil.TestMessage.UPDATE_FAILED_PREVIOUSLY]);
                             })
                             .done(() => { done(); }, (e) => { done(e); });
                     });
             }, ScenarioInstallOnRestartWithRevert);
-            
+
         TestBuilder.describe("#codePush.restartApplication",
             () => {
                 TestBuilder.it("codePush.restartApplication.checkPackages", true,
                     (done: MochaDone) => {
-                        ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(false, targetPlatform) };
+                        ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
 
                         setupUpdateScenario(projectManager, targetPlatform, UpdateNotifyApplicationReady, "Update 1")
                             .then<void>((updatePath: string) => {
@@ -963,7 +965,7 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                                     new ServerUtil.AppMessage(ServerUtil.TestMessage.PENDING_PACKAGE, [null]),
                                     new ServerUtil.AppMessage(ServerUtil.TestMessage.CURRENT_PACKAGE, [null]),
                                     new ServerUtil.AppMessage(ServerUtil.TestMessage.SYNC_STATUS, [ServerUtil.TestMessage.SYNC_UPDATE_INSTALLED]),
-                                    new ServerUtil.AppMessage(ServerUtil.TestMessage.PENDING_PACKAGE, [ServerUtil.updateResponse.updateInfo.packageHash]),
+                                    new ServerUtil.AppMessage(ServerUtil.TestMessage.PENDING_PACKAGE, [ServerUtil.updateResponse.update_info.packageHash]),
                                     new ServerUtil.AppMessage(ServerUtil.TestMessage.CURRENT_PACKAGE, [null]),
                                     ServerUtil.TestMessage.DEVICE_READY_AFTER_UPDATE]);
                             })
@@ -975,12 +977,12 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             .done(() => { done(); }, (e) => { done(e); });
                     });
             }, ScenarioRestart);
-            
+
         TestBuilder.describe("#codePush.restartApplication.2x",
             () => {
                 TestBuilder.it("blocks when a restart is in progress and doesn't crash if there is a pending package", false,
                     (done: MochaDone) => {
-                        ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(false, targetPlatform) };
+                        ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
                         setupTestRunScenario(projectManager, targetPlatform, ScenarioInstallRestart2x)
                             .then(setupUpdateScenario.bind(this, projectManager, targetPlatform, UpdateDeviceReady, "Update 1"))
                             .then<void>((updatePath: string) => {
@@ -994,10 +996,10 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             })
                             .done(() => { done(); }, (e) => { done(e); });
                     });
-                    
+
                 TestBuilder.it("doesn't block when the restart is ignored", false,
                     (done: MochaDone) => {
-                        ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(false, targetPlatform) };
+                        ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
                         setupTestRunScenario(projectManager, targetPlatform, ScenarioRestart2x)
                             .then(setupUpdateScenario.bind(this, projectManager, targetPlatform, UpdateDeviceReady, "Update 1"))
                             .then<void>((updatePath: string) => {
@@ -1012,7 +1014,7 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             .done(() => { done(); }, (e) => { done(e); });
                     });
             });
-            
+
         TestBuilder.describe("#window.codePush.sync",
             () => {
                 // We test the functionality with sync twice--first, with sync only called once,
@@ -1023,9 +1025,9 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                         TestBuilder.it("window.codePush.sync.noupdate", false,
                             (done: MochaDone) => {
                                 const noUpdateResponse = ServerUtil.createDefaultResponse();
-                                noUpdateResponse.isAvailable = false;
-                                noUpdateResponse.appVersion = "0.0.1";
-                                ServerUtil.updateResponse = { updateInfo: noUpdateResponse };
+                                noUpdateResponse.is_available = false;
+                                noUpdateResponse.app_version = "0.0.1";
+                                ServerUtil.updateResponse = { update_info: noUpdateResponse };
 
                                 Q({})
                                     .then<void>(p => {
@@ -1035,7 +1037,7 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                                     })
                                     .done(() => { done(); }, (e) => { done(e); });
                             });
-                        
+
                         TestBuilder.it("window.codePush.sync.checkerror", false,
                             (done: MochaDone) => {
                                 ServerUtil.updateResponse = "invalid {{ json";
@@ -1048,12 +1050,12 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                                     })
                                     .done(() => { done(); }, (e) => { done(e); });
                             });
-                        
+
                         TestBuilder.it("window.codePush.sync.downloaderror", false,
                             (done: MochaDone) => {
                                 const invalidUrlResponse = ServerUtil.createUpdateResponse();
-                                invalidUrlResponse.downloadURL = path.join(TestConfig.templatePath, "invalid_path.zip");
-                                ServerUtil.updateResponse = { updateInfo: invalidUrlResponse };
+                                invalidUrlResponse.download_url = path.join(TestConfig.templatePath, "invalid_path.zip");
+                                ServerUtil.updateResponse = { update_info: invalidUrlResponse };
 
                                 Q({})
                                     .then<void>(p => {
@@ -1063,11 +1065,11 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                                     })
                                     .done(() => { done(); }, (e) => { done(e); });
                             });
-                        
+
                         TestBuilder.it("window.codePush.sync.dorevert", false,
                             (done: MochaDone) => {
-                                ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(false, targetPlatform) };
-                            
+                                ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
+
                                 /* create an update */
                                 setupUpdateScenario(projectManager, targetPlatform, UpdateDeviceReady, "Update 1 (bad update)")
                                     .then<void>((updatePath: string) => {
@@ -1082,10 +1084,10 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                                     })
                                     .done(() => { done(); }, (e) => { done(e); });
                             });
-                        
+
                         TestBuilder.it("window.codePush.sync.update", false,
                             (done: MochaDone) => {
-                                ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(false, targetPlatform) };
+                                ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
 
                                 /* create an update */
                                 setupUpdateScenario(projectManager, targetPlatform, UpdateSync, "Update 1 (good update)")
@@ -1099,9 +1101,9 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                                     .then<void>(() => {
                                         // restart the app and make sure it didn't roll out!
                                         const noUpdateResponse = ServerUtil.createDefaultResponse();
-                                        noUpdateResponse.isAvailable = false;
-                                        noUpdateResponse.appVersion = "0.0.1";
-                                        ServerUtil.updateResponse = { updateInfo: noUpdateResponse };
+                                        noUpdateResponse.is_available = false;
+                                        noUpdateResponse.app_version = "0.0.1";
+                                        ServerUtil.updateResponse = { update_info: noUpdateResponse };
                                         targetPlatform.getEmulatorManager().restartApplication(TestConfig.TestNamespace);
                                         return ServerUtil.expectTestMessages([
                                             ServerUtil.TestMessage.DEVICE_READY_AFTER_UPDATE,
@@ -1109,18 +1111,18 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                                     })
                                     .done(() => { done(); }, (e) => { done(e); });
                             });
-                        
+
                     }, ScenarioSync1x);
-                    
+
                 TestBuilder.describe("#window.codePush.sync 2x",
                     () => {
                         // Tests where sync is called again before the first sync finishes
                         TestBuilder.it("window.codePush.sync.2x.noupdate", false,
                             (done: MochaDone) => {
                                 const noUpdateResponse = ServerUtil.createDefaultResponse();
-                                noUpdateResponse.isAvailable = false;
-                                noUpdateResponse.appVersion = "0.0.1";
-                                ServerUtil.updateResponse = { updateInfo: noUpdateResponse };
+                                noUpdateResponse.is_available = false;
+                                noUpdateResponse.app_version = "0.0.1";
+                                ServerUtil.updateResponse = { update_info: noUpdateResponse };
 
                                 Q({})
                                     .then<void>(p => {
@@ -1131,7 +1133,7 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                                     })
                                     .done(() => { done(); }, (e) => { done(e); });
                             });
-                        
+
                         TestBuilder.it("window.codePush.sync.2x.checkerror", false,
                             (done: MochaDone) => {
                                 ServerUtil.updateResponse = "invalid {{ json";
@@ -1145,12 +1147,12 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                                     })
                                     .done(() => { done(); }, (e) => { done(e); });
                             });
-                        
+
                         TestBuilder.it("window.codePush.sync.2x.downloaderror", false,
                             (done: MochaDone) => {
                                 const invalidUrlResponse = ServerUtil.createUpdateResponse();
-                                invalidUrlResponse.downloadURL = path.join(TestConfig.templatePath, "invalid_path.zip");
-                                ServerUtil.updateResponse = { updateInfo: invalidUrlResponse };
+                                invalidUrlResponse.download_url = path.join(TestConfig.templatePath, "invalid_path.zip");
+                                ServerUtil.updateResponse = { update_info: invalidUrlResponse };
 
                                 Q({})
                                     .then<void>(p => {
@@ -1161,11 +1163,11 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                                     })
                                     .done(() => { done(); }, (e) => { done(e); });
                             });
-                        
+
                         TestBuilder.it("window.codePush.sync.2x.dorevert", false,
                             (done: MochaDone) => {
-                                ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(false, targetPlatform) };
-                        
+                                ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
+
                                 /* create an update */
                                 setupUpdateScenario(projectManager, targetPlatform, UpdateDeviceReady, "Update 1 (bad update)")
                                     .then<void>((updatePath: string) => {
@@ -1183,10 +1185,10 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                                     })
                                     .done(() => { done(); }, (e) => { done(e); });
                             });
-                        
+
                         TestBuilder.it("window.codePush.sync.2x.update", true,
                             (done: MochaDone) => {
-                                ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(false, targetPlatform) };
+                                ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
 
                                 /* create an update */
                                 setupUpdateScenario(projectManager, targetPlatform, UpdateSync2x, "Update 1 (good update)")
@@ -1202,9 +1204,9 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                                     .then<void>(() => {
                                         // restart the app and make sure it didn't roll out!
                                         const noUpdateResponse = ServerUtil.createDefaultResponse();
-                                        noUpdateResponse.isAvailable = false;
-                                        noUpdateResponse.appVersion = "0.0.1";
-                                        ServerUtil.updateResponse = { updateInfo: noUpdateResponse };
+                                        noUpdateResponse.is_available = false;
+                                        noUpdateResponse.app_version = "0.0.1";
+                                        ServerUtil.updateResponse = { update_info: noUpdateResponse };
                                         targetPlatform.getEmulatorManager().restartApplication(TestConfig.TestNamespace);
                                         return ServerUtil.expectTestMessages([
                                             ServerUtil.TestMessage.DEVICE_READY_AFTER_UPDATE,
@@ -1215,16 +1217,16 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             });
                     }, ScenarioSync2x);
             });
-        
+
         TestBuilder.describe("#window.codePush.sync minimum background duration tests",
             () => {
                 TestBuilder.it("defaults to no minimum", false,
                     (done: MochaDone) => {
-                        ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(false, targetPlatform) };
+                        ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
 
                         setupTestRunScenario(projectManager, targetPlatform, ScenarioSyncResume).then<string>(() => {
-                                return setupUpdateScenario(projectManager, targetPlatform, UpdateSync, "Update 1 (good update)");
-                            })
+                            return setupUpdateScenario(projectManager, targetPlatform, UpdateSync, "Update 1 (good update)");
+                        })
                             .then<void>((updatePath: string) => {
                                 ServerUtil.updatePackagePath = updatePath;
                                 projectManager.runApplication(TestConfig.testRunDirectory, targetPlatform);
@@ -1233,9 +1235,9 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             })
                             .then<void>(() => {
                                 const noUpdateResponse = ServerUtil.createDefaultResponse();
-                                noUpdateResponse.isAvailable = false;
-                                noUpdateResponse.appVersion = "0.0.1";
-                                ServerUtil.updateResponse = { updateInfo: noUpdateResponse };
+                                noUpdateResponse.is_available = false;
+                                noUpdateResponse.app_version = "0.0.1";
+                                ServerUtil.updateResponse = { update_info: noUpdateResponse };
                                 targetPlatform.getEmulatorManager().resumeApplication(TestConfig.TestNamespace);
                                 return ServerUtil.expectTestMessages([
                                     ServerUtil.TestMessage.DEVICE_READY_AFTER_UPDATE,
@@ -1243,14 +1245,14 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             })
                             .done(() => { done(); }, (e) => { done(e); });
                     });
-                
+
                 TestBuilder.it("min background duration 5s", false,
                     (done: MochaDone) => {
-                        ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(false, targetPlatform) };
+                        ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
 
                         setupTestRunScenario(projectManager, targetPlatform, ScenarioSyncResumeDelay).then<string>(() => {
-                                return setupUpdateScenario(projectManager, targetPlatform, UpdateSync, "Update 1 (good update)");
-                            })
+                            return setupUpdateScenario(projectManager, targetPlatform, UpdateSync, "Update 1 (good update)");
+                        })
                             .then((updatePath: string) => {
                                 ServerUtil.updatePackagePath = updatePath;
                                 projectManager.runApplication(TestConfig.testRunDirectory, targetPlatform);
@@ -1259,9 +1261,9 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             })
                             .then(() => {
                                 const noUpdateResponse = ServerUtil.createDefaultResponse();
-                                noUpdateResponse.isAvailable = false;
-                                noUpdateResponse.appVersion = "0.0.1";
-                                ServerUtil.updateResponse = { updateInfo: noUpdateResponse };
+                                noUpdateResponse.is_available = false;
+                                noUpdateResponse.app_version = "0.0.1";
+                                ServerUtil.updateResponse = { update_info: noUpdateResponse };
                                 return targetPlatform.getEmulatorManager().resumeApplication(TestConfig.TestNamespace, 3 * 1000);
                             })
                             .then(() => {
@@ -1272,14 +1274,14 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             })
                             .done(() => { done(); }, (e) => { done(e); });
                     });
-                    
+
                 TestBuilder.it("has no effect on restart", false,
                     (done: MochaDone) => {
-                        ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(false, targetPlatform) };
+                        ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
 
                         setupTestRunScenario(projectManager, targetPlatform, ScenarioSyncRestartDelay).then<string>(() => {
-                                return setupUpdateScenario(projectManager, targetPlatform, UpdateSync, "Update 1 (good update)");
-                            })
+                            return setupUpdateScenario(projectManager, targetPlatform, UpdateSync, "Update 1 (good update)");
+                        })
                             .then<void>((updatePath: string) => {
                                 ServerUtil.updatePackagePath = updatePath;
                                 projectManager.runApplication(TestConfig.testRunDirectory, targetPlatform);
@@ -1288,9 +1290,9 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             })
                             .then<void>(() => {
                                 const noUpdateResponse = ServerUtil.createDefaultResponse();
-                                noUpdateResponse.isAvailable = false;
-                                noUpdateResponse.appVersion = "0.0.1";
-                                ServerUtil.updateResponse = { updateInfo: noUpdateResponse };
+                                noUpdateResponse.is_available = false;
+                                noUpdateResponse.app_version = "0.0.1";
+                                ServerUtil.updateResponse = { update_info: noUpdateResponse };
                                 targetPlatform.getEmulatorManager().restartApplication(TestConfig.TestNamespace);
                                 return ServerUtil.expectTestMessages([
                                     ServerUtil.TestMessage.DEVICE_READY_AFTER_UPDATE,
@@ -1299,16 +1301,16 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             .done(() => { done(); }, (e) => { done(e); });
                     });
             });
-            
+
         TestBuilder.describe("#window.codePush.sync mandatory install mode tests",
             () => {
                 TestBuilder.it("defaults to IMMEDIATE", false,
                     (done: MochaDone) => {
-                        ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(true, targetPlatform) };
+                        ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(true, targetPlatform) };
 
                         setupTestRunScenario(projectManager, targetPlatform, ScenarioSyncMandatoryDefault).then<string>(() => {
-                                return setupUpdateScenario(projectManager, targetPlatform, UpdateDeviceReady, "Update 1 (good update)");
-                            })
+                            return setupUpdateScenario(projectManager, targetPlatform, UpdateDeviceReady, "Update 1 (good update)");
+                        })
                             .then<void>((updatePath: string) => {
                                 ServerUtil.updatePackagePath = updatePath;
                                 projectManager.runApplication(TestConfig.testRunDirectory, targetPlatform);
@@ -1316,14 +1318,14 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             })
                             .done(() => { done(); }, (e) => { done(e); });
                     });
-                    
+
                 TestBuilder.it("works correctly when update is mandatory and mandatory install mode is specified", false,
                     (done: MochaDone) => {
-                        ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(true, targetPlatform) };
+                        ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(true, targetPlatform) };
 
                         setupTestRunScenario(projectManager, targetPlatform, ScenarioSyncMandatoryResume).then<string>(() => {
-                                return setupUpdateScenario(projectManager, targetPlatform, UpdateDeviceReady, "Update 1 (good update)");
-                            })
+                            return setupUpdateScenario(projectManager, targetPlatform, UpdateDeviceReady, "Update 1 (good update)");
+                        })
                             .then<void>((updatePath: string) => {
                                 ServerUtil.updatePackagePath = updatePath;
                                 projectManager.runApplication(TestConfig.testRunDirectory, targetPlatform);
@@ -1332,23 +1334,23 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             })
                             .then<void>(() => {
                                 const noUpdateResponse = ServerUtil.createDefaultResponse();
-                                noUpdateResponse.isAvailable = false;
-                                noUpdateResponse.appVersion = "0.0.1";
-                                ServerUtil.updateResponse = { updateInfo: noUpdateResponse };
+                                noUpdateResponse.is_available = false;
+                                noUpdateResponse.app_version = "0.0.1";
+                                ServerUtil.updateResponse = { update_info: noUpdateResponse };
                                 targetPlatform.getEmulatorManager().resumeApplication(TestConfig.TestNamespace, 5 * 1000);
                                 return ServerUtil.expectTestMessages([
                                     ServerUtil.TestMessage.DEVICE_READY_AFTER_UPDATE]);
                             })
                             .done(() => { done(); }, (e) => { done(e); });
                     });
-                    
+
                 TestBuilder.it("has no effect on updates that are not mandatory", false,
                     (done: MochaDone) => {
-                        ServerUtil.updateResponse = { updateInfo: ServerUtil.createUpdateResponse(false, targetPlatform) };
+                        ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
 
                         setupTestRunScenario(projectManager, targetPlatform, ScenarioSyncMandatoryRestart).then<string>(() => {
-                                return setupUpdateScenario(projectManager, targetPlatform, UpdateDeviceReady, "Update 1 (good update)");
-                            })
+                            return setupUpdateScenario(projectManager, targetPlatform, UpdateDeviceReady, "Update 1 (good update)");
+                        })
                             .then<void>((updatePath: string) => {
                                 ServerUtil.updatePackagePath = updatePath;
                                 projectManager.runApplication(TestConfig.testRunDirectory, targetPlatform);

--- a/test/test.ts
+++ b/test/test.ts
@@ -484,7 +484,7 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                     (done: MochaDone) => {
                         const noUpdateResponse = ServerUtil.createDefaultResponse();
                         noUpdateResponse.is_available = false;
-                        noUpdateResponse.app_version = "0.0.1";
+                        noUpdateResponse.target_binary_range = "0.0.1";
                         ServerUtil.updateResponse = { update_info: noUpdateResponse };
 
                         ServerUtil.testMessageCallback = (requestBody: any) => {
@@ -509,7 +509,7 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
 
                         const noUpdateResponse = ServerUtil.createDefaultResponse();
                         noUpdateResponse.is_available = false;
-                        noUpdateResponse.app_version = "0.0.1";
+                        noUpdateResponse.target_binary_range = "0.0.1";
 
                         ServerUtil.updateCheckCallback = (request: any) => {
                             try {
@@ -537,7 +537,7 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                     (done: MochaDone) => {
                         const updateAppVersionResponse = ServerUtil.createDefaultResponse();
                         updateAppVersionResponse.is_available = true;
-                        updateAppVersionResponse.app_version = "2.0.0";
+                        updateAppVersionResponse.target_binary_range = "2.0.0";
 
                         ServerUtil.updateResponse = { update_info: updateAppVersionResponse };
 
@@ -563,12 +563,12 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                                 assert.equal(requestBody.message, ServerUtil.TestMessage.CHECK_UPDATE_AVAILABLE);
                                 assert.notEqual(requestBody.args[0], null);
                                 const remotePackage: any = requestBody.args[0];
-                                assert.equal(remotePackage.download_url, updateResponse.download_url);
-                                assert.equal(remotePackage.isMandatory, updateResponse.isMandatory);
+                                assert.equal(remotePackage.downloadUrl, updateResponse.download_url);
+                                assert.equal(remotePackage.isMandatory, updateResponse.is_mandatory);
                                 assert.equal(remotePackage.label, updateResponse.label);
                                 assert.equal(remotePackage.packageHash, updateResponse.package_hash);
                                 assert.equal(remotePackage.packageSize, updateResponse.package_size);
-                                assert.equal(remotePackage.deployment_key, targetPlatform.getDefaultDeploymentKey());
+                                assert.equal(remotePackage.deploymentKey, targetPlatform.getDefaultDeploymentKey());
                                 done();
                             } catch (e) {
                                 done(e);
@@ -1026,7 +1026,7 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             (done: MochaDone) => {
                                 const noUpdateResponse = ServerUtil.createDefaultResponse();
                                 noUpdateResponse.is_available = false;
-                                noUpdateResponse.app_version = "0.0.1";
+                                noUpdateResponse.target_binary_range = "0.0.1";
                                 ServerUtil.updateResponse = { update_info: noUpdateResponse };
 
                                 Q({})
@@ -1102,7 +1102,7 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                                         // restart the app and make sure it didn't roll out!
                                         const noUpdateResponse = ServerUtil.createDefaultResponse();
                                         noUpdateResponse.is_available = false;
-                                        noUpdateResponse.app_version = "0.0.1";
+                                        noUpdateResponse.target_binary_range = "0.0.1";
                                         ServerUtil.updateResponse = { update_info: noUpdateResponse };
                                         targetPlatform.getEmulatorManager().restartApplication(TestConfig.TestNamespace);
                                         return ServerUtil.expectTestMessages([
@@ -1121,7 +1121,7 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             (done: MochaDone) => {
                                 const noUpdateResponse = ServerUtil.createDefaultResponse();
                                 noUpdateResponse.is_available = false;
-                                noUpdateResponse.app_version = "0.0.1";
+                                noUpdateResponse.target_binary_range = "0.0.1";
                                 ServerUtil.updateResponse = { update_info: noUpdateResponse };
 
                                 Q({})
@@ -1205,7 +1205,7 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                                         // restart the app and make sure it didn't roll out!
                                         const noUpdateResponse = ServerUtil.createDefaultResponse();
                                         noUpdateResponse.is_available = false;
-                                        noUpdateResponse.app_version = "0.0.1";
+                                        noUpdateResponse.target_binary_range = "0.0.1";
                                         ServerUtil.updateResponse = { update_info: noUpdateResponse };
                                         targetPlatform.getEmulatorManager().restartApplication(TestConfig.TestNamespace);
                                         return ServerUtil.expectTestMessages([
@@ -1236,7 +1236,7 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             .then<void>(() => {
                                 const noUpdateResponse = ServerUtil.createDefaultResponse();
                                 noUpdateResponse.is_available = false;
-                                noUpdateResponse.app_version = "0.0.1";
+                                noUpdateResponse.target_binary_range = "0.0.1";
                                 ServerUtil.updateResponse = { update_info: noUpdateResponse };
                                 targetPlatform.getEmulatorManager().resumeApplication(TestConfig.TestNamespace);
                                 return ServerUtil.expectTestMessages([
@@ -1262,7 +1262,7 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             .then(() => {
                                 const noUpdateResponse = ServerUtil.createDefaultResponse();
                                 noUpdateResponse.is_available = false;
-                                noUpdateResponse.app_version = "0.0.1";
+                                noUpdateResponse.target_binary_range = "0.0.1";
                                 ServerUtil.updateResponse = { update_info: noUpdateResponse };
                                 return targetPlatform.getEmulatorManager().resumeApplication(TestConfig.TestNamespace, 3 * 1000);
                             })
@@ -1291,7 +1291,7 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             .then<void>(() => {
                                 const noUpdateResponse = ServerUtil.createDefaultResponse();
                                 noUpdateResponse.is_available = false;
-                                noUpdateResponse.app_version = "0.0.1";
+                                noUpdateResponse.target_binary_range = "0.0.1";
                                 ServerUtil.updateResponse = { update_info: noUpdateResponse };
                                 targetPlatform.getEmulatorManager().restartApplication(TestConfig.TestNamespace);
                                 return ServerUtil.expectTestMessages([
@@ -1335,7 +1335,7 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             .then<void>(() => {
                                 const noUpdateResponse = ServerUtil.createDefaultResponse();
                                 noUpdateResponse.is_available = false;
-                                noUpdateResponse.app_version = "0.0.1";
+                                noUpdateResponse.target_binary_range = "0.0.1";
                                 ServerUtil.updateResponse = { update_info: noUpdateResponse };
                                 targetPlatform.getEmulatorManager().resumeApplication(TestConfig.TestNamespace, 5 * 1000);
                                 return ServerUtil.expectTestMessages([


### PR DESCRIPTION
The test server used an outdated camel case response signature. In this PR, we replaced the camel case with a snake case.

**Changes:**

- Replaced camel case with snake case in `defaultResponse` and `updateResponse` on server side

- Updated code-push-plugin-testing-framework.d.ts

- Updated tests

