### PR TITLE
Bump code-push to version 4.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
-        "code-push": "^4.2.2",
+        "code-push": "4.2.3",
         "glob": "^7.1.7",
         "hoist-non-react-statics": "^3.3.2",
         "inquirer": "^8.1.5",
@@ -1233,9 +1233,9 @@
       }
     },
     "node_modules/code-push": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/code-push/-/code-push-4.2.2.tgz",
-      "integrity": "sha512-45pvyF6bhJ5h8tllcE9CkmZaCxT+QvA8hxUpUdUevLAOCWv+Tlw/B8XXC1Q7ai3qyZwkiVbEuq3E8lyGmjMsrQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/code-push/-/code-push-4.2.3.tgz",
+      "integrity": "sha512-FPwcU9/5lgMJH7MfBgkr4nCta513DGx2v4mg2yW860+8sCQTbhHHnduoAjSlZgyZJj3FIxzW2ccD41pVtTJDow==",
       "dependencies": {
         "appcenter-file-upload-client": "0.1.0",
         "proxy-agent": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "url": "https://github.com/microsoft/react-native-code-push"
   },
   "dependencies": {
-    "code-push": "^4.2.2",
+    "code-push": "4.2.3",
     "glob": "^7.1.7",
     "hoist-non-react-statics": "^3.3.2",
     "inquirer": "^8.1.5",


### PR DESCRIPTION
### Description
Updated code-push dependency to latest version 4.2.3
Here are the changes from latest version (4.2.3) of code-push https://github.com/microsoft/code-push/pull/851
[Build](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1551064&view=results)