### PR TITLE
Bump shelljs to 0.8.5 via shx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "mocha": "^9.1.1",
         "q": "^1.5.1",
         "run-sequence": "latest",
-        "shx": "^0.3.3",
+        "shx": "^0.3.4",
         "slash": "^3.0.0",
         "tslint": "^6.1.3",
         "typescript": "^4.4.3"
@@ -3907,9 +3907,9 @@
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "node_modules/shelljs": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
       "dev": true,
       "dependencies": {
         "glob": "^7.0.0",
@@ -3924,13 +3924,13 @@
       }
     },
     "node_modules/shx": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.3.tgz",
-      "integrity": "sha512-nZJ3HFWVoTSyyB+evEKjJ1STiixGztlqwKLTUNV5KqMWtGey9fTd4KU1gdZ1X9BV6215pswQ/Jew9NsuS/fNDA==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.3",
-        "shelljs": "^0.8.4"
+        "shelljs": "^0.8.5"
       },
       "bin": {
         "shx": "lib/cli.js"
@@ -7595,9 +7595,9 @@
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "shelljs": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
       "dev": true,
       "requires": {
         "glob": "^7.0.0",
@@ -7606,13 +7606,13 @@
       }
     },
     "shx": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.3.tgz",
-      "integrity": "sha512-nZJ3HFWVoTSyyB+evEKjJ1STiixGztlqwKLTUNV5KqMWtGey9fTd4KU1gdZ1X9BV6215pswQ/Jew9NsuS/fNDA==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.3",
-        "shelljs": "^0.8.4"
+        "shelljs": "^0.8.5"
       }
     },
     "side-channel": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "mocha": "^9.1.1",
     "q": "^1.5.1",
     "run-sequence": "latest",
-    "shx": "^0.3.3",
+    "shx": "^0.3.4",
     "slash": "^3.0.0",
     "tslint": "^6.1.3",
     "typescript": "^4.4.3"


### PR DESCRIPTION
This PR resolves the High level alert (we update shx to the latest version):

![image](https://user-images.githubusercontent.com/91679500/150867096-b7c0c682-4d47-4404-8555-725799405d51.png)
