### PR TITLE
Increase macOS job timeout to 2hrs

### DIFF
--- a/.azurepipelines/test-rn-code-push.yml
+++ b/.azurepipelines/test-rn-code-push.yml
@@ -73,6 +73,7 @@ stages:
       displayName: 'Run Android test'
 
   - job: TestIOS
+    timeoutInMinutes: 120
     displayName: 'Test IOS'
     steps:
 


### PR DESCRIPTION
Fixed failing jobs for ios tests  due to timeout on runner image.

[Failed job 
](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1534714&view=results)[Success job](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1534881&view=results) 

