### PR TITLE
Bump nimbus-jose-jwt to 9.15.2 in android/app/build.gradle

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -27,5 +27,5 @@ android {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation 'com.nimbusds:nimbus-jose-jwt:5.1'
+    implementation 'com.nimbusds:nimbus-jose-jwt:9.15.2'
 }


### PR DESCRIPTION
In testing `nimbus-jose-jwt` on 9.15.2 with react-native-codepush, there were no observed compile time errors or breaking API changes, so updating to 9.15.2 should have low regression risk.