### PR TITLE
Fix Android build failure if `bundleJsAndAssets` is disabled

### DIFF
--- a/android/codepush.gradle
+++ b/android/codepush.gradle
@@ -48,7 +48,7 @@ gradle.projectsEvaluated {
         // Make this task run right after the bundle task
         def generateBundledResourcesHash;
 
-        if (variant.hasProperty("bundleJsAndAssets")) {
+        if (variant.hasProperty("bundleJsAndAssets") && variant.bundleJsAndAssets.enabled) {
             def reactBundleTask = variant.bundleJsAndAssets
             jsBundleDir = reactBundleTask.generatedAssetsFolders[0].absolutePath
             resourcesDir = reactBundleTask.generatedResFolders[0].absolutePath


### PR DESCRIPTION
Previously, we have only checked for the existence of React Native's gradle task `bundleJsAndAssets` to determine whether we should use `generatedAssetsFolders` and `generatedResFolders`, or we should use folders provided by the user through React Native's gradle config (`project.react`). 

This broke Android builds when the user has disabled bundling in `project.react`, because as of React Native 0.63, the [`bundleJsAndAssets` gradle task is always created](https://github.com/facebook/react-native/blob/4f897336b6ce6c640a65f86b65c6d386ea55b944/react.gradle#L220). Consequently, `variant.hasProperty("bundleJsAndAssets")` is always `true`, and the else branch is never reached.

This commit adds an additional check whether `bundleJsAndAssets` task is enabled, provided it exists of course.