### PR TITLE
Revert code changes as it causes integrity check failure

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateUtils.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateUtils.java
@@ -98,10 +98,7 @@ public class CodePushUpdateUtils {
     }
 
     public static void copyNecessaryFilesFromCurrentPackage(String diffManifestFilePath, String currentPackageFolderPath, String newPackageFolderPath) throws IOException {
-        if (currentPackageFolderPath == null || !new File(currentPackageFolderPath).exists()) {
-            CodePushUtils.log("Unable to copy files from current package during diff update, because currentPackageFolderPath is invalid.");
-            return;
-        }
+        FileUtils.copyDirectoryContents(currentPackageFolderPath, newPackageFolderPath);        
         JSONObject diffManifest = CodePushUtils.getJsonObjectFromFile(diffManifestFilePath);
         try {
             JSONArray deletedFiles = diffManifest.getJSONArray("deletedFiles");


### PR DESCRIPTION
Changes from https://github.com/microsoft/react-native-code-push/pull/2566  are causing CodePushInvalidUpdateException to be thrown which rollbacks every update for Android devices as reported https://github.com/microsoft/react-native-code-push/issues/2725.

[AB#107438](https://dev.azure.com/msmobilecenter/Mobile-Center/_boards/board/t/Mobile%20SDK%20team/Backlog%20Items/?workitem=107438)
[Build](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1537511&view=results)