### PR TITLE
Add deployment key creation via CLI to the docs

### DIFF
--- a/docs/setup-android.md
+++ b/docs/setup-android.md
@@ -65,6 +65,8 @@ In order to integrate CodePush into your Android project, please perform the fol
 
    ![Deployment list](https://cloud.githubusercontent.com/assets/116461/11601733/13011d5e-9a8a-11e5-9ce2-b100498ffb34.png)
 
+   If no key is shown, running the add command `appcenter codepush deployment add -a {UserName}/{ProjectNameInAppCenter} DEPLOYMENT_ENV` will generate a deployment key for the specified deployment environment. Use 'Staging', 'Developpment' or 'Production' as the deployment environments.
+
    In order to effectively make use of the `Staging` and `Production` deployments that were created along with your CodePush app, refer to the [multi-deployment testing](../README.md#multi-deployment-testing) docs below before actually moving your app's usage of CodePush into production.
 
    Your `strings.xml` should looks like this:


### PR DESCRIPTION
When me and my team were following the guide, we didn't have a deployment key setup to our account.

After some search we found a solution for creating a deployment key within the cli, the command:
`appcenter codepush deployment add -a {UserName}/{ProjectNameInAppCenter} DEPLOYMENT_ENV` 

Adding this line to show the usage of this command can help someone that doesn't have any previuous experience with CodePush or similar services

We suggest using the Staging | Production | Development to specify the environtment for which the key will be added, but we are not sure if this has to be enforced or the user is free to name the environment as they will.