### PR TITLE
fix length of bytes calculation for utf-8 string for package hash

### DIFF
--- a/ios/CodePush/CodePushUpdateUtils.m
+++ b/ios/CodePush/CodePushUpdateUtils.m
@@ -93,7 +93,7 @@ NSString * const IgnoreCodePushMetadata = @".codepushrelease";
     // The JSON serialization turns path separators into "\/", e.g. "CodePush\/assets\/image.png"
     manifestString = [manifestString stringByReplacingOccurrencesOfString:@"\\/"
                                                                withString:@"/"];
-    return [self computeHashForData:[NSData dataWithBytes:manifestString.UTF8String length:manifestString.length]];
+    return [self computeHashForData:[NSData dataWithBytes:manifestString.UTF8String length:[manifestString lengthOfBytesUsingEncoding:NSUTF8StringEncoding]]];
 }
 
 + (NSString *)computeHashForData:(NSData *)inputData


### PR DESCRIPTION
The UTF-8 encoding of Chinese characters is multi-byte. 

``` objective-c
NSString *str = @"您来啦啦";
[str lengthOfBytesUsingEncoding:NSUTF8StringEncoding]
// get 12 bytes
str.length;
// get 4
```