### PR TITLE
Fix `CodePushDialog.showDialog` show incorrect buttons order on Android

### DIFF
--- a/AlertAdapter.js
+++ b/AlertAdapter.js
@@ -5,17 +5,20 @@ if (Platform.OS === "android") {
   const { NativeModules: { CodePushDialog } } = React;
     
   Alert = {
-    alert(title, message, buttons) {
+    alert(title, message, rawButtons) {
+      // Fix for #2420 (incorrect button order)
+      const buttons = Array.from(rawButtons).reverse();
+
       if (buttons.length > 2) {
         throw "Can only show 2 buttons for Android dialog.";
       }
-      
+
       const button1Text = buttons[0] ? buttons[0].text : null,
             button2Text = buttons[1] ? buttons[1].text : null;
-      
+
       CodePushDialog.showDialog(
         title, message, button1Text, button2Text,
-        (buttonId) => { buttons[buttonId].onPress && buttons[buttonId].onPress(); }, 
+        (buttonId) => { buttons[buttonId].onPress && buttons[buttonId].onPress(); },
         (error) => { throw error; });
     }
   };


### PR DESCRIPTION
fix: #2420
spec: https://reactnative.dev/docs/alert#alert


---

to test

```tsx
import {Alert} from 'react-native';
import {Alert as AlertAdapter}  from 'react-native-code-push/AlertAdapter'


AlertAdapter.alert('title (AlertAdapter)', 'msg', [
  {text:'1'},
  {text:'2'}
]);
Alert.alert('title (Alert)', 'msg', [
  {text:'1'},
  {text:'2'}
]);
```


<table>
<tbody>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td>


<img width="503" alt="Screenshot 2023-02-04 at 09 26 43" src="https://user-images.githubusercontent.com/4661784/216757336-b3b4f580-b991-4ba5-8e22-3d231cee51b0.png">

<img width="499" alt="Screenshot 2023-02-04 at 09 26 48" src="https://user-images.githubusercontent.com/4661784/216757340-33e84dea-6651-4745-8550-e289b5842e67.png">

</td>
<td>

<img width="503" alt="Screenshot 2023-02-04 at 09 26 43" src="https://user-images.githubusercontent.com/4661784/216757336-b3b4f580-b991-4ba5-8e22-3d231cee51b0.png">


<img width="512" alt="Screenshot 2023-02-04 at 09 29 47" src="https://user-images.githubusercontent.com/4661784/216757387-6cdeeb6a-d692-4ea8-a23d-95fb8ded35dd.png">


</td>
</tr>
</tbody>
</table>

