### PR TITLE
Update Google store guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,16 @@ If you would like to display an update confirmation dialog (an "active install")
 
 ### Store Guideline Compliance
 
-While Google Play and internally distributed apps (for example Enterprise, Fabric, HockeyApp) have no limitations over how to publish updates using CodePush, the iOS App Store and its corresponding guidelines have more precise rules you should be aware of before integrating the solution within your application.
+Android Google Play and iOS App Store have corresponding guidelines that have rules you should be aware of before integrating the CodePush solution within your application.
+
+#### Google play
+
+Third paragraph of [Device and Network Abuse](https://support.google.com/googleplay/android-developer/answer/9888379?hl=en) topic describe that updating source code by any method other than Google Play's update mechanism is restricted. But this restriction is not apply to updating javascript bundles.
+> This restriction does not apply to code that runs in a virtual machine and has limited access to Android APIs (such as JavaScript in a webview or browser).
+
+That fully allow CodePush as it updates just JS bundles and can't update native code part.
+
+#### App Store
 
 Paragraph **3.3.2**, since back in 2015's [Apple Developer Program License Agreement](https://developer.apple.com/programs/ios/information/) fully allowed performing over-the-air updates of JavaScript and assets -  and in its latest version (20170605) [downloadable here](https://developer.apple.com/terms/) this ruling is even broader:
 


### PR DESCRIPTION
Google updated `Device and Network Abuse`. We also should update our Store Guideline Compliance.

Related issue: https://github.com/microsoft/react-native-code-push/issues/1941 