### PR TITLE
Fix type specs for allow/disallowRestart

### DIFF
--- a/typings/react-native-code-push.d.ts
+++ b/typings/react-native-code-push.d.ts
@@ -277,12 +277,12 @@ declare namespace CodePush {
     /**
      * Allow CodePush to restart the app.
      */
-    function allowRestart(): void;
+    function allowRestart(): Promise<null>;
 
     /**
      * Forbid CodePush to restart the app.
      */
-    function disallowRestart(): void;
+    function disallowRestart(): Promise<null>;
 
     /**
      * Clear all downloaded CodePush updates.


### PR DESCRIPTION
Both iOS/Android native module functions return a promise for `allowRestart` and `disallowRestart` this lines up the typespec to match

# iOS:

https://github.com/microsoft/react-native-code-push/blob/d35a02606ddde84645f9966e5ca27a9ffce92bfe/ios/CodePush/CodePush.m#L991-L1005
https://github.com/microsoft/react-native-code-push/blob/d35a02606ddde84645f9966e5ca27a9ffce92bfe/ios/CodePush/CodePush.m#L1014-L1020

# Android

https://github.com/microsoft/react-native-code-push/blob/d35a02606ddde84645f9966e5ca27a9ffce92bfe/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java#L240-L254
https://github.com/microsoft/react-native-code-push/blob/d35a02606ddde84645f9966e5ca27a9ffce92bfe/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java#L263-L269