### PR TITLE
Move namespace definition to build.gradle

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,6 +6,8 @@ def DEFAULT_TARGET_SDK_VERSION = 26
 def DEFAULT_MIN_SDK_VERSION = 16
 
 android {
+    namespace "com.microsoft.codepush.react"
+
     compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
     buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
 

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.microsoft.codepush.react">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.microsoft.codepush.react">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,6 +14,9 @@ buildscript {
 }
 
 allprojects {
+    android {
+        namespace "com.microsoft.codepush.react"
+    }
     repositories {
         mavenLocal()
         mavenCentral()


### PR DESCRIPTION
## Description
The namespace declaration in AndroidManifest.xml is currently deprecated. Therefore, following the [recommendation](https://developer.android.com/build/configure-app-module#set-namespace), we moved the namespace declaration to build.gradle file.

## Related PRs or issues
Issue: #2743 