### PR TITLE
Replace deprecated method for reloading bundle on iOS

### DIFF
--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -5,6 +5,7 @@
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTRootView.h>
 #import <React/RCTUtils.h>
+#import <React/RCTReloadCommand.h>
 #else // back compatibility for RN version < 0.40
 #import "RCTAssert.h"
 #import "RCTBridgeModule.h"
@@ -540,7 +541,7 @@ static NSString *const LatestRollbackCountKey = @"count";
             [super.bridge setValue:[CodePush bundleURL] forKey:@"bundleURL"];
         }
 
-        [super.bridge reload];
+        RCTTriggerReloadCommandListeners(@"react-native-code-push: Restart");
     });
 }
 


### PR DESCRIPTION
The code is currently using a deprecated method to reload the bundle. This PR will switch to the recommended method of using `RCTTriggerReloadCommandListeners`.

When using New Architecture, the iOS app does not restart properly using the deprecated method. (tested in RN 0.76.3, RN CodePush 9.0.0).

It either hangs or crashes. However, the new bundle is installed and loaded properly when the app is killed and restarted. 

Switching to the one in this PR, makes the iOS app restart properly and use the new bundle, when New Architecture is enabled, and also works when it's disabled.