### PR TITLE
Fixed issue where foreign characters break data integrity check

### DIFF
--- a/ios/CodePush/CodePushUpdateUtils.m
+++ b/ios/CodePush/CodePushUpdateUtils.m
@@ -93,7 +93,7 @@ NSString * const IgnoreCodePushMetadata = @".codepushrelease";
     // The JSON serialization turns path separators into "\/", e.g. "CodePush\/assets\/image.png"
     manifestString = [manifestString stringByReplacingOccurrencesOfString:@"\\/"
                                                                withString:@"/"];
-    return [self computeHashForData:[NSData dataWithBytes:manifestString.UTF8String length:manifestString.length]];
+    return [self computeHashForData:[NSData dataWithBytes:manifestString.UTF8String length:[manifestString lengthOfBytesUsingEncoding:NSUTF8StringEncoding]]];
 }
 
 + (NSString *)computeHashForData:(NSData *)inputData


### PR DESCRIPTION
This PR is related to the following issue: https://github.com/microsoft/react-native-code-push/issues/2061
It is also potentially related to the following issue: https://github.com/microsoft/react-native-code-push/issues/2030

Currently, projects containing foreign characters (Japanese and Chinese as far as I know, maybe others too), fail to update on the second OTA codepush update due to the data integrity check. This is due to the character encoding.

To reproduce the issue you can do the following:
1. Create a new react native project with codepush 7.0.0 set up
2. Add some Japanese or Chinese characters in file names and within files' contents (only js or asset files that may end up in the codepush bundle)
3. Deploy this initial version to codepush
4. Install the app on a device
5. Restart the app and ensure the first update is installed *successfully*
6. Make a change to one of the files that ends up in the codepush bundle (js or assets), for example a `console.log`. Deploy this new version to codepush.
7. Restart the app on the device, and notice the update failing due to the data integrity check. 

A log of the issue can be found here: 
```
[javascript] [CodePush] Checking for update.
2021-04-01 18:07:27.985351+0200 paters_rn[62827:6524162] [javascript] [CodePush] Downloading package.
2021-04-01 18:07:28.384039+0200 paters_rn[62827:6534108] [native] Sending CodePushDownloadProgress with no listeners registered.
[CodePush] Applying diff update.
[CodePush] Verifying hash for folder path: /Users/eranpeer/Library/Developer/CoreSimulator/Devices/206E0D93-38F4-4273-A468-D05FC0D84BDE/data/Containers/Data/Application/BD5B1BAE-7B46-488D-AFF8-003FB6EE10CA/Library/Application Support/CodePush/401429e0ef823eb3ef4f091553ade7fce228120ac195ddc3dcfd18ca4e99e2d9
[CodePush] Manifest string: (
"CodePush/main.jsbundle:e2abe4e022d9699100ad1322a9792e47984c3a66e9cecbc9ad2c7da8c5acde54",
"CodePush/assets/locales/en.json:7f9e37482cecda411947d763d2486775b6fb0e590770469207a672a787123db3",
"CodePush/assets/app.json:590f86d6cd11f7aadcbbbd3b368307878c420dc609ed10f0350a70ec82721d0e",
"CodePush/assets/node_modules/react-native/package.json:0087a3a7be0dd03690b6c32626875ac2db1b5b19f4fa2e78f35e15bcb1e92057",
"CodePush/assets/node_modules/css-color-keywords/colors.json:354f1816e82e3aa407d5493a59ff75f6d073d18e39db48e792b3bde951419ff5",
"CodePush/assets/node_modules/@react-navigation/stack/src/views/assets/back-icon@3x.png:3ddd0773ed27e23d25789f301731b3ac455ad8be5aa27a0a1b838f89c6d27225",
"CodePush/assets/node_modules/@react-navigation/stack/src/views/assets/back-icon@2x.png:2b7443a9a58e92ca11a575bdc11598615a57dde305cd8ce70d602606b302cd98",
"CodePush/assets/node_modules/@react-navigation/stack/src/views/assets/back-icon.png:2cdfeb8e5ccde7976f7012fb8cce73
[CodePush] Expected hash: 401429e0ef823eb3ef4f091553ade7fce228120ac195ddc3dcfd18ca4e99e2d9, actual hash: ac957e370d67678f22e843ccd046f1bed67ebe100e62ae56844d8a77822048b6
[CodePush] The update contents failed the data integrity check.
2021-04-01 18:07:28.963611+0200 paters_rn[62827:6524162] [javascript] [CodePush] An unknown error occurred.
2021-04-01 18:07:28.963829+0200 paters_rn[62827:6524162] [javascript] [CodePush] The update contents failed the data integrity check.
```