### PR TITLE
Fix React Native Warn "new NativeEventEmitter()` was called with a non-null argument without the required listener"

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -693,4 +693,14 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
         CodePushUtils.log("Clearing updates.");
         mCodePush.clearUpdates();
     }
+
+    @ReactMethod
+    public void addListener(String eventName) {
+        // Set up any upstream listeners or background tasks as necessary
+    }
+
+    @ReactMethod
+    public void removeListeners(Integer count) {
+        // Remove upstream listeners, stop unnecessary background tasks
+    }
 }


### PR DESCRIPTION
Fix warnings produced for the new version of react-native:

- `new NativeEventEmitter() was called with a non-null argument without the required addListener method`
- `new NativeEventEmitter() was called with a non-null argument without the required removeListener method`