### PR TITLE
Fix CVE-2022-22912

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3059,12 +3059,12 @@
       }
     },
     "node_modules/plist": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.5.tgz",
-      "integrity": "sha512-83vX4eYdQp3vP9SxuYgEM/G/pJQqLUz/V/xzPrzruLs7fz7jxGQ1msZ/mg1nwZxUSuOp4sb+/bEIbRrbzZRxDA==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.6.tgz",
+      "integrity": "sha512-WiIVYyrp8TD4w8yCvyeIr+lkmrGRd5u0VbRnU+tP/aRLxP/YadJUYOMZJ/6hIa3oUyVCsycXvtNRgd5XBJIbiA==",
       "dependencies": {
         "base64-js": "^1.5.1",
-        "xmlbuilder": "^9.0.7"
+        "xmlbuilder": "^15.1.1"
       },
       "engines": {
         "node": ">=6"
@@ -4517,11 +4517,11 @@
       "dev": true
     },
     "node_modules/xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
       "engines": {
-        "node": ">=4.0"
+        "node": ">=8.0"
       }
     },
     "node_modules/xregexp": {
@@ -6946,12 +6946,12 @@
       "dev": true
     },
     "plist": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.5.tgz",
-      "integrity": "sha512-83vX4eYdQp3vP9SxuYgEM/G/pJQqLUz/V/xzPrzruLs7fz7jxGQ1msZ/mg1nwZxUSuOp4sb+/bEIbRrbzZRxDA==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.6.tgz",
+      "integrity": "sha512-WiIVYyrp8TD4w8yCvyeIr+lkmrGRd5u0VbRnU+tP/aRLxP/YadJUYOMZJ/6hIa3oUyVCsycXvtNRgd5XBJIbiA==",
       "requires": {
         "base64-js": "^1.5.1",
-        "xmlbuilder": "^9.0.7"
+        "xmlbuilder": "^15.1.1"
       }
     },
     "plugin-error": {
@@ -8033,9 +8033,9 @@
       "dev": true
     },
     "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="
     },
     "xregexp": {
       "version": "2.0.0",


### PR DESCRIPTION
Fix CVE-2022-22912: Prototype pollution vulnerability via .parse() in Plist before v3.0.4.