### PR TITLE
No longer throw when attempting to hash

### DIFF
--- a/windows/CodePush/CodePushNativeModule.cpp
+++ b/windows/CodePush/CodePushNativeModule.cpp
@@ -485,31 +485,10 @@ namespace Microsoft::CodePush::ReactNative
         auto configuration{ CodePushConfig::Current().GetConfiguration() };
         if (isRunningBinaryVersion)
         {
-            hstring binaryHash;
-            try
-            {
-                auto errorMessage{ L"Error: Package hashing is currently unimplemented. Binary hash was not obtained." };
-                auto error{ hresult_error(E_NOTIMPL, errorMessage) };
-                CodePushUtils::Log(error);
-                throw error;
-            }
-            catch(...)
-            {
-                CodePushUtils::Log(L"Error obtaining hash for binary contents.");
-                promise.Resolve(configuration);
-                co_return;
-            }
-
-            if (binaryHash.empty())
-            {
-                // The hash was not generated either due to a previous unknown error or the fact that
-                // the React Native assets were not bundled in the binary (e.g. during release)
-                // builds.
-                promise.Resolve(configuration);
-                co_return;
-            }
-
-            configuration.Insert(PackageHashKey, JsonValue::CreateStringValue(binaryHash));
+            auto errorMessage{ L"Error: Package hashing is currently unimplemented. Binary hash was not obtained." };
+            auto error{ hresult_error(E_NOTIMPL, errorMessage) };
+            CodePushUtils::Log(error);
+            CodePushUtils::Log(L"Error obtaining hash for binary contents.");
             promise.Resolve(configuration);
             co_return;
         }

--- a/windows/CodePush/CodePushPackage.cpp
+++ b/windows/CodePush/CodePushPackage.cpp
@@ -172,14 +172,9 @@ namespace Microsoft::CodePush::ReactNative
 
                 if (needToVerifyHash)
                 {
-                    try
-                    {
-                        auto errorMessage{ L"Error: package content verification is not currently supported." };
-                        hresult_error error{ E_NOTIMPL, errorMessage };
-                        CodePushUtils::Log(error);
-                        throw error;
-                    }
-                    catch (...) {}
+                    auto errorMessage{ L"Error: package content verification is not currently supported." };
+                    hresult_error error{ E_NOTIMPL, errorMessage };
+                    CodePushUtils::Log(error);
                 }
             }
         }


### PR DESCRIPTION
@vmoroz told me that some users are having issues with the Windows implementation because it currently throws a NOT_IMPL error when it reaches a point when it should hash package contents. To keep their builds from breaking, this PR removes the throwing behavior. A hashing fail message is still logged in debug output.