### PR TITLE
Add support for merged_res directory

### DIFF
--- a/android/codepush.gradle
+++ b/android/codepush.gradle
@@ -82,6 +82,11 @@ gradle.projectsEvaluated {
                 resourcesDir = file("$buildDir/intermediates/res/${targetPath}")
             }
 
+            // For versions of RN / Gradle which use 'merged_res' folder instead of 'res' or 'res/merged'
+            if (!resourcesDir.exists() && file("$buildDir/intermediates/merged_res/${targetPath}").exists()) {
+                resourcesDir = file("$buildDir/intermediates/merged_res/${targetPath}")
+            }
+
             jsBundleFile = file("$jsBundleDir/$bundleAssetName")
 
             def resourcesMapTempFileName = "CodePushResourcesMap-" + java.util.UUID.randomUUID().toString().substring(0,8) + ".json"


### PR DESCRIPTION
This PR adds functionality for projects which have android build directory structure of: 

```
- android
     - app
          - build
               - intermediates
                    - merged_res
                    - <other_folders>
```
For folder structures which use 'merged_res' instead of 'res' or 'res/merged'. 

This helps avoid errors such as: 

```
Error: ENOENT: no such file or directory, scandir '/Users/$USER/app/android/app/build/intermediates/res/merged/release'
Resources directory path does not exist.
Unable to find '/Users/$USER/app/android/app/build/intermediates/res/merged/release' directory. Please check version of Android Plugin for Gradle.
    at Object.readdirSync (node:fs:1438:3)
    at getFilesInFolder (/Users/$USER/app/node_modules/react-native-code-push/scripts/getFilesInFolder.js:7:26)
```

I've tested this and it fixes the issue. It is backwards compatible thanks to the !resourcesDir.exists().

Error from: 
react-native: 0.70.6
react-native-code-push: 7.0.5
Android SDK: 32.0.0
