### PR TITLE
nimbus-jose-jwt dependency upgrade 

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -27,5 +27,5 @@ android {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation 'com.nimbusds:nimbus-jose-jwt:5.1'
+    implementation 'com.nimbusds:nimbus-jose-jwt:9.22'
 }


### PR DESCRIPTION
**There is a problem to resolve all task dependencies in the build process**

> Could not resolve all task dependencies for configuration ':app:wobizDebugRuntimeClasspath'.
   > Could not resolve net.minidev:json-smart:[1.3.1,2.3].
     Required by:
         project :app > project :react-native-code-push > com.nimbusds:nimbus-jose-jwt:5.1
      > Failed to list versions for net.minidev:json-smart.
         > Unable to load Maven meta-data from https://jcenter.bintray.com/net/minidev/json-smart/maven-metadata.xml.
            > Could not HEAD 'https://jcenter.bintray.com/net/minidev/json-smart/maven-metadata.xml'.
               > org.apache.http.client.ClientProtocolException (no error message)

The solution is to upgrade com.nimbusds:nimbus-jose-jwt's version from 5.1 to 9.22