### PR TITLE
fix priority in calculating node_modules location in gradle.

### DIFF
--- a/android/codepush.gradle
+++ b/android/codepush.gradle
@@ -23,13 +23,13 @@ gradle.projectsEvaluated {
         // https://github.com/microsoft/cordova-plugin-code-push/issues/264
         it.resValue 'string', "CODE_PUSH_APK_BUILD_TIME", String.format("\"%d\"", System.currentTimeMillis())
     }
-    
+
     android.applicationVariants.all { variant ->
         def nodeModulesPath;
-        if (config.root) {
-            nodeModulesPath = Paths.get(config.root, "/node_modules");
-        } else if (project.hasProperty('nodeModulesPath')) {
+        if (project.hasProperty('nodeModulesPath')) {
             nodeModulesPath = project.nodeModulesPath
+        } else if (config.root) {
+            nodeModulesPath = Paths.get(config.root, "/node_modules");
         } else {
             nodeModulesPath = "../../node_modules";
         }
@@ -62,7 +62,7 @@ gradle.projectsEvaluated {
                 enabled config."bundleIn${targetName}" ||
                 config."bundleIn${variant.buildType.name.capitalize()}" ?:
                 targetName.toLowerCase().contains("release")
-            }   
+            }
         } else {
             def jsBundleDirConfigName = "jsBundleDir${targetName}"
             jsBundleDir = elvisFile(config."$jsBundleDirConfigName") ?:
@@ -72,7 +72,7 @@ gradle.projectsEvaluated {
             resourcesDir = elvisFile(config."${resourcesDirConfigName}") ?:
                     file("$buildDir/intermediates/res/merged/${targetPath}")
 
-            // In case version of 'Android Plugin for Gradle'' is lower than 1.3.0 
+            // In case version of 'Android Plugin for Gradle'' is lower than 1.3.0
             // '$buildDir' has slightly different structure - 'merged' folder
             // does not exists so '${targetPath}' folder contains directly in 'res' folder.
             if (!resourcesDir.exists() && file("$buildDir/intermediates/res/${targetPath}").exists()) {


### PR DESCRIPTION
See #1887 for details, but basically if config explicitly states where to find the node_modules folder, that should take priority over calculations based on a config setting saying where the overall root is.