### PR TITLE
Fix tests environment 

### DIFF
--- a/.github/workflows/react-native-code-push-ci.yml
+++ b/.github/workflows/react-native-code-push-ci.yml
@@ -60,6 +60,8 @@ jobs:
         with:
           ruby-version: '2.7.6'
           bundler-cache: true
+      - name: (Workaround) Install activesupport 7.0.8
+        run: gem install activesupport -v 7.0.8
       - name: Install dependencies
         run: npm install
       - name: Setup iOS tests


### PR DESCRIPTION
[AB#103443](https://dev.azure.com/msmobilecenter/Mobile-Center/_boards/board/t/SDK/Backlog%20Items/?workitem=103443)

This PR fixing issue with activesupport gem version of 7.1.1. Right now this version is broken, and need to revert this PR once initial issue will be fixed: https://github.com/CocoaPods/CocoaPods/issues/12098