### PR TITLE
Prioritize nodeModulesPath over config.root if present.

### DIFF
--- a/android/codepush.gradle
+++ b/android/codepush.gradle
@@ -33,10 +33,10 @@ gradle.projectsEvaluated {
         }
 
         def nodeModulesPath;
-        if (config.root) {
-            nodeModulesPath = Paths.get(config.root.asFile.get().absolutePath, "/node_modules");
-        } else if (project.hasProperty('nodeModulesPath')) {
+        if (project.hasProperty('nodeModulesPath')) {
             nodeModulesPath = project.nodeModulesPath
+        } else if (config.root) {
+            nodeModulesPath = Paths.get(config.root.asFile.get().absolutePath, "/node_modules");
         } else {
             nodeModulesPath = "../../node_modules";
         }


### PR DESCRIPTION
This has been discussed before in issue https://github.com/microsoft/react-native-code-push/issues/1887 and in pull request https://github.com/microsoft/react-native-code-push/pull/1943, but was closed because of inactivity.

Like mentioned in links, it would maybe be more natural to prioritize the direct `nodeModulesPath` property if present, not the reference to projects root.
And with react native 0.71 new android config, I have seen that root is present even when not setting it in project. Which means `nodeModulesPath` is never used, which makes it useless in that case. Therefore taking up this change again, to switch the priority. 

