### PR TITLE
Fix: react-native init command error in test

### DIFF
--- a/test/test.ts
+++ b/test/test.ts
@@ -308,13 +308,13 @@ class RNProjectManager extends ProjectManager {
         }
         mkdirp.sync(projectDirectory);
 
-        return TestUtil.getProcessOutput("react-native init " + appName, { cwd: projectDirectory, timeout: 30 * 60 * 1000 })
-            .then((e) => { console.log(`"react-native init ${appName}" success. cwd=${projectDirectory}`); return e; })
+        return TestUtil.getProcessOutput("npx react-native init " + appName, { cwd: projectDirectory, timeout: 30 * 60 * 1000 })
+            .then((e) => { console.log(`"npx react-native init ${appName}" success. cwd=${projectDirectory}`); return e; })
             .then(this.copyTemplate.bind(this, templatePath, projectDirectory))
             .then<void>(TestUtil.getProcessOutput.bind(undefined, TestConfig.thisPluginInstallString, { cwd: path.join(projectDirectory, TestConfig.TestAppName) }))
             .then(() => { return null; })
             .catch((error) => {
-                console.log(`"react-native init ${appName} failed". cwd=${projectDirectory}`, error);
+                console.log(`"npx react-native init ${appName} failed". cwd=${projectDirectory}`, error);
                 throw new Error(error);
             });
     }


### PR DESCRIPTION
error in 
```
npm run test:setup:android
```

**have no global react-native case**
[all log](https://app.warp.dev/block/0mN0WQ1Doo7sN1BlGJLdkA)
```
npm run test:android
....
Running command: react-native init TestCodePush
/bin/sh: react-native: command not found
Error: Command failed: react-native init TestCodePush
/bin/sh: react-native: command not found
...
```

**have global react-native case**
[all log](https://app.warp.dev/block/pEgqqve0wck2PiO6mbeKdV)
```
...
error Your Ruby version is 2.6.8, but your Gemfile specified 2.7.5
...
```

**add npx command in test/test.ts**
```
...
 ✔ sets up tests correctly (158788ms)
...
```