### PR TITLE
replace jcenter with mavenCentral

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.3.0'
@@ -15,6 +15,6 @@ buildscript {
 allprojects {
     repositories {
         mavenLocal()
-        jcenter()
+        mavenCentral()
     }
 }


### PR DESCRIPTION
replace jCenter with mavenCentral. jCentral is having a pretty long outage and it's deprecated. Move on from jCenter and replace it with mavenCentral