### PR TITLE
Update Nimbus-Jose-JWT

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -27,5 +27,5 @@ android {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation 'com.nimbusds:nimbus-jose-jwt:5.1'
+    implementation 'com.nimbusds:nimbus-jose-jwt:9.37.3'
 }

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateUtils.java
@@ -3,11 +3,12 @@ package com.microsoft.codepush.react;
 import android.content.Context;
 import android.util.Base64;
 
+import com.nimbusds.jose.crypto.JWSVerifier;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jose.crypto.SignedJWT;
+
 import java.security.interfaces.*;
 
-import com.nimbusds.jose.*;
-import com.nimbusds.jose.crypto.*;
-import com.nimbusds.jwt.*;
 
 import org.json.JSONArray;
 import org.json.JSONException;

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateUtils.java
@@ -3,9 +3,9 @@ package com.microsoft.codepush.react;
 import android.content.Context;
 import android.util.Base64;
 
-import com.nimbusds.jose.crypto.JWSVerifier;
+import com.nimbusds.jose.JWSVerifier;
 import com.nimbusds.jose.crypto.RSASSAVerifier;
-import com.nimbusds.jose.crypto.SignedJWT;
+import com.nimbusds.jwt.SignedJWT;
 
 import java.security.interfaces.*;
 


### PR DESCRIPTION
Update Nimbus-Jose-JWT to the actual version to fix [CVE-2019-17195](https://nvd.nist.gov/vuln/detail/CVE-2019-17195), and correct imports to mitigate [CWE-469](https://cwe.mitre.org/data/definitions/649.html)

#2533
[AB#104106](https://msmobilecenter.visualstudio.com/Mobile-Center/_boards/board/t/Mobile%20SDK%20team/Backlog%20Items/?workitem=104106)