### PR TITLE
use afterEvaluate instead of gradle.projectsEvaluated

### DIFF
--- a/android/codepush.gradle
+++ b/android/codepush.gradle
@@ -17,7 +17,7 @@ void runBefore(String dependentTaskName, Task task) {
     }
 }
 
-gradle.projectsEvaluated {
+afterEvaluate {
     android.buildTypes.each {
         // to prevent incorrect long value restoration from strings.xml we need to wrap it with double quotes
         // https://github.com/microsoft/cordova-plugin-code-push/issues/264


### PR DESCRIPTION
I ran into #1981 and upon digging I noticed that that `generateBundledResourcesHash` task does not run when org.gradle.configureondemand is set to true. This diff uses  afterEvaluate instead of  gradle.projectsEvaluated to ensure that the `generateBundledResourcesHash` is run.