### PR TITLE
Block sending requests if the deployment key is missed

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -188,6 +188,10 @@ async function tryReportStatus(statusReport, resumeListener) {
     if (statusReport.appVersion) {
       log(`Reporting binary update (${statusReport.appVersion})`);
 
+      if (!config.deploymentKey) {
+        throw new Error("Deployment key is missed");
+      }
+
       const sdk = getPromisifiedSdk(requestFetchAdapter, config);
       await sdk.reportStatusDeploy(/* deployedPackage */ null, /* status */ null, previousLabelOrAppVersion, previousDeploymentKey);
     } else {

--- a/code-push-plugin-testing-framework/script/testUtil.js
+++ b/code-push-plugin-testing-framework/script/testUtil.js
@@ -45,7 +45,7 @@ var TestUtil = (function () {
         options = options || {};
         // set default options
         if (options.maxBuffer === undefined)
-            options.maxBuffer = 1024 * 500;
+            options.maxBuffer = 1024 * 1024 * 500;
         if (options.timeout === undefined)
             options.timeout = 10 * 60 * 1000;
         if (!options.noLogCommand)

--- a/test/test.ts
+++ b/test/test.ts
@@ -233,7 +233,7 @@ class RNIOS extends Platform.IOS implements RNPlatform {
                 const hashWithParen = targetEmulator.match(hashRegEx)[0];
                 const hash = hashWithParen.substr(1, hashWithParen.length - 2);
                 return TestUtil.getProcessOutput("xcodebuild -workspace " + path.join(iOSProject, TestConfig.TestAppName) + ".xcworkspace -scheme " + TestConfig.TestAppName +
-                    " -configuration Release -destination \"platform=iOS Simulator,id=" + hash + "\" -derivedDataPath build", { cwd: iOSProject, maxBuffer: 1024 * 1024 * 20, noLogStdOut: true });
+                    " -configuration Release -destination \"platform=iOS Simulator,id=" + hash + "\" -derivedDataPath build", { cwd: iOSProject, maxBuffer: 1024 * 1024 * 500, noLogStdOut: true });
             })
             .then<void>(
                 () => { return null; },

--- a/test/test.ts
+++ b/test/test.ts
@@ -233,7 +233,7 @@ class RNIOS extends Platform.IOS implements RNPlatform {
                 const hashWithParen = targetEmulator.match(hashRegEx)[0];
                 const hash = hashWithParen.substr(1, hashWithParen.length - 2);
                 return TestUtil.getProcessOutput("xcodebuild -workspace " + path.join(iOSProject, TestConfig.TestAppName) + ".xcworkspace -scheme " + TestConfig.TestAppName +
-                    " -configuration Release -destination \"platform=iOS Simulator,id=" + hash + "\" -derivedDataPath build", { cwd: iOSProject, maxBuffer: 1024 * 1024 * 500, noLogStdOut: true });
+                    " -configuration Release -destination \"platform=iOS Simulator,id=" + hash + "\" -derivedDataPath build EXCLUDED_ARCHS=arm64", { cwd: iOSProject, maxBuffer: 1024 * 1024 * 500, noLogStdOut: true });
             })
             .then<void>(
                 () => { return null; },


### PR DESCRIPTION
We get a lot of 404 errors when we try to send reportStatusDeploy from the binary version of the app. To reduce this number, we blocked sending a request when a deployment key is missed.
Related issue: #1820 