### PR TITLE
Bump vm2 from 3.9.3 to 3.9.5 in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4411,9 +4411,9 @@
       }
     },
     "node_modules/vm2": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.3.tgz",
-      "integrity": "sha512-smLS+18RjXYMl9joyJxMNI9l4w7biW8ilSDaVRvFBDwOH8P0BK1ognFQTpg0wyQ6wIKLTblHJvROW692L/E53Q==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.5.tgz",
+      "integrity": "sha512-LuCAHZN75H9tdrAiLFf030oW7nJV5xwNMuk1ymOZwopmuK3d2H4L1Kv4+GFHgarKiLfXXLFU+7LDABHnwOkWng==",
       "bin": {
         "vm2": "bin/vm2"
       },
@@ -7964,9 +7964,9 @@
       "dev": true
     },
     "vm2": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.3.tgz",
-      "integrity": "sha512-smLS+18RjXYMl9joyJxMNI9l4w7biW8ilSDaVRvFBDwOH8P0BK1ognFQTpg0wyQ6wIKLTblHJvROW692L/E53Q=="
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.5.tgz",
+      "integrity": "sha512-LuCAHZN75H9tdrAiLFf030oW7nJV5xwNMuk1ymOZwopmuK3d2H4L1Kv4+GFHgarKiLfXXLFU+7LDABHnwOkWng=="
     },
     "wcwidth": {
       "version": "1.0.1",


### PR DESCRIPTION
Resolves the _critical severity_ alert from Dependabot.

![image](https://user-images.githubusercontent.com/91679500/144930707-78e968c4-9041-4fe7-991a-b0e6703d8050.png)