### PR TITLE
[Bug] Fix iOS rollback recording

### DIFF
--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -895,6 +895,7 @@ RCT_EXPORT_METHOD(setLatestRollbackInfo:(NSString *)packageHash
                   reject:(RCTPromiseRejectBlock)reject)
 {
     [[self class] setLatestRollbackInfo:packageHash];
+    resolve(nil);
 }
 
 


### PR DESCRIPTION
**Issue:** We found that react-native-code-push on iOS does not record rollbacks when broken bundles are pushed. The reason was that the `setLatestRollbackInfo` function would not resolve the promise.

**Solution:** Add promise resolve to `setLatestRollbackInfo` function. 