### PR TITLE
fix: Clear updates on initializeUpdateAfterRestart in case codepush.json is corrupted

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -301,7 +301,7 @@ public class CodePush implements ReactPackage {
                 packageMetadata = this.mUpdateManager.getCurrentPackage();
             } catch (CodePushMalformedDataException e) {
                 // We need to recover the app in case 'codepush.json' is corrupted
-                CodePushUtils.log(e.getMessage());
+                CodePushUtils.log(e);
                 clearUpdates();
                 return;
             }

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -295,7 +295,16 @@ public class CodePush implements ReactPackage {
 
         JSONObject pendingUpdate = mSettingsManager.getPendingUpdate();
         if (pendingUpdate != null) {
-            JSONObject packageMetadata = this.mUpdateManager.getCurrentPackage();
+            JSONObject packageMetadata = null;
+
+            try {
+                packageMetadata = this.mUpdateManager.getCurrentPackage();
+            } catch (CodePushMalformedDataException e) {
+                // We need to recover the app in case 'codepush.json' is corrupted
+                CodePushUtils.log(e.getMessage());
+                clearUpdates();
+                return;
+            }
             if (packageMetadata == null || !isPackageBundleLatest(packageMetadata) && hasBinaryVersionChanged(packageMetadata)) {
                 CodePushUtils.log("Skipping initializeUpdateAfterRestart(), binary version is newer");
                 return;


### PR DESCRIPTION
A fix for https://github.com/microsoft/react-native-code-push/issues/2654, https://github.com/microsoft/react-native-code-push/issues/1149

Fixed in the same manner as for getJSBundleFileInternal
<img width="670" alt="image" src="https://github.com/microsoft/react-native-code-push/assets/25794983/ce09934f-086a-405b-b71e-c83054506ba5">
