### PR TITLE
add timeout parameter on checkForUpdate

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -8,85 +8,103 @@ import hoistStatics from 'hoist-non-react-statics';
 let NativeCodePush = require("react-native").NativeModules.CodePush;
 const PackageMixins = require("./package-mixins")(NativeCodePush);
 
-async function checkForUpdate(deploymentKey = null, handleBinaryVersionMismatchCallback = null) {
-  /*
-   * Before we ask the server if an update exists, we
-   * need to retrieve three pieces of information from the
-   * native side: deployment key, app version (e.g. 1.0.1)
-   * and the hash of the currently running update (if there is one).
-   * This allows the client to only receive updates which are targetted
-   * for their specific deployment and version and which are actually
-   * different from the CodePush update they have already installed.
-   */
-  const nativeConfig = await getConfiguration();
-  /*
-   * If a deployment key was explicitly provided,
-   * then let's override the one we retrieved
-   * from the native-side of the app. This allows
-   * dynamically "redirecting" end-users at different
-   * deployments (e.g. an early access deployment for insiders).
-   */
-  const config = deploymentKey ? { ...nativeConfig, ...{ deploymentKey } } : nativeConfig;
-  const sdk = getPromisifiedSdk(requestFetchAdapter, config);
 
-  // Use dynamically overridden getCurrentPackage() during tests.
-  const localPackage = await module.exports.getCurrentPackage();
+function timeout(prom, time) {
+  let timer;
+	return Promise.race([
+		prom,
+		new Promise((_r, reject) => {
+      timer = setTimeout(reject, time)
+    })
+	]).finally(() => clearTimeout(timer));
+}
 
-  /*
-   * If the app has a previously installed update, and that update
-   * was targetted at the same app version that is currently running,
-   * then we want to use its package hash to determine whether a new
-   * release has been made on the server. Otherwise, we only need
-   * to send the app version to the server, since we are interested
-   * in any updates for current binary version, regardless of hash.
-   */
-  let queryPackage;
-  if (localPackage) {
-    queryPackage = localPackage;
-  } else {
-    queryPackage = { appVersion: config.appVersion };
-    if (Platform.OS === "ios" && config.packageHash) {
-      queryPackage.packageHash = config.packageHash;
-    }
-  }
+async function checkForUpdate(deploymentKey = null, checkUpdateTimeout = null, handleBinaryVersionMismatchCallback = null) {
+  async function handleCheckUpdate(){
+    /*
+    * Before we ask the server if an update exists, we
+    * need to retrieve three pieces of information from the
+    * native side: deployment key, app version (e.g. 1.0.1)
+    * and the hash of the currently running update (if there is one).
+    * This allows the client to only receive updates which are targetted
+    * for their specific deployment and version and which are actually
+    * different from the CodePush update they have already installed.
+    */
+    const nativeConfig = await getConfiguration();
+    /*
+    * If a deployment key was explicitly provided,
+    * then let's override the one we retrieved
+    * from the native-side of the app. This allows
+    * dynamically "redirecting" end-users at different
+    * deployments (e.g. an early access deployment for insiders).
+    */
+    const config = deploymentKey ? { ...nativeConfig, ...{ deploymentKey } } : nativeConfig;
+    const sdk = getPromisifiedSdk(requestFetchAdapter, config);
 
-  const update = await sdk.queryUpdateWithCurrentPackage(queryPackage);
+    // Use dynamically overridden getCurrentPackage() during tests.
+    const localPackage = await module.exports.getCurrentPackage();
 
-  /*
-   * There are four cases where checkForUpdate will resolve to null:
-   * ----------------------------------------------------------------
-   * 1) The server said there isn't an update. This is the most common case.
-   * 2) The server said there is an update but it requires a newer binary version.
-   *    This would occur when end-users are running an older binary version than
-   *    is available, and CodePush is making sure they don't get an update that
-   *    potentially wouldn't be compatible with what they are running.
-   * 3) The server said there is an update, but the update's hash is the same as
-   *    the currently running update. This should _never_ happen, unless there is a
-   *    bug in the server, but we're adding this check just to double-check that the
-   *    client app is resilient to a potential issue with the update check.
-   * 4) The server said there is an update, but the update's hash is the same as that
-   *    of the binary's currently running version. This should only happen in Android -
-   *    unlike iOS, we don't attach the binary's hash to the updateCheck request
-   *    because we want to avoid having to install diff updates against the binary's
-   *    version, which we can't do yet on Android.
-   */
-  if (!update || update.updateAppVersion ||
-      localPackage && (update.packageHash === localPackage.packageHash) ||
-      (!localPackage || localPackage._isDebugOnly) && config.packageHash === update.packageHash) {
-    if (update && update.updateAppVersion) {
-      log("An update is available but it is not targeting the binary version of your app.");
-      if (handleBinaryVersionMismatchCallback && typeof handleBinaryVersionMismatchCallback === "function") {
-        handleBinaryVersionMismatchCallback(update)
+    /*
+    * If the app has a previously installed update, and that update
+    * was targetted at the same app version that is currently running,
+    * then we want to use its package hash to determine whether a new
+    * release has been made on the server. Otherwise, we only need
+    * to send the app version to the server, since we are interested
+    * in any updates for current binary version, regardless of hash.
+    */
+    let queryPackage;
+    if (localPackage) {
+      queryPackage = localPackage;
+    } else {
+      queryPackage = { appVersion: config.appVersion };
+      if (Platform.OS === "ios" && config.packageHash) {
+        queryPackage.packageHash = config.packageHash;
       }
     }
 
-    return null;
-  } else {
-    const remotePackage = { ...update, ...PackageMixins.remote(sdk.reportStatusDownload) };
-    remotePackage.failedInstall = await NativeCodePush.isFailedUpdate(remotePackage.packageHash);
-    remotePackage.deploymentKey = deploymentKey || nativeConfig.deploymentKey;
-    return remotePackage;
+    const update = await sdk.queryUpdateWithCurrentPackage(queryPackage);
+
+    /*
+    * There are four cases where checkForUpdate will resolve to null:
+    * ----------------------------------------------------------------
+    * 1) The server said there isn't an update. This is the most common case.
+    * 2) The server said there is an update but it requires a newer binary version.
+    *    This would occur when end-users are running an older binary version than
+    *    is available, and CodePush is making sure they don't get an update that
+    *    potentially wouldn't be compatible with what they are running.
+    * 3) The server said there is an update, but the update's hash is the same as
+    *    the currently running update. This should _never_ happen, unless there is a
+    *    bug in the server, but we're adding this check just to double-check that the
+    *    client app is resilient to a potential issue with the update check.
+    * 4) The server said there is an update, but the update's hash is the same as that
+    *    of the binary's currently running version. This should only happen in Android -
+    *    unlike iOS, we don't attach the binary's hash to the updateCheck request
+    *    because we want to avoid having to install diff updates against the binary's
+    *    version, which we can't do yet on Android.
+    */
+    if (!update || update.updateAppVersion ||
+        localPackage && (update.packageHash === localPackage.packageHash) ||
+        (!localPackage || localPackage._isDebugOnly) && config.packageHash === update.packageHash) {
+      if (update && update.updateAppVersion) {
+        log("An update is available but it is not targeting the binary version of your app.");
+        if (handleBinaryVersionMismatchCallback && typeof handleBinaryVersionMismatchCallback === "function") {
+          handleBinaryVersionMismatchCallback(update)
+        }
+      }
+
+      return null;
+    } else {
+      const remotePackage = { ...update, ...PackageMixins.remote(sdk.reportStatusDownload) };
+      remotePackage.failedInstall = await NativeCodePush.isFailedUpdate(remotePackage.packageHash);
+      remotePackage.deploymentKey = deploymentKey || nativeConfig.deploymentKey;
+      return remotePackage;
+    }
   }
+
+  if(checkUpdateTimeout == null){
+    return handleCheckUpdate()
+  }
+  return timeout(handleCheckUpdate(), checkUpdateTimeout)
 }
 
 const getConfiguration = (() => {
@@ -371,6 +389,7 @@ async function syncInternal(options = {}, syncStatusChangeCallback, downloadProg
     mandatoryInstallMode: CodePush.InstallMode.IMMEDIATE,
     minimumBackgroundDuration: 0,
     updateDialog: null,
+    checkUpdateTimeout: null,
     ...options
   };
 
@@ -417,7 +436,8 @@ async function syncInternal(options = {}, syncStatusChangeCallback, downloadProg
     await CodePush.notifyApplicationReady();
 
     syncStatusChangeCallback(CodePush.SyncStatus.CHECKING_FOR_UPDATE);
-    const remotePackage = await checkForUpdate(syncOptions.deploymentKey, handleBinaryVersionMismatchCallback);
+
+    const remotePackage = await checkForUpdate(syncOptions.deploymentKey, checkUpdateTimeout, handleBinaryVersionMismatchCallback);
 
     const doDownloadAndInstall = async () => {
       syncStatusChangeCallback(CodePush.SyncStatus.DOWNLOADING_PACKAGE);

--- a/typings/react-native-code-push.d.ts
+++ b/typings/react-native-code-push.d.ts
@@ -144,6 +144,11 @@ export interface SyncOptions {
      * one or more of the default values.
      */
     rollbackRetryOptions?: RollbackRetryOptions;
+
+    /**
+     * Add an timeout for `checkForUpdate`. Use this parameter to prevent issues with CodePush Servers (such as requests taking too much time to complete). If the timeout exceeds, the `SyncStatus` will be `UNKNOWN_ERROR`
+     */
+    checkUpdateTimeout?: number;
 }
 
 export interface UpdateDialog {
@@ -257,10 +262,10 @@ declare namespace CodePush {
      * Asks the CodePush service whether the configured app deployment has an update available.
      *
      * @param deploymentKey The deployment key to use to query the CodePush server for an update.
-     * 
+     * @param checkUpdateTimeout Add an timeout for request. Useful to prevent issues with CodePush Servers (such as requests taking too much time to complete). If the timeout exceeds, an error will thrown
      * @param handleBinaryVersionMismatchCallback An optional callback for handling target binary version mismatch
      */
-    function checkForUpdate(deploymentKey?: string, handleBinaryVersionMismatchCallback?: HandleBinaryVersionMismatchCallback): Promise<RemotePackage | null>;
+    function checkForUpdate(deploymentKey?: string, checkUpdateTimeout?: number, handleBinaryVersionMismatchCallback?: HandleBinaryVersionMismatchCallback): Promise<RemotePackage | null>;
 
     /**
      * Retrieves the metadata for an installed update (e.g. description, mandatory).

--- a/typings/react-native-code-push.d.ts
+++ b/typings/react-native-code-push.d.ts
@@ -146,7 +146,8 @@ export interface SyncOptions {
     rollbackRetryOptions?: RollbackRetryOptions;
 
     /**
-     * Add an timeout for `checkForUpdate`. Use this parameter to prevent issues with CodePush Servers (such as requests taking too much time to complete). If the timeout exceeds, the `SyncStatus` will be `UNKNOWN_ERROR`
+     * Add an timeout for `checkForUpdate`. Use this parameter to prevent issues with CodePush Servers (such as requests taking too much time to complete)
+     * or user network issues. Value should be in `milliseconds`. If the timeout exceeds, the `SyncStatus` will be `UNKNOWN_ERROR`.
      */
     checkUpdateTimeout?: number;
 }
@@ -262,7 +263,7 @@ declare namespace CodePush {
      * Asks the CodePush service whether the configured app deployment has an update available.
      *
      * @param deploymentKey The deployment key to use to query the CodePush server for an update.
-     * @param checkUpdateTimeout Add an timeout for request. Useful to prevent issues with CodePush Servers (such as requests taking too much time to complete). If the timeout exceeds, an error will thrown
+     * @param checkUpdateTimeout Add an timeout for request. Useful to prevent issues with CodePush Servers (such as requests taking too much time to complete) or user network issues. Value should be in `milliseconds`. If the timeout exceeds, an error will thrown
      * @param handleBinaryVersionMismatchCallback An optional callback for handling target binary version mismatch
      */
     function checkForUpdate(deploymentKey?: string, checkUpdateTimeout?: number, handleBinaryVersionMismatchCallback?: HandleBinaryVersionMismatchCallback): Promise<RemotePackage | null>;


### PR DESCRIPTION
### Summary
Added `checkUpdateTimeout` property (like Axios does). It makes the developer prevent app for waiting too much time for `checkForUpdate` method.
I haven't the screenshot now but used `Flipper` to see my Network requests and the route to check update ended in approximately 64 seconds.

Added `checkUpdateTimeout` in `react-native-code-push.d.ts`

Fixes #2032 

### Breaking change

- `checkForUpdate` second parameter is now `checkUpdateTimeout`, `handleBinaryVersionMismatchCallback` is now the third parameter