### PR TITLE
Rework dependencies order for hash generation

### DIFF
--- a/android/codepush.gradle
+++ b/android/codepush.gradle
@@ -63,6 +63,7 @@ gradle.projectsEvaluated {
                 config."bundleIn${variant.buildType.name.capitalize()}" ?:
                 targetName.toLowerCase().contains("release")
             }
+            
             runBefore("merge${targetName}Resources", generateBundledResourcesHash)
             runBefore("merge${targetName}Assets", generateBundledResourcesHash)   
         } else {

--- a/android/codepush.gradle
+++ b/android/codepush.gradle
@@ -62,7 +62,9 @@ gradle.projectsEvaluated {
                 enabled config."bundleIn${targetName}" ||
                 config."bundleIn${variant.buildType.name.capitalize()}" ?:
                 targetName.toLowerCase().contains("release")
-            }   
+            }
+            runBefore("merge${targetName}Resources", generateBundledResourcesHash)
+            runBefore("merge${targetName}Assets", generateBundledResourcesHash)   
         } else {
             def jsBundleDirConfigName = "jsBundleDir${targetName}"
             jsBundleDir = elvisFile(config."$jsBundleDirConfigName") ?:


### PR DESCRIPTION
#838 #1981 
```
debug

> Task :app:copyEinsteinReleaseBundledJs
The CodePushHash is not found

> Task :app:generateBundledResourcesHashEinsteinRelease
Now the hash generation starts
```

The reason why CodePushHash might not be in final APK in some cases is the **wrong order of Gradle tasks** (assets are copied before the hash generation).

This PR shall resolve this.