### PR TITLE
Fix ON_NEXT_SUSPEND install mode

### DIFF
--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -643,8 +643,7 @@ static NSString *const LatestRollbackCountKey = @"count";
 - (void)applicationWillEnterForeground
 {
     if (_appSuspendTimer) {
-        [_appSuspendTimer invalidate];
-        _appSuspendTimer = nil;
+        return;
     }
     // Determine how long the app was in the background and ensure
     // that it meets the minimum duration amount of time.

--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -655,7 +655,6 @@ static NSString *const LatestRollbackCountKey = @"count";
         if (durationInBackground < _minimumBackgroundDuration) {
             [_appSuspendTimer invalidate];
             _appSuspendTimer = nil;
-            return;
         }
     } else {
         // For resume install mode

--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -644,15 +644,14 @@ static NSString *const LatestRollbackCountKey = @"count";
 {
     // Determine how long the app was in the background and ensure
     // that it meets the minimum duration amount of time.
-
     int durationInBackground = 0;
     if (_lastResignedDate) {
         durationInBackground = [[NSDate date] timeIntervalSinceDate:_lastResignedDate];
     }
 
     if (_installMode == CodePushInstallModeOnNextSuspend) {
-        // We shouldn't use loadBundle in this case, because _appSuspendTimer will call loadBundleOnTick
-        // We should cancel timer for _appSuspendTimer if durationInBackground is lower than _minimumBackgroundDuration
+        // We shouldn't use loadBundle in this case, because _appSuspendTimer will call loadBundleOnTick.
+        // We should cancel timer for _appSuspendTimer because otherwise, we would call loadBundle two times.
         if (durationInBackground < _minimumBackgroundDuration) {
             [_appSuspendTimer invalidate];
             _appSuspendTimer = nil;

--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -657,7 +657,7 @@ static NSString *const LatestRollbackCountKey = @"count";
             _appSuspendTimer = nil;
         }
     } else {
-        // For resume install mode
+        // For resume install mode.
         if (durationInBackground >= _minimumBackgroundDuration) {
            [self loadBundle];
         }


### PR DESCRIPTION
**Issue**: There are two functions, which call **uploadBundle** method. This leads to confusion in the work of the RTC bridge. 

**Related issue**: #1762 

**Solution**: Cancel loadBundle for ON_NEXT_SUSPEND mode