### PR TITLE
Handle null values in CodePushUtils.java

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUtils.java
@@ -67,7 +67,9 @@ public class CodePushUtils {
             String key = it.next();
             Object obj = null;
             try {
-                obj = jsonObj.get(key);
+                if (!jsonObj.isNull(key)) {
+                    obj = jsonObj.get(key);
+                }
             } catch (JSONException jsonException) {
                 // Should not happen.
                 throw new CodePushUnknownException("Key " + key + " should exist in " + jsonObj.toString() + ".", jsonException);


### PR DESCRIPTION
The error occurs when the user calls the `CodePushUtils::convertJsonObjectToWritable()` function within the native module of their application and passes a JSON object that contains a null value. This PR addresses and handles this specific case to prevent the error.
Use patch from #2683

[AB#104795](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/104795)