### PR TITLE
Add update notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ We try our best to maintain backwards compatibility of our plugin with previous 
 | v0.56-v0.58             | v5.4+ *(RN upgraded versions for Android tools)*      |
 | v0.59                   | v5.6+ *(RN refactored js bundle loader code)*         |
 | v0.60-v0.61             | v6.0+ *(RN migrated to Autolinking)*                  |
-| v0.62                   | v6.2+ *(RN removed LiveReload)*                       |
+| v0.62-v0.63             | v6.2+ *(RN removed LiveReload)*                       |
+
+*NOTE: React-native versions are lower than to v0.45 will stop working n the near future. You can find more information in our [documentation]().*
 
 We work hard to respond to new RN releases, but they do occasionally break us. We will update this chart with each RN release, so that users can check to see what our "official" support is.
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ We try our best to maintain backwards compatibility of our plugin with previous 
 | v0.60-v0.61             | v6.0+ *(RN migrated to Autolinking)*                  |
 | v0.62-v0.63             | v6.2+ *(RN removed LiveReload)*                       |
 
-*NOTE: React-native versions are lower than to v0.45 will stop working n the near future. You can find more information in our [documentation](https://github.com/microsoft/code-push/blob/feature/add_doc_for_new_release/Update.md).*
+*NOTE: React-native versions are lower than to v0.45 will stop working n the near future. You can find more information in our [documentation](https://github.com/microsoft/code-push/blob/master/MigrationNotice.md).*
 
 We work hard to respond to new RN releases, but they do occasionally break us. We will update this chart with each RN release, so that users can check to see what our "official" support is.
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ We try our best to maintain backwards compatibility of our plugin with previous 
 | v0.60-v0.61             | v6.0+ *(RN migrated to Autolinking)*                  |
 | v0.62-v0.63             | v6.2+ *(RN removed LiveReload)*                       |
 
-*NOTE: `react-native-code-push` versions are lower than to **v5.7.0** will stop working in the near future. You can find more information in our [documentation](https://github.com/microsoft/code-push/blob/master/MigrationNotice.md).*
+*NOTE: `react-native-code-push` versions are lower than to **[v5.7.0](https://github.com/microsoft/react-native-code-push/releases/tag/v5.7.0)** will stop working in the near future. You can find more information in our [documentation](https://github.com/microsoft/code-push/blob/master/MigrationNotice.md).*
 
 We work hard to respond to new RN releases, but they do occasionally break us. We will update this chart with each RN release, so that users can check to see what our "official" support is.
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ We try our best to maintain backwards compatibility of our plugin with previous 
 | v0.60-v0.61             | v6.0+ *(RN migrated to Autolinking)*                  |
 | v0.62-v0.63             | v6.2+ *(RN removed LiveReload)*                       |
 
-*NOTE: `react-native-code-push` versions lower than **[v5.7.0](https://github.com/microsoft/react-native-code-push/releases/tag/v5.7.0)** will stop working in the near future. You can find more information in our [documentation](https://github.com/microsoft/code-push/blob/master/MigrationNotice.md).*
+*NOTE: `react-native-code-push` versions lower than **[v5.7.0](https://github.com/microsoft/react-native-code-push/releases/tag/v5.7.0)** will stop working in the near future. You can find more information in our [documentation](https://github.com/microsoft/code-push/blob/master/migration-notice.md).*
 
 We work hard to respond to new RN releases, but they do occasionally break us. We will update this chart with each RN release, so that users can check to see what our "official" support is.
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ We try our best to maintain backwards compatibility of our plugin with previous 
 | v0.60-v0.61             | v6.0+ *(RN migrated to Autolinking)*                  |
 | v0.62-v0.63             | v6.2+ *(RN removed LiveReload)*                       |
 
-*NOTE: `react-native-code-push` versions are lower than to v5.7.0 will stop working in the near future. You can find more information in our [documentation](https://github.com/microsoft/code-push/blob/master/MigrationNotice.md).*
+*NOTE: `react-native-code-push` versions are lower than to **v5.7.0** will stop working in the near future. You can find more information in our [documentation](https://github.com/microsoft/code-push/blob/master/MigrationNotice.md).*
 
 We work hard to respond to new RN releases, but they do occasionally break us. We will update this chart with each RN release, so that users can check to see what our "official" support is.
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ We try our best to maintain backwards compatibility of our plugin with previous 
 | v0.60-v0.61             | v6.0+ *(RN migrated to Autolinking)*                  |
 | v0.62-v0.63             | v6.2+ *(RN removed LiveReload)*                       |
 
-*NOTE: React-native versions are lower than to v0.45 will stop working n the near future. You can find more information in our [documentation](https://github.com/microsoft/code-push/blob/master/MigrationNotice.md).*
+*NOTE: `react-native-code-push` versions are lower than to v5.7.0 will stop working in the near future. You can find more information in our [documentation](https://github.com/microsoft/code-push/blob/master/MigrationNotice.md).*
 
 We work hard to respond to new RN releases, but they do occasionally break us. We will update this chart with each RN release, so that users can check to see what our "official" support is.
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ We try our best to maintain backwards compatibility of our plugin with previous 
 | v0.60-v0.61             | v6.0+ *(RN migrated to Autolinking)*                  |
 | v0.62-v0.63             | v6.2+ *(RN removed LiveReload)*                       |
 
-*NOTE: `react-native-code-push` versions are lower than to **[v5.7.0](https://github.com/microsoft/react-native-code-push/releases/tag/v5.7.0)** will stop working in the near future. You can find more information in our [documentation](https://github.com/microsoft/code-push/blob/master/MigrationNotice.md).*
+*NOTE: `react-native-code-push` versions lower than **[v5.7.0](https://github.com/microsoft/react-native-code-push/releases/tag/v5.7.0)** will stop working in the near future. You can find more information in our [documentation](https://github.com/microsoft/code-push/blob/master/MigrationNotice.md).*
 
 We work hard to respond to new RN releases, but they do occasionally break us. We will update this chart with each RN release, so that users can check to see what our "official" support is.
 


### PR DESCRIPTION
CodePush SDK migrated to a new service. `react-native-code-push` versions are lower than to v5.7.0 will stop working in the near future