### PR TITLE
Fix crash "NSInvalidArgumentException" on ios 14.5

### DIFF
--- a/ios/CodePush/CodePushDownloadHandler.m
+++ b/ios/CodePush/CodePushDownloadHandler.m
@@ -48,6 +48,12 @@ failCallback:(void (^)(NSError *err))failCallback {
     return nil;
 }
 
+- (NSURLRequest *)connection:(NSURLConnection *)connection
+             willSendRequest:(NSURLRequest *)request
+            redirectResponse:(NSURLResponse *)response {
+    return request;
+}
+
 - (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response {
     if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
         NSInteger statusCode = [(NSHTTPURLResponse *)response statusCode];


### PR DESCRIPTION
Crash logs:
```


2021-05-23 18:42:44.461430+0700 Example.app[75769:1179260] -[fir_34E9EC6F-977D-4014-BDCD-AA837334A87D_CodePushDownloadHandler _flex_swizzle_cbc47522_connection:willSendRequest:redirectResponse:]: unrecognized selector sent to instance 0x60000cd93d40
2021-05-23 18:42:44.486049+0700 Example.app[75769:1179260] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[fir_34E9EC6F-977D-4014-BDCD-AA837334A87D_CodePushDownloadHandler _flex_swizzle_cbc47522_connection:willSendRequest:redirectResponse:]: unrecognized selector sent to instance 0x60000cd93d40'
*** First throw call stack:
(
	0   CoreFoundation                      0x00007fff20422fba __exceptionPreprocess + 242
	1   libobjc.A.dylib                     0x00007fff20193ff5 objc_exception_throw + 48
	2   CoreFoundation                      0x00007fff20431d2f +[NSObject(NSObject) instanceMethodSignatureForSelector:] + 0
	3   CoreFoundation                      0x00007fff204274cf ___forwarding___ + 1455
	4   CoreFoundation                      0x00007fff204297a8 _CF_forwarding_prep_0 + 120
	5   Example.app                         0x0000000106bd0aef __62+[FLEXNetworkObserver injectWillSendRequestIntoDelegateClass:]_block_invoke.271 + 63
	6   Example.app                         0x0000000106bcc01c +[FLEXNetworkObserver sniffWithoutDuplicationForObject:selector:sniffingBlock:originalImplementationBlock:] + 444
	7   Example.app                         0x0000000106bd05d2 __62+[FLEXNetworkObserver injectWillSendRequestIntoDelegateClass:]_block_invoke_2 + 770
	8   CFNetwork                           0x00007fff23757ce5 kCFNIE + 11101
	9   CFNetwork                           0x00007fff2378b14e __CFTubeSetTubeTypeNotifier + 101882
	10  Foundation                          0x00007fff207fa0be __NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__ + 7
	11  Foundation                          0x00007fff207f9fb6 -[NSBlockOperation main] + 98
	12  Foundation                          0x00007fff207fcfd2 __NSOPERATION_IS_INVOKING_MAIN__ + 17
	13  Foundation                          0x00007fff207f9200 -[NSOperation start] + 785
	14  Foundation                          0x00007fff207fd947 __NSOPERATIONQUEUE_IS_STARTING_AN_OPERATION__ + 17
	15  Foundation                          0x00007fff207fd46a __NSOQSchedule_f + 182
	16  libdispatch.dylib                   0x000000010f4bd2c5 _dispatch_block_async_invoke2 + 83
	17  libdispatch.dylib                   0x000000010f4ae74e _dispatch_client_callout + 8
	18  libdispatch.dylib                   0x000000010f4b4f9a _dispatch_lane_serial_drain + 796
	19  libdispatch.dylib                   0x000000010f4b5c67 _dispatch_lane_invoke + 436
	20  libdispatch.dylib                   0x000000010f4c1a7a _dispatch_workloop_worker_thread + 872
	21  libsystem_pthread.dylib             0x00007fff603404c0 _pthread_wqthread + 314
	22  libsystem_pthread.dylib             0x00007fff6033f493 start_wqthread + 15
)
libc++abi: terminating with uncaught exception of type NSException
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[fir_34E9EC6F-977D-4014-BDCD-AA837334A87D_CodePushDownloadHandler _flex_swizzle_cbc47522_connection:willSendRequest:redirectResponse:]: unrecognized selector sent to instance 0x60000cd93d40'
terminating with uncaught exception of type NSException
CoreSimulator 757.5 - Device: iPhone 12 (42D5DC3E-5752-43D6-A961-8A40A59E4E04) - Runtime: iOS 14.5 (18E182) - DeviceType: iPhone 12
```