### PR TITLE
add(SyncOptions): add type ignoreFailedUpdates

### DIFF
--- a/typings/react-native-code-push.d.ts
+++ b/typings/react-native-code-push.d.ts
@@ -137,6 +137,13 @@ export interface SyncOptions {
     updateDialog?: UpdateDialog;
 
     /**
+     * It does not ignore failed updates, and you can continue to retry.
+     * It has a higher priority than rollbackRetryOptions.
+     * The default value is true.
+     */
+    ignoreFailedUpdates?: boolean;
+
+    /**
      * The rollback retry mechanism allows the application to attempt to reinstall an update that was previously rolled back (with the restrictions
      * specified in the options). It is an "options" object used to determine whether a rollback retry should occur, and if so, what settings to use
      * for the rollback retry. This defaults to null, which has the effect of disabling the retry mechanism. Setting this to any truthy value will enable


### PR DESCRIPTION
![Untitled (8)](https://github.com/microsoft/react-native-code-push/assets/48432932/7f3afe5a-4483-4016-98be-7a9aaaeb4366)

`syncOptions` object can have `ignoreFailedUpdates` option but not specified in `SyncOptions` type definition.


# Make `ignoreFailedUpdates` option public

## Background
Currently, CodePush has internal logic to ignore failed updates, controlled by `ignoreFailedUpdates` which defaults to `true`. While there is a `rollbackRetryOptions` to control retry attempts, this approach has limitations.

## Problem
1. In some applications, especially those with tight frontend-backend coupling, rolling back may not be a viable option. When the backend API changes, older versions of the app may not function properly.
(in my case, we only managed latest backend and frontend in 1:1 relationship, so rolledback wasn't the answer to recover) 

2. Some update failures occur due to temporary issues (network instability, device state, etc.) rather than problems with the update itself. In these cases, permanently ignoring the update is overly restrictive.

3. Current workaround of setting very high `maxRetryAttempts` in `rollbackRetryOptions` to effectively "never ignore" updates is:
   - Not semantically clear (obscures the actual intent)
   - Unnecessarily complex
   - Still maintains artificial retry limits

## Solution
Make `ignoreFailedUpdates` option public in the type definitions, allowing developers to explicitly set it to `false` when they want to continue attempting updates regardless of previous failures.

This provides:
1. Clear semantic intent - `ignoreFailedUpdates: false` directly communicates "keep trying failed updates"
2. Simple configuration - One boolean setting instead of manipulating retry counts
3. Better control - Allows applications to handle update failures according to their specific needs

## Real-world Use Case
In our production environment with hundreds of mobile devices, we occasionally see updates fail on some devices due to temporary issues. With `ignoreFailedUpdates: true`, these devices become stuck on older versions even though the update itself is valid. By setting `ignoreFailedUpdates: false`, we ensure all devices eventually receive critical updates.

## Impact
This change only exposes an existing option - it doesn't modify the default behavior, so existing applications won't be affected unless they explicitly opt in.

## Note
Previously, when Microsoft operated the CodePush server, `ignoreFailedUpdates` was kept internal to prevent unnecessary server load from retry attempts. However, now that CodePush requires self-hosted servers, it makes more sense to expose this existing property and let implementers decide how to handle update retries based on their own infrastructure and needs.