### PR TITLE
Improve root component ref definition

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -576,7 +576,7 @@ function codePushify(options = {}) {
 
         // We can set ref property on class components only (not stateless)
         // Check it by render method
-        if (RootComponent.prototype.render) {
+        if (RootComponent.prototype && RootComponent.prototype.render) {
           props.ref = this.rootComponentRef;
         }
 

--- a/CodePush.js
+++ b/CodePush.js
@@ -531,42 +531,41 @@ function codePushify(options = {}) {
     );
   }
 
-  var decorator = (RootComponent) => {
-    const extended = class CodePushComponent extends React.Component {
+  const decorator = (RootComponent) => {
+    class CodePushComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        this.rootComponentRef = React.createRef();
+      }
+
       componentDidMount() {
         if (options.checkFrequency === CodePush.CheckFrequency.MANUAL) {
           CodePush.notifyAppReady();
         } else {
-          let rootComponentInstance = this.refs.rootComponent;
+          const rootComponentInstance = this.rootComponentRef.current;
 
           let syncStatusCallback;
           if (rootComponentInstance && rootComponentInstance.codePushStatusDidChange) {
-            syncStatusCallback = rootComponentInstance.codePushStatusDidChange;
-            if (rootComponentInstance instanceof React.Component) {
-              syncStatusCallback = syncStatusCallback.bind(rootComponentInstance);
-            }
+            syncStatusCallback = rootComponentInstance.codePushStatusDidChange.bind(rootComponentInstance);
           }
 
           let downloadProgressCallback;
           if (rootComponentInstance && rootComponentInstance.codePushDownloadDidProgress) {
-            downloadProgressCallback = rootComponentInstance.codePushDownloadDidProgress;
-            if (rootComponentInstance instanceof React.Component) {
-              downloadProgressCallback = downloadProgressCallback.bind(rootComponentInstance);
-            }
+            downloadProgressCallback = rootComponentInstance.codePushDownloadDidProgress.bind(rootComponentInstance);
           }
 
           let handleBinaryVersionMismatchCallback;
           if (rootComponentInstance && rootComponentInstance.codePushOnBinaryVersionMismatch) {
-            handleBinaryVersionMismatchCallback = rootComponentInstance.codePushOnBinaryVersionMismatch;
-            if (rootComponentInstance instanceof React.Component) {
-              handleBinaryVersionMismatchCallback = handleBinaryVersionMismatchCallback.bind(rootComponentInstance);
-            }
+            handleBinaryVersionMismatchCallback = rootComponentInstance.codePushOnBinaryVersionMismatch.bind(rootComponentInstance);
           }
 
           CodePush.sync(options, syncStatusCallback, downloadProgressCallback, handleBinaryVersionMismatchCallback);
+
           if (options.checkFrequency === CodePush.CheckFrequency.ON_APP_RESUME) {
             ReactNative.AppState.addEventListener("change", (newState) => {
-              newState === "active" && CodePush.sync(options, syncStatusCallback, downloadProgressCallback);
+              if (newState === "active") {
+                CodePush.sync(options, syncStatusCallback, downloadProgressCallback);
+              }
             });
           }
         }
@@ -575,17 +574,17 @@ function codePushify(options = {}) {
       render() {
         const props = {...this.props};
 
-        // we can set ref property on class components only (not stateless)
-        // check it by render method
+        // We can set ref property on class components only (not stateless)
+        // Check it by render method
         if (RootComponent.prototype.render) {
-          props.ref = "rootComponent";
+          props.ref = this.rootComponentRef;
         }
 
         return <RootComponent {...props} />
       }
     }
 
-    return hoistStatics(extended, RootComponent);
+    return hoistStatics(CodePushComponent, RootComponent);
   }
 
   if (typeof options === "function") {


### PR DESCRIPTION
After deprecating the reference string for React, such warnings began to appear

> ERROR Warning: Component "CodePushComponent" contains the string ref "rootComponent". Support for string refs will be removed in a future major release. We recommend using useRef() or createRef() instead.

Therefore, we migrated to using createRef() instead of string ref.

https://github.com/microsoft/react-native-code-push/issues/2701/
[AB#107092](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/107092)