### PR TITLE
Add compatibility with react-native v0.62

### DIFF
--- a/Examples/create-app.js
+++ b/Examples/create-app.js
@@ -10,7 +10,7 @@ Requirements:
 Usage: node create-app.js <appName> <reactNativeVersion> <reactNativeCodePushVersion>
     1. node create-app.js 
     2. node create-app.js myapp
-    3. node create-app.js myapp react-native@0.61.5 react-native-code-push@6.0.0 
+    3. node create-app.js myapp react-native@0.62 react-native-code-push@6.1.0 
     4. node create-app.js myapp react-native@latest Microsoft/react-native-code-push
 
 Parameters:
@@ -225,6 +225,7 @@ function isReactNativeVersionLowerThan(version) {
 // Configuring android applications for react-native version higher than 0.60
 function androidSetup() {
     const buildGradlePath = path.join('android', 'app', 'build.gradle');
+    const settingsGradlePath = path.join('android', 'settings.gradle');
     const mainApplicationPath = path.join('android', 'app', 'src', 'main', 'java', 'com', appName, 'MainApplication.java');
     const stringsResourcesPath = path.join('android', 'app', 'src', 'main', 'res', 'values', 'strings.xml');
 
@@ -240,6 +241,13 @@ function androidSetup() {
     buildGradleContents = buildGradleContents.replace(reactGradleLink,
         `${reactGradleLink}${codePushGradleLink}`);
     fs.writeFileSync(buildGradlePath, buildGradleContents);
+
+    let settingsGradleContents = fs.readFileSync(settingsGradlePath, "utf8");
+    const settingsGradleInclude = "include \':app\'";
+    const codePushProjectImport= `':react-native-code-push'\nproject(':react-native-code-push').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-code-push/android/app')`;
+    settingsGradleContents = settingsGradleContents.replace(settingsGradleInclude,
+        `${settingsGradleInclude}, ${codePushProjectImport}`);
+    fs.writeFileSync(settingsGradlePath, settingsGradleContents);
 
     const getJSBundleFileOverride = `
     @Override

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -158,11 +158,14 @@ public class CodePush implements ReactPackage {
                     if (m.getName().equals("isReloadOnJSChangeEnabled")) {
                         try {
                             return (boolean) m.invoke(devInternalSettings);
-                        } catch (Exception x) { }
+                        } catch (Exception x) {
+                            return false;
+                        }
                     }
                 }
             }
         }
+
         return false;
     }
 

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -20,6 +20,7 @@ import org.json.JSONObject;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.lang.reflect.Method;
 
 public class CodePush implements ReactPackage {
 
@@ -145,20 +146,28 @@ public class CodePush implements ReactPackage {
         return null;
     }
 
-    public void clearDebugCacheIfNeeded(ReactInstanceManager instanceManager) {
-        boolean isLiveReloadEnabled = false;
-
+    private boolean isLiveReloadEnabled(ReactInstanceManager instanceManager) {
         // Use instanceManager for checking if we use LiveReload mode. In this case we should not remove ReactNativeDevBundle.js file
         // because we get error with trying to get this after reloading. Issue: https://github.com/Microsoft/react-native-code-push/issues/1272
         if (instanceManager != null) {
             DevSupportManager devSupportManager = instanceManager.getDevSupportManager();
             if (devSupportManager != null) {
                 DevInternalSettings devInternalSettings = (DevInternalSettings)devSupportManager.getDevSettings();
-                isLiveReloadEnabled = devInternalSettings.isReloadOnJSChangeEnabled();
+                Method[] methods = devInternalSettings.getClass().getMethods();
+                for (Method m : methods) {
+                    if (m.getName().equals("isReloadOnJSChangeEnabled")) {
+                        try {
+                            return (boolean) m.invoke(devInternalSettings);
+                        } catch (Exception x) { }
+                    }
+                }
             }
         }
+        return false;
+    }
 
-        if (mIsDebugMode && mSettingsManager.isPendingUpdate(null) && !isLiveReloadEnabled) {
+    public void clearDebugCacheIfNeeded(ReactInstanceManager instanceManager) {
+        if (mIsDebugMode && mSettingsManager.isPendingUpdate(null) && !isLiveReloadEnabled(instanceManager)) {
             // This needs to be kept in sync with https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManager.java#L78
             File cachedDevBundle = new File(mContext.getFilesDir(), "ReactNativeDevBundle.js");
             if (cachedDevBundle.exists()) {

--- a/docs/setup-android.md
+++ b/docs/setup-android.md
@@ -19,7 +19,14 @@ In order to integrate CodePush into your Android project, please perform the fol
 
 ### Plugin Installation and Configuration for React Native 0.60 version and above (Android)
 
-1. In your `android/app/build.gradle` file, add the `codepush.gradle` file as an additional build task definition underneath `react.gradle`:
+1. In your `android/settings.gradle` file, make the following additions:
+
+    ```gradle
+    include ':app', ':react-native-code-push'
+    project(':react-native-code-push').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-code-push/android/app')
+    ```
+    
+2. In your `android/app/build.gradle` file, add the `codepush.gradle` file as an additional build task definition underneath `react.gradle`:
 
     ```gradle
     ...
@@ -27,7 +34,8 @@ In order to integrate CodePush into your Android project, please perform the fol
     apply from: "../../node_modules/react-native-code-push/android/codepush.gradle"
     ...
     ```
-2. Update the `MainApplication.java` file to use CodePush via the following changes:
+
+3. Update the `MainApplication.java` file to use CodePush via the following changes:
 
     ```java
     ...
@@ -50,7 +58,7 @@ In order to integrate CodePush into your Android project, please perform the fol
     }
     ```
 
-3. Add the Deployment key to `strings.xml`:
+4. Add the Deployment key to `strings.xml`:
    
    To let the CodePush runtime know which deployment it should query for updates, open your app's `strings.xml` file and add a new string named `CodePushDeploymentKey`, whose value is the key of the deployment you want to configure this app against (like the key for the `Staging` deployment for the `FooBar` app). You can retrieve this value by running `code-push deployment ls <appName> -k` in the CodePush CLI (the `-k` flag is necessary since keys aren't displayed by default) and copying the value of the `Deployment Key` column which corresponds to the deployment you want to use (see below). Note that using the deployment's name (like Staging) will not work. The "friendly name" is intended only for authenticated management usage from the CLI, and not for public consumption within your app.
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -87,6 +87,12 @@ class RNAndroid extends Platform.Android implements RNPlatform {
             "apply from: \"../../node_modules/react-native/react.gradle\"",
             "apply from: \"../../node_modules/react-native/react.gradle\"\napply from: \"" + gradleContent + "\"");
 
+        // Add CodePush to android/settings.gradle
+        const settingsGradle = path.join(innerprojectDirectory, "android", "settings.gradle");
+        TestUtil.replaceString(settingsGradle,
+            "include ':app'",
+            "include ':app', ':react-native-code-push'\nproject(':react-native-code-push').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-code-push/android/app')");
+
         //// Set the app version to 1.0.0 instead of 1.0
         // Set the app version to 1.0.0 in android/app/build.gradle
         TestUtil.replaceString(buildGradle, "versionName \"1.0\"", "versionName \"1.0.0\"");

--- a/test/test.ts
+++ b/test/test.ts
@@ -233,7 +233,7 @@ class RNIOS extends Platform.IOS implements RNPlatform {
                 const hashWithParen = targetEmulator.match(hashRegEx)[0];
                 const hash = hashWithParen.substr(1, hashWithParen.length - 2);
                 return TestUtil.getProcessOutput("xcodebuild -workspace " + path.join(iOSProject, TestConfig.TestAppName) + ".xcworkspace -scheme " + TestConfig.TestAppName +
-                    " -configuration Release -destination \"platform=iOS Simulator,id=" + hash + "\" -derivedDataPath build", { cwd: iOSProject, maxBuffer: 1024 * 1000 * 10, noLogStdOut: true });
+                    " -configuration Release -destination \"platform=iOS Simulator,id=" + hash + "\" -derivedDataPath build", { cwd: iOSProject, maxBuffer: 1024 * 1024 * 20, noLogStdOut: true });
             })
             .then<void>(
                 () => { return null; },


### PR DESCRIPTION
After the release of the new version of react-native v0.62 we faced some compatibility issues. This PR adds react-native-code-push and react-native v0.62 compatibility.

**Changes:**

- Since with Rn 0.62 Fast Refresh has been enabled by default. We adapted the code for compatibility with older versions.
- Updated documentation for android installation
- Updated create-app script
- Updated test configuration