### PR TITLE
Mitigate zipperdown

### DIFF
--- a/CodePush.podspec
+++ b/CodePush.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   # we explicitly let CocoaPods pull in the versions below so all dependencies are resolved and 
   # linked properly at a parent workspace level.
   s.dependency 'React'
-  s.dependency 'SSZipArchive', '~> 2.1'
+  s.dependency 'SSZipArchive', '~> 2.2.2'
   s.dependency 'JWT', '~> 3.0.0-beta.12'
   s.dependency 'Base64', '~> 1.1'
 end

--- a/android/app/src/main/java/com/microsoft/codepush/react/FileUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/FileUtils.java
@@ -123,6 +123,20 @@ public class FileUtils {
         }
     }
 
+    private static String validateFileName(String fileName, String targetDirectory) throws IOException {
+        File file = new File(fileName);
+        String canonicalPath = file.getCanonicalPath();
+
+        File targetFile = new File(targetDirectory);
+        String targetCanonicalPath = targetFile.getCanonicalPath();
+
+        if (!canonicalPath.startsWith(targetCanonicalPath)) {
+            throw new IllegalStateException("File is outside extraction target directory.");
+        }
+
+        return canonicalPath;
+    }
+
     public static void unzipFile(File zipFile, String destination) throws IOException {
         FileInputStream fileStream = null;
         BufferedInputStream bufferedStream = null;
@@ -142,7 +156,7 @@ public class FileUtils {
 
             byte[] buffer = new byte[WRITE_BUFFER_SIZE];
             while ((entry = zipStream.getNextEntry()) != null) {
-                String fileName = entry.getName();
+                String fileName = validateFileName(entry.getName(), ".");
                 File file = new File(destinationFolder, fileName);
                 if (entry.isDirectory()) {
                     file.mkdirs();


### PR DESCRIPTION
**Issue**: Addresses the vulnerability identified in #1283.

The current unzip method is vulnerable to a zipperdown attack if an attacker can get a malicious file to the handling code.

**Solution**: https://github.com/microsoft/react-native-code-push/pull/1702